### PR TITLE
Store Workflow Layer Provenance as Dictionary

### DIFF
--- a/evaluator/layers/workflow.py
+++ b/evaluator/layers/workflow.py
@@ -145,7 +145,7 @@ class WorkflowCalculationLayer(CalculationLayer, abc.ABC):
             workflow_graph.add_workflow(workflow)
 
             provenance[physical_property.id] = CalculationSource(
-                fidelity=cls.__name__, provenance=workflow.schema.json()
+                fidelity=cls.__name__, provenance=workflow.schema
             )
 
         return workflow_graph, provenance


### PR DESCRIPTION
## Description
This PR fixes the workflow layer provenance being stored as string, rather than a JSON serializable dictionary.

## Status
- [X] Ready to go