### PR TITLE
[WIP] Add Basic Support For Parallel Tempering

### DIFF
--- a/integration_tests/scratch/run.py
+++ b/integration_tests/scratch/run.py
@@ -1,0 +1,81 @@
+import os
+import shutil
+
+from propertyestimator import unit
+from propertyestimator.backends import ComputeResources
+from propertyestimator.protocols import coordinates, forcefield, simulation
+from propertyestimator.substances import Substance
+from propertyestimator.tests.utils import build_tip3p_smirnoff_force_field
+from propertyestimator.thermodynamics import Ensemble, ThermodynamicState
+from propertyestimator.utils import setup_timestamp_logging
+from propertyestimator.utils.exceptions import PropertyEstimatorException
+
+
+def _setup_dummy_system(directory):
+
+    force_field_path = os.path.join(directory, 'ff.json')
+
+    with open(force_field_path, 'w') as file:
+        file.write(build_tip3p_smirnoff_force_field().json())
+
+    substance = Substance.from_components('C')
+
+    build_coordinates = coordinates.BuildCoordinatesPackmol('build_coordinates')
+    build_coordinates.max_molecules = 1
+    build_coordinates.mass_density = 0.001 * unit.grams / unit.milliliters
+    build_coordinates.substance = substance
+    build_coordinates.execute(directory, None)
+
+    assign_parameters = forcefield.BuildSmirnoffSystem(f'assign_parameters')
+    assign_parameters.force_field_path = force_field_path
+    assign_parameters.coordinate_file_path = build_coordinates.coordinate_file_path
+    assign_parameters.substance = substance
+    assign_parameters.execute(directory, None)
+
+    return build_coordinates.coordinate_file_path, assign_parameters.system_path
+
+
+def main():
+
+    setup_timestamp_logging()
+
+    thermodynamic_state = ThermodynamicState(298 * unit.kelvin)
+
+    compute_resources = ComputeResources(number_of_threads=1)
+
+    if os.path.isdir('setup'):
+        shutil.rmtree('setup')
+    if os.path.isdir('run'):
+        shutil.rmtree('run')
+
+    os.makedirs('setup', exist_ok=True)
+    os.makedirs('run', exist_ok=True)
+
+    coordinate_path, system_path = _setup_dummy_system('setup')
+
+    protocol = simulation.OpenMMParallelTempering('protocol')
+    protocol.total_number_of_iterations = 333
+    protocol.steps_per_iteration = 3000
+    protocol.thermodynamic_state = thermodynamic_state
+    protocol.input_coordinate_file = coordinate_path
+    protocol.system_path = system_path
+    protocol.ensemble = Ensemble.NVT
+    protocol.enable_pbc = False
+    protocol.allow_gpu_platforms = False
+    protocol.high_precision = True
+
+    protocol.maximum_temperature = 450 * unit.kelvin
+    protocol.number_of_replicas = 4
+
+    result = protocol.execute('run', compute_resources)
+    assert not isinstance(result, PropertyEstimatorException)
+
+    # for iterations in range(1, 11):
+    #
+    #     equilibration_simulation.total_number_of_iterations = iterations
+    #     assert isinstance(equilibration_simulation.execute('run', compute_resources), dict)
+    #     print(iterations)
+
+
+if __name__ == "__main__":
+    main()

--- a/integration_tests/scratch/run.py
+++ b/integration_tests/scratch/run.py
@@ -1,8 +1,15 @@
+import logging
 import os
 import shutil
+import sys
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+from openforcefield.topology import Molecule, Topology
+from scipy.optimize import newton
+from scipy.stats import norm
+from simtk import openmm, unit as simtk_unit
+from simtk.openmm import app
 
 from propertyestimator import unit
 from propertyestimator.backends import ComputeResources
@@ -10,50 +17,304 @@ from propertyestimator.protocols import coordinates, forcefield, simulation
 from propertyestimator.substances import Substance
 from propertyestimator.tests.utils import build_tip3p_smirnoff_force_field
 from propertyestimator.thermodynamics import Ensemble, ThermodynamicState
-from propertyestimator.utils import setup_timestamp_logging
 from propertyestimator.utils.exceptions import PropertyEstimatorException
+from propertyestimator.utils.openmm import disable_pbc
+from propertyestimator.utils.statistics import StatisticsArray, ObservableType
+from propertyestimator.utils.utils import temporarily_change_directory
 
 
-def _setup_dummy_system(directory, coordinte_file_name, system_file_name):
+# OpenMM constant for Coulomb interactions (openmm/platforms/reference/
+# include/SimTKOpenMMRealType.h) in OpenMM units
+ONE_4PI_EPS0 = 138.935456
+
+
+def _build_system(smiles, number_of_molecules, directory, coordinate_file_name, system_file_name):
+    """Set up the coordinates / system object for a given smiles and
+    containing a specified number of molecules.
+    """
+
+    import parmed as pmd
 
     force_field_path = os.path.join(directory, 'ff.json')
 
     with open(force_field_path, 'w') as file:
         file.write(build_tip3p_smirnoff_force_field().json())
 
-    substance = Substance.from_components('CCC(=O)O')
+    substance = Substance.from_components(smiles)
 
     build_coordinates = coordinates.BuildCoordinatesPackmol('build_coordinates')
     build_coordinates.max_molecules = 1
-    build_coordinates.mass_density = 0.001 * unit.grams / unit.milliliters
     build_coordinates.substance = substance
     build_coordinates.execute(directory, None)
 
+    original_structure = pmd.load_file(os.path.join(directory, 'output.pdb'))
+    new_structure = pmd.Structure()
+
+    shifted_positions = []
+
+    for index in range(number_of_molecules):
+
+        for position in original_structure.positions:
+
+            shifted_position = position + (0.01 * index,
+                                           0.01 * index,
+                                           0.01 * index) * simtk_unit.angstrom
+
+            shifted_positions.append(shifted_position.value_in_unit(simtk_unit.angstrom))
+
+        new_structure += original_structure
+
+    with open(coordinate_file_name, 'w') as file:
+        app.PDBFile.writeFile(new_structure.topology, shifted_positions * simtk_unit.angstrom, file)
+
     assign_parameters = forcefield.BuildSmirnoffSystem(f'assign_parameters')
     assign_parameters.force_field_path = force_field_path
-    assign_parameters.coordinate_file_path = build_coordinates.coordinate_file_path
+    assign_parameters.coordinate_file_path = coordinate_file_name
     assign_parameters.substance = substance
     assign_parameters.execute(directory, None)
 
-    shutil.copyfile(build_coordinates.coordinate_file_path, coordinte_file_name)
-    shutil.copyfile(assign_parameters.system_path, system_file_name)
+    # Force disable any pbc
+    with open(assign_parameters.system_path) as file:
+        system = openmm.XmlSerializer.deserialize(file.read())
+
+    disable_pbc(system)
+
+    with open(system_file_name, 'w') as file:
+        file.write(openmm.XmlSerializer.serialize(system))
 
 
-def main():
+def _convert_nonbonded_to_custom(original_force):
+    """Convert an openmm NonbondedForce into a CustomNonbondedForce
+    """
 
-    import mdtraj
+    energy_expression = (f'4*epsilon*((sigma/r)^12-(sigma/r)^6)+'
+                         f'ONE_4PI_EPS0*chargeprod/r; '
+                          
+                         # Steric mixing rules
+                         f'sigma=sqrt(sigma1*sigma2); '
+                         f'epsilon=sqrt(epsilon1*epsilon2); '
+                          
+                         # Electrostatic mixing rules
+                         f'chargeprod=charge1*charge2; '
+                         f'ONE_4PI_EPS0={ONE_4PI_EPS0:f};')
 
-    setup_timestamp_logging()
+    custom_force = openmm.CustomNonbondedForce(energy_expression)
 
-    compute_resources = ComputeResources(number_of_threads=1)
+    custom_force.setNonbondedMethod(openmm.CustomNonbondedForce.NoCutoff)
 
-    coordinate_path = 'input.pdb'
-    system_path = 'system.xml'
+    custom_force.addPerParticleParameter("charge")
+    custom_force.addPerParticleParameter("sigma")
+    custom_force.addPerParticleParameter("epsilon")
 
-    if not os.path.isfile(coordinate_path) or not os.path.isfile(system_path):
+    custom_force.setUseSwitchingFunction(original_force.getUseSwitchingFunction())
+    custom_force.setCutoffDistance(original_force.getCutoffDistance())
+    custom_force.setSwitchingDistance(original_force.getSwitchingDistance())
+    custom_force.setUseLongRangeCorrection(original_force.getUseDispersionCorrection())
 
-        os.makedirs('setup', exist_ok=True)
-        _setup_dummy_system('setup', coordinate_path, system_path)
+    for index in range(original_force.getNumParticles()):
+
+        charge, sigma, epsilon = original_force.getParticleParameters(index)
+
+        custom_force.addParticle([charge, sigma, epsilon])
+        original_force.setParticleParameters(index, 0.0, 0.0, 0.0)
+
+        custom_charge, custom_sigma, custom_epsilon = custom_force.getParticleParameters(index)
+
+        assert (np.isclose(charge.value_in_unit(simtk_unit.elementary_charge), custom_charge) and
+                np.isclose(sigma.value_in_unit(simtk_unit.nanometer), custom_sigma) and
+                np.isclose(epsilon.value_in_unit(simtk_unit.kilojoule_per_mole), custom_epsilon))
+
+    for index in range(original_force.getNumExceptions()):
+
+        atom_i, atom_j, *original_parameters = original_force.getExceptionParameters(index)
+        custom_force.addExclusion(atom_i, atom_j)
+
+    return custom_force
+
+
+def _make_system_ideal(smiles, coordinate_file_path,
+                       system_file_path, new_system_file_path=None):
+    """Converts a system of interacting molecules into one of
+    ideal ones.
+    """
+
+    substance = Substance.from_components(smiles)
+
+    unique_molecules = [Molecule.from_smiles(component.smiles) for
+                        component in substance.components]
+
+    openmm_topology = app.PDBFile(coordinate_file_path).topology
+    topology = Topology.from_openmm(openmm_topology, unique_molecules)
+
+    with open(system_file_path) as file:
+        system = openmm.XmlSerializer.deserialize(file.read())
+
+    if topology.n_topology_molecules > 1:
+
+        # Set up a custom ideal force in the case of multiple molecules.
+        nonbonded_force_indices = [index for index in range(system.getNumForces()) if
+                                   isinstance(system.getForce(index), openmm.NonbondedForce)]
+
+        assert len(nonbonded_force_indices) == 1
+        nonbonded_force_index = nonbonded_force_indices[0]
+
+        # Convert the original force into a custom one on which we
+        # can define interaction groups.
+        custom_force = _convert_nonbonded_to_custom(system.getForce(nonbonded_force_index))
+
+        # Setup the custom interaction groups.
+        for molecule in topology.topology_molecules:
+
+            atom_indices = [atom.topology_atom_index for atom in molecule.atoms]
+            custom_force.addInteractionGroup(atom_indices, atom_indices)
+
+        # system.removeForce(nonbonded_force_index)
+        system.addForce(custom_force)
+
+    if new_system_file_path is None:
+        new_system_file_path = system_file_path
+
+    with open(new_system_file_path, 'w') as file:
+        file.write(openmm.XmlSerializer.serialize(system))
+
+
+def _determine_temperatures(minimum_temperature, maximum_temperature, number_of_intermediates,
+                            number_of_molecules, desired_probability, coordinate_path, system_path,
+                            compute_resources, plot=False):
+    """Determine which temperatures to use for the replica exchange by
+    running a short set of simulations over the temperature range of interest,
+    fitting the potential energy as a function of temperature, then iteratively
+    selecting the temperatures to theoretically achieve a specific exchange
+    probability.
+    """
+
+    assert 0 < desired_probability <= 1.0
+
+    temperatures = minimum_temperature + np.linspace(0.0, 1.0, number_of_intermediates + 2) * (maximum_temperature -
+                                                                                               minimum_temperature)
+
+    mu = np.zeros(len(temperatures))
+    # sigma = np.zeros(len(temperatures))
+
+    # Determine the energy as a function of T
+    for index, temperature in enumerate(temperatures):
+
+        os.makedirs(f'setup_{temperature}', exist_ok=True)
+
+        protocol = simulation.RunOpenMMSimulation('protocol')
+        protocol.input_coordinate_file = coordinate_path
+        protocol.system_path = system_path
+        protocol.steps_per_iteration = 50000
+        protocol.output_frequency = 500
+        protocol.ensemble = Ensemble.NVT
+        protocol.enable_pbc = False
+        protocol.allow_gpu_platforms = number_of_molecules != 1
+        protocol.high_precision = number_of_molecules == 1
+        protocol.thermodynamic_state = ThermodynamicState(temperature)
+
+        result = protocol.execute(f'setup_{temperature}', compute_resources)
+        assert not isinstance(result, PropertyEstimatorException)
+
+        statistics_array = StatisticsArray.from_pandas_csv(protocol.statistics_file_path)
+        potentials = statistics_array[ObservableType.PotentialEnergy].to(unit.kilojoule / unit.mole).magnitude
+
+        mu[index] = np.mean(potentials)
+        sigma = np.std(potentials)
+
+        if plot:
+            x_values = np.linspace(mu[index] - 3 * sigma, mu[index] + 3 * sigma, 100)
+            plt.plot(x_values, norm.pdf(x_values, mu[index], sigma))
+
+    if plot:
+        plt.show()
+
+    # Fit a polynomial
+    coefficients = np.polyfit(temperatures.to(unit.kelvin).magnitude, mu, 2)
+
+    current_temperature = temperatures[0]
+    replica_temperatures = [current_temperature]
+
+    while current_temperature < maximum_temperature:
+
+        def evaluate(x):
+
+            beta_1 = 1.0 / (current_temperature * unit.molar_gas_constant)
+            beta_2 = 1.0 / (x * unit.kelvin * unit.molar_gas_constant)
+
+            energy_1 = (coefficients[0] * current_temperature.to(unit.kelvin).magnitude ** 2 +
+                        coefficients[1] * current_temperature.to(unit.kelvin).magnitude +
+                        coefficients[2]) * unit.kilojoule / unit.mole
+
+            energy_2 = (coefficients[0] * x ** 2 +
+                        coefficients[1] * x +
+                        coefficients[2]) * unit.kilojoule / unit.mole
+
+            return ((beta_1 - beta_2) *
+                    (energy_1 - energy_2)).to(unit.dimensionless).magnitude - np.log(desired_probability)
+
+        def evaluate_gradient(x):
+
+            beta_1 = 1.0 / (current_temperature * unit.molar_gas_constant)
+            beta_2 = 1.0 / (x * unit.kelvin * unit.molar_gas_constant)
+
+            energy_gradient = (coefficients[0] * x * 2 +
+                               coefficients[1]) * unit.kilojoule / unit.mole
+
+            return -((beta_1 - beta_2) * energy_gradient).to(unit.dimensionless).magnitude
+
+        new_temperature = newton(evaluate,
+                                 current_temperature.to(unit.kelvin).magnitude * 1.5,
+                                 evaluate_gradient,
+                                 tol=5.0,
+                                 maxiter=10000) * unit.kelvin
+
+        if new_temperature < maximum_temperature:
+            replica_temperatures.append(new_temperature)
+
+        current_temperature = new_temperature
+
+    replica_temperatures += [maximum_temperature]
+
+    for index, temperature in enumerate(replica_temperatures):
+
+        directory = f'replica_{temperature.magnitude:.1f}'
+        os.makedirs(directory, exist_ok=True)
+
+        protocol = simulation.RunOpenMMSimulation('protocol')
+        protocol.input_coordinate_file = coordinate_path
+        protocol.system_path = system_path
+        protocol.steps_per_iteration = 50000
+        protocol.output_frequency = 500
+        protocol.ensemble = Ensemble.NVT
+        protocol.enable_pbc = False
+        protocol.allow_gpu_platforms = number_of_molecules != 1
+        protocol.high_precision = number_of_molecules == 1
+        protocol.thermodynamic_state = ThermodynamicState(temperature)
+
+        result = protocol.execute(directory, compute_resources)
+        assert not isinstance(result, PropertyEstimatorException)
+
+        statistics_array = StatisticsArray.from_pandas_csv(protocol.statistics_file_path)
+        potentials = statistics_array[ObservableType.PotentialEnergy].to(unit.kilojoule / unit.mole).magnitude
+
+        mu = np.mean(potentials)
+        sigma = np.std(potentials)
+
+        if plot:
+            x_values = np.linspace(mu - 3 * sigma, mu + 3 * sigma, 100)
+            plt.plot(x_values, norm.pdf(x_values, mu, sigma))
+
+    if plot:
+        plt.show()
+
+    return replica_temperatures
+
+
+def _run_parallel_tempering(temperatures, total_number_of_iterations, steps_per_iteration, number_of_molecules,
+                            coordinate_path, system_path, compute_resources, plot=False):
+    """Perform the parallel tempering simulation using the
+    OpenMMParallelTempering protocol.
+    """
 
     if os.path.isdir('run'):
         shutil.rmtree('run')
@@ -61,37 +322,140 @@ def main():
     os.makedirs('run', exist_ok=True)
 
     protocol = simulation.OpenMMParallelTempering('protocol')
-    protocol.total_number_of_iterations = 2000
-    protocol.steps_per_iteration = 100
+    protocol.total_number_of_iterations = total_number_of_iterations
+    protocol.steps_per_iteration = steps_per_iteration
     protocol.input_coordinate_file = coordinate_path
     protocol.system_path = system_path
     protocol.ensemble = Ensemble.NVT
     protocol.enable_pbc = False
-    protocol.allow_gpu_platforms = False
-    protocol.high_precision = True
+    protocol.allow_gpu_platforms = number_of_molecules != 1
+    protocol.high_precision = number_of_molecules == 1
 
-    protocol.thermodynamic_state = ThermodynamicState(298 * unit.kelvin)
-    protocol.maximum_temperature = 1243 * unit.kelvin
-    # protocol.number_of_replicas = 4
-
-    protocol.replica_temperatures = [313 * unit.kelvin,
-                                     343 * unit.kelvin,
-                                     403 * unit.kelvin,
-                                     523 * unit.kelvin,
-                                     763 * unit.kelvin]
+    protocol.thermodynamic_state = ThermodynamicState(temperatures[0])
+    protocol.maximum_temperature = temperatures[-1]
+    protocol.replica_temperatures = temperatures[1:-1]
 
     result = protocol.execute('run', compute_resources)
     assert not isinstance(result, PropertyEstimatorException)
 
-    trajectory = mdtraj.load_dcd('trajectory.dcd', top=coordinate_path)
+    if plot:
 
-    dihedrals = mdtraj.compute_dihedrals(trajectory, indices=np.array([[3, 2, 4, 10]]))[:, 0]
-    dihedrals = dihedrals / np.pi * 180.0 + 180
+        import mdtraj
 
-    num_bins = 180
+        trajectory = mdtraj.load_dcd(protocol.trajectory_file_path, top=coordinate_path)
 
-    plt.hist(dihedrals, num_bins, range=[0.0, 360])
-    plt.show()
+        dihedrals = mdtraj.compute_dihedrals(trajectory, indices=np.array([[3, 2, 4, 10]]))[:, 0]
+        dihedrals = dihedrals / np.pi * 180.0 + 180
+
+        num_bins = 180
+
+        plt.hist(dihedrals, num_bins, range=[0.0, 360])
+        plt.show()
+
+        statistics = StatisticsArray.from_pandas_csv(protocol.statistics_file_path)
+        plt.plot(statistics[ObservableType.PotentialEnergy].magnitude)
+        plt.show()
+
+
+def _run(root_directory, smiles, maximum_temperature, number_of_molecules, exchange_probability,
+         total_number_of_iterations, steps_per_iteration):
+
+    """A convenience function for running the full parallel tempering workflow
+    with a given set of parameters.
+    """
+
+    with temporarily_change_directory(root_directory):
+
+        # Define the resources to use.
+        number_of_gpus = 1 if number_of_molecules == 1 else 0
+        compute_resources = ComputeResources(number_of_threads=1, number_of_gpus=number_of_gpus,
+                                             preferred_gpu_toolkit=ComputeResources.GPUToolkit.CUDA)
+
+        coordinate_path = 'input.pdb'
+        system_path = 'system.xml'
+
+        # Create the initial system object and coordinates.
+        os.makedirs('setup', exist_ok=True)
+
+        _build_system(smiles='CCC(=O)O',
+                      number_of_molecules=number_of_molecules,
+                      directory='setup',
+                      coordinate_file_name=coordinate_path,
+                      system_file_name=system_path)
+
+        # Make the system an ideal gas.
+        ideal_system_path = 'ideal_system.xml'
+
+        _make_system_ideal(smiles=smiles,
+                           coordinate_file_path=coordinate_path,
+                           system_file_path=system_path,
+                           new_system_file_path=ideal_system_path)
+
+        # Determine the replica temperatures
+        temperatures = _determine_temperatures(298.0 * unit.kelvin,
+                                               maximum_temperature,
+                                               1,
+                                               number_of_molecules,
+                                               exchange_probability,
+                                               coordinate_path,
+                                               ideal_system_path,
+                                               compute_resources,
+                                               plot=False)
+
+        # Run the parallel tempering
+        _run_parallel_tempering(temperatures,
+                                total_number_of_iterations,
+                                steps_per_iteration,
+                                number_of_molecules,
+                                coordinate_path,
+                                system_path,
+                                compute_resources,
+                                plot=False)
+
+
+def main():
+
+    formatter = logging.Formatter(fmt='%(asctime)s.%(msecs)03d %(levelname)-8s %(message)s',
+                                  datefmt='%H:%M:%S')
+
+    logger_handler = logging.StreamHandler(stream=sys.stdout)
+    logger_handler.setFormatter(formatter)
+
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(logger_handler)
+
+    # Define the core settings to use.
+    smiles = ['CCC(=O)O', 'CC(=O)CCC(=O)O', 'CCOC(=O)CC(=O)C']
+
+    exchange_probabilities = [0.2, 0.3, 0.4]
+    maximum_temperatures = [600 * unit.kelvin, 800 * unit.kelvin, 1000 * unit.kelvin]
+
+    for smiles_index, smiles in enumerate(smiles):
+
+        for probability_index, exchange_probability in enumerate(exchange_probabilities):
+
+            for temperature_index, maximum_temperature in enumerate(maximum_temperatures):
+
+                directory_name = f'{smiles_index}_{probability_index}_{temperature_index}'
+                os.makedirs(directory_name, exist_ok=True)
+
+                logger.info(f'Starting {smiles} {exchange_probability} {maximum_temperature}')
+
+                try:
+
+                    _run(root_directory=directory_name,
+                         smiles=smiles,
+                         maximum_temperature=maximum_temperature,
+                         number_of_molecules=1,
+                         exchange_probability=exchange_probability,
+                         total_number_of_iterations=10000,
+                         steps_per_iteration=100)
+
+                except:
+                    logger.info(f'Run failed')
+                else:
+                    logger.info(f'Finished run.')
 
 
 if __name__ == "__main__":

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -885,8 +885,7 @@ class OpenMMParallelTempering(BaseOpenMMSimulation):
         )
 
         # Run the parallel tempering simulation.
-        parallel_tempering = ParallelTemperingSampler('swap-neighbors',
-                                                      mcmc_moves=langevin_move,
+        parallel_tempering = ParallelTemperingSampler(mcmc_moves=langevin_move,
                                                       number_of_iterations=self.total_number_of_iterations)
 
         storage_path = os.path.join(directory, 'replicas.nc')

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -919,8 +919,7 @@ class OpenMMParallelTempering(BaseOpenMMSimulation):
         parallel_tempering.run()
 
         mdtraj_trajectory, statistics = self._extract_trajectory_statistics(os.path.join(directory, 'replicas.nc'),
-                                                                            system,
-                                                                            replica_index=0)
+                                                                            system)
 
         self.statistics_file_path = os.path.join(directory, 'statistics.csv')
         self.trajectory_file_path = os.path.join(directory, 'trajectory.dcd')
@@ -930,7 +929,7 @@ class OpenMMParallelTempering(BaseOpenMMSimulation):
 
         return self._get_output_dictionary()
 
-    def _extract_trajectory_statistics(self, nc_path, reference_system, replica_index):
+    def _extract_trajectory_statistics(self, nc_path, reference_system):
         """Extract the trajectory and statistics of a replica from the NetCDF4 file.
 
         Parameters
@@ -939,10 +938,6 @@ class OpenMMParallelTempering(BaseOpenMMSimulation):
             Path to the primary nc_file storing the analysis options
         reference_system: simtk.openmm.System
             The system object describing the system which was simulated.
-        replica_index : int, optional
-            The index of the replica for which to extract the trajectory. One and
-            only one between state_index and replica_index must be not None (default
-            is None).
 
         Returns
         -------
@@ -1007,12 +1002,12 @@ class OpenMMParallelTempering(BaseOpenMMSimulation):
             for i, iteration in enumerate(frame_indices):
 
                 positions[i, :, :] = reporter_storage.variables['positions'][
-                                     iteration, replica_index, :, :].astype(np.float32)
+                                     iteration, 0, :, :].astype(np.float32)
 
                 if box_vectors is not None:
 
                     box_vectors[i, :, :] = reporter_storage.variables['box_vectors'][
-                                           iteration, replica_index, :, :].astype(np.float32)
+                                           iteration, 0, :, :].astype(np.float32)
 
         finally:
 

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -895,7 +895,7 @@ class OpenMMParallelTempering(BaseOpenMMSimulation):
                                             box_vectors=initial_pdb_file.topology.getPeriodicBoxVectors())
 
         # Propagate the replicas with Langevin dynamics.
-        langevin_move = mcmc.LangevinDynamicsMove(
+        langevin_move = mcmc.GHMCMove(
             timestep=pint_quantity_to_openmm(self.timestep),
             collision_rate=pint_quantity_to_openmm(self.thermostat_friction),
             n_steps=self.steps_per_iteration,

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -882,7 +882,8 @@ class OpenMMParallelTempering(BaseOpenMMSimulation):
         reference_state = states.ThermodynamicState(system, openmm_temperature, openmm_pressure)
 
         initial_pdb_file = app.PDBFile(self.input_coordinate_file)
-        sampler_state = [states.SamplerState(positions=initial_pdb_file.positions)]
+        sampler_state = [states.SamplerState(positions=initial_pdb_file.positions,
+                                             box_vectors=initial_pdb_file.topology.getPeriodicBoxVectors())]
 
         # Propagate the replicas with Langevin dynamics.
         langevin_move = mcmc.GHMCMove(

--- a/propertyestimator/protocols/yank.py
+++ b/propertyestimator/protocols/yank.py
@@ -10,6 +10,7 @@ import traceback
 from enum import Enum
 
 import yaml
+
 from propertyestimator import unit
 from propertyestimator.thermodynamics import ThermodynamicState
 from propertyestimator.utils.exceptions import PropertyEstimatorException

--- a/propertyestimator/tests/test_parallel_tempering.py
+++ b/propertyestimator/tests/test_parallel_tempering.py
@@ -24,8 +24,8 @@ def _run_regular_simulation(temperature, total_number_of_iterations, steps_per_i
     RunOpenMMSimulation protocol.
     """
 
-    if os.path.isdir('run_regular'):
-        shutil.rmtree('run_regular')
+    # if os.path.isdir('run_regular'):
+    #     shutil.rmtree('run_regular')
 
     os.makedirs('run_regular', exist_ok=True)
 
@@ -61,8 +61,8 @@ def _run_parallel_tempering(temperatures, total_number_of_iterations, steps_per_
     OpenMMParallelTempering protocol.
     """
 
-    if os.path.isdir('run_parallel'):
-        shutil.rmtree('run_parallel')
+    # if os.path.isdir('run_parallel'):
+    #     shutil.rmtree('run_parallel')
 
     os.makedirs('run_parallel', exist_ok=True)
 

--- a/propertyestimator/tests/test_parallel_tempering.py
+++ b/propertyestimator/tests/test_parallel_tempering.py
@@ -1,0 +1,183 @@
+"""This file is only temporary will the effect of different default settings is
+explored.
+"""
+import json
+import logging
+import os
+import shutil
+import time
+
+from propertyestimator import unit
+from propertyestimator.protocols import analysis, simulation
+from propertyestimator.thermodynamics import Ensemble, ThermodynamicState
+from propertyestimator.utils.exceptions import PropertyEstimatorException
+from propertyestimator.utils.serialization import TypedJSONDecoder
+from propertyestimator.utils.statistics import ObservableType
+from propertyestimator.utils.utils import temporarily_change_directory
+
+
+def _run_regular_simulation(temperature, total_number_of_iterations, steps_per_iteration, timestep,
+                            number_of_molecules, coordinate_path, system_path, compute_resources):
+    """Perform the simulation using the
+    RunOpenMMSimulation protocol.
+    """
+
+    if os.path.isdir('run_regular'):
+        shutil.rmtree('run_regular')
+
+    os.makedirs('run_regular', exist_ok=True)
+
+    protocol = simulation.RunOpenMMSimulation('protocol')
+    protocol.total_number_of_iterations = total_number_of_iterations
+    protocol.steps_per_iteration = steps_per_iteration
+    protocol.output_frequency = steps_per_iteration
+    protocol.input_coordinate_file = coordinate_path
+    protocol.thermodynamic_state = ThermodynamicState(temperature)
+    protocol.system_path = system_path
+    protocol.timestep = timestep
+    protocol.ensemble = Ensemble.NVT
+    protocol.enable_pbc = False
+    protocol.allow_gpu_platforms = number_of_molecules != 1
+    protocol.high_precision = number_of_molecules == 1
+
+    result = protocol.execute('run_regular', compute_resources)
+    assert not isinstance(result, PropertyEstimatorException)
+
+    extract_energy = analysis.ExtractAverageStatistic('extract')
+    extract_energy.statistics_type = ObservableType.PotentialEnergy
+    extract_energy.statistics_path = protocol.statistics_file_path
+
+    result = extract_energy.execute('run_regular', compute_resources)
+    assert not isinstance(result, PropertyEstimatorException)
+
+    return extract_energy.value
+
+
+def _run_parallel_tempering(temperatures, total_number_of_iterations, steps_per_iteration, timestep, integrator,
+                            number_of_molecules, coordinate_path, system_path, compute_resources):
+    """Perform the parallel tempering simulation using the
+    OpenMMParallelTempering protocol.
+    """
+
+    if os.path.isdir('run_parallel'):
+        shutil.rmtree('run_parallel')
+
+    os.makedirs('run_parallel', exist_ok=True)
+
+    protocol = simulation.OpenMMParallelTempering('protocol')
+    protocol.total_number_of_iterations = total_number_of_iterations
+    protocol.steps_per_iteration = steps_per_iteration
+    protocol.input_coordinate_file = coordinate_path
+    protocol.system_path = system_path
+    protocol.timestep = timestep
+    protocol.integrator = integrator
+    protocol.ensemble = Ensemble.NVT
+    protocol.enable_pbc = False
+    protocol.output_frequency = 2
+    protocol.allow_gpu_platforms = number_of_molecules != 1
+    protocol.high_precision = number_of_molecules == 1
+
+    protocol.thermodynamic_state = ThermodynamicState(temperatures[0])
+    protocol.maximum_temperature = temperatures[-1]
+    protocol.replica_temperatures = temperatures[1:-1]
+
+    result = protocol.execute('run_parallel', compute_resources)
+    assert not isinstance(result, PropertyEstimatorException)
+
+    extract_energy = analysis.ExtractAverageStatistic('extract')
+    extract_energy.statistics_type = ObservableType.PotentialEnergy
+    extract_energy.statistics_path = protocol.statistics_file_path
+
+    result = extract_energy.execute('run_parallel', compute_resources)
+    assert not isinstance(result, PropertyEstimatorException)
+
+    return extract_energy.value
+
+
+def test_run(input_json, available_resources):
+
+    """A convenience function for running the full parallel tempering workflow
+    with a given set of parameters.
+    """
+
+    input_dictionary = json.loads(input_json, cls=TypedJSONDecoder)
+
+    root_directory = input_dictionary['root_directory']
+    original_coordinate_path = input_dictionary['coordinate_path']
+    original_system_path = input_dictionary['system_path']
+    replica_temperatures = input_dictionary['replica_temperatures']
+    number_of_molecules = input_dictionary['number_of_molecules']
+    total_number_of_iterations = input_dictionary['total_number_of_iterations']
+    steps_per_iteration = input_dictionary['steps_per_iteration']
+    timestep = input_dictionary['timestep']
+    integrator = input_dictionary['integrator']
+    replicates = input_dictionary['replicates']
+
+    simulation_mean_deviation = 0.0 * unit.kilojoule / unit.mole
+    parallel_mean_deviation = 0.0 * unit.kilojoule / unit.mole
+
+    simulation_error_deviation = 0.0 * unit.kilojoule / unit.mole
+    parallel_error_deviation = 0.0 * unit.kilojoule / unit.mole
+
+    for replicate_index in range(replicates):
+
+        directory = os.path.join(root_directory, f'{replicate_index}')
+        os.makedirs(directory, exist_ok=True)
+
+        coordinate_path = os.path.join(directory, 'input.pdb')
+        system_path = os.path.join(directory, 'system.xml')
+
+        shutil.copyfile(original_coordinate_path, coordinate_path)
+        shutil.copyfile(original_system_path, system_path)
+
+        coordinate_path = 'input.pdb'
+        system_path = 'system.xml'
+
+        with temporarily_change_directory(directory):
+
+            # Run the parallel tempering
+            parallel_tempering_start_time = time.perf_counter()
+
+            parallel_average_energy = _run_parallel_tempering(replica_temperatures,
+                                                              total_number_of_iterations,
+                                                              steps_per_iteration,
+                                                              timestep,
+                                                              integrator,
+                                                              number_of_molecules,
+                                                              coordinate_path,
+                                                              system_path,
+                                                              available_resources)
+
+            parallel_tempering_end_time = time.perf_counter()
+
+            parallel_mean_deviation += parallel_average_energy.value
+            parallel_error_deviation += parallel_average_energy.uncertainty
+
+            # Run a regular simulation for comparison
+            simulation_start_time = time.perf_counter()
+
+            average_energy = _run_regular_simulation(replica_temperatures[0],
+                                                     total_number_of_iterations,
+                                                     steps_per_iteration,
+                                                     timestep,
+                                                     number_of_molecules,
+                                                     coordinate_path,
+                                                     system_path,
+                                                     available_resources)
+
+            simulation_end_time = time.perf_counter()
+
+            simulation_mean_deviation += average_energy.value
+            simulation_error_deviation += average_energy.uncertainty
+
+            logging.info(f'Regular_Time {(simulation_end_time - simulation_start_time) * 1000} '
+                         f'Parallel_Time {(parallel_tempering_end_time - parallel_tempering_start_time) * 1000}')
+
+    parallel_mean_deviation /= replicates
+    parallel_error_deviation /= replicates
+
+    simulation_mean_deviation /= replicates
+    simulation_error_deviation /= replicates
+
+    return (simulation_mean_deviation, simulation_error_deviation,
+            parallel_mean_deviation, parallel_error_deviation)

--- a/propertyestimator/tests/test_protocols/test_simulation.py
+++ b/propertyestimator/tests/test_protocols/test_simulation.py
@@ -149,6 +149,25 @@ def test_openmm_parallel_tempering():
         protocol.high_precision = True
         protocol.enable_pbc = False
         protocol.allow_gpu_platforms = False
+        protocol.replica_temperatures = []
 
         result = protocol.execute(directory, ComputeResources())
         assert not isinstance(result, PropertyEstimatorException)
+
+        original_number_of_points = len(StatisticsArray.from_pandas_csv(protocol.statistics_file_path))
+
+        result = protocol.execute(directory, ComputeResources())
+        assert not isinstance(result, PropertyEstimatorException)
+
+        new_number_of_points = len(StatisticsArray.from_pandas_csv(protocol.statistics_file_path))
+
+        assert new_number_of_points == original_number_of_points
+
+        # Increase the number of steps to make sure things resume from the
+        # checkpoint correctly.
+        protocol.total_number_of_iterations = 2
+        result = protocol.execute(directory, ComputeResources())
+        assert not isinstance(result, PropertyEstimatorException)
+
+        new_number_of_points = len(StatisticsArray.from_pandas_csv(protocol.statistics_file_path))
+        assert new_number_of_points == original_number_of_points + 1

--- a/propertyestimator/tests/test_protocols/test_simulation.py
+++ b/propertyestimator/tests/test_protocols/test_simulation.py
@@ -140,10 +140,15 @@ def test_openmm_parallel_tempering():
 
         protocol = OpenMMParallelTempering('protocol')
         protocol.total_number_of_iterations = 1
-        protocol.steps_per_iteration = 5
+        protocol.steps_per_iteration = 1
         protocol.thermodynamic_state = thermodynamic_state
+        protocol.maximum_temperature = 500 * unit.kelvin
+        protocol.number_of_replicas = 1
         protocol.input_coordinate_file = coordinate_path
         protocol.system_path = system_path
+        protocol.high_precision = True
+        protocol.enable_pbc = False
+        protocol.allow_gpu_platforms = False
 
         result = protocol.execute(directory, ComputeResources())
         assert not isinstance(result, PropertyEstimatorException)

--- a/propertyestimator/utils/utils.py
+++ b/propertyestimator/utils/utils.py
@@ -155,7 +155,7 @@ def setup_timestamp_logging(file_path=None):
     logger_handler.setFormatter(formatter)
 
     logger = logging.getLogger()
-    logger.setLevel(logging.INFO)
+    logger.setLevel(logging.DEBUG)
     logger.addHandler(logger_handler)
 
 


### PR DESCRIPTION
## Description
This PR aims to add basic support for performing parallel tempering simulations, making use of the fantastic utilities in [openmmtools](openmmtools.readthedocs.io). This will in principle enable more comprehensive sampling of molecules with configurations separated by large energy barriers, such as when estimating the vacuum energies of carboxylic acids and esters.

## Status
- [ ] Ready to go