### PR TITLE
Make Dask Backends Colab Compatible

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -184,6 +184,7 @@ Calculation Backends API
 
     CalculationBackend
     ComputeResources
+    QueueWorkerResources
 
 **Dask Backends**
 
@@ -197,7 +198,6 @@ Calculation Backends API
     DaskLocalCluster
     DaskLSFBackend
     DaskPBSBackend
-    QueueWorkerResources
 
 Storage API
 -----------

--- a/evaluator/backends/__init__.py
+++ b/evaluator/backends/__init__.py
@@ -1,12 +1,7 @@
 from .backends import CalculationBackend, ComputeResources, QueueWorkerResources
-from .dask import BaseDaskBackend, DaskLocalCluster, DaskLSFBackend, DaskPBSBackend
 
 __all__ = [
     ComputeResources,
     CalculationBackend,
     QueueWorkerResources,
-    BaseDaskBackend,
-    DaskLocalCluster,
-    DaskLSFBackend,
-    DaskPBSBackend,
 ]

--- a/evaluator/backends/dask.py
+++ b/evaluator/backends/dask.py
@@ -11,7 +11,6 @@ import traceback
 
 import dask
 from dask import distributed
-from dask_jobqueue import LSFCluster, PBSCluster
 from distributed import get_worker
 
 import evaluator
@@ -526,7 +525,7 @@ class DaskLSFBackend(BaseDaskJobQueueBackend):
         >>>
         >>> # Create the backend which will adaptively try to spin up between one and
         >>> # ten workers with the requested resources depending on the calculation load.
-        >>> from evaluator.backends import DaskLSFBackend
+        >>> from evaluator.backends.dask import DaskLSFBackend
         >>>
         >>> lsf_backend = DaskLSFBackend(minimum_number_of_workers=1,
         >>>                              maximum_number_of_workers=10,
@@ -574,6 +573,8 @@ class DaskLSFBackend(BaseDaskJobQueueBackend):
         return extra_kwargs
 
     def _get_cluster_class(self):
+        from dask_jobqueue import LSFCluster
+
         return LSFCluster
 
 
@@ -630,7 +631,7 @@ class DaskPBSBackend(BaseDaskJobQueueBackend):
         >>>
         >>> # Create the backend which will adaptively try to spin up between one and
         >>> # ten workers with the requested resources depending on the calculation load.
-        >>> from evaluator.backends import DaskPBSBackend
+        >>> from evaluator.backends.dask import DaskPBSBackend
         >>>
         >>> pbs_backend = DaskPBSBackend(minimum_number_of_workers=1,
         >>>                              maximum_number_of_workers=10,
@@ -662,6 +663,8 @@ class DaskPBSBackend(BaseDaskJobQueueBackend):
         return extra_kwargs
 
     def _get_cluster_class(self):
+        from dask_jobqueue import PBSCluster
+
         return PBSCluster
 
 

--- a/evaluator/server/server.py
+++ b/evaluator/server/server.py
@@ -114,7 +114,7 @@ class EvaluatorServer:
     and a local file storage backend:
 
     >>> # Create the backend which will be responsible for distributing the calculations
-    >>> from evaluator.backends import DaskLocalCluster, ComputeResources
+    >>> from evaluator.backends.dask import DaskLocalCluster
     >>> calculation_backend = DaskLocalCluster()
     >>> calculation_backend.start()
     >>>

--- a/evaluator/tests/test_backends/test_dask.py
+++ b/evaluator/tests/test_backends/test_dask.py
@@ -1,7 +1,7 @@
 import pytest
 
-from evaluator.backends import DaskLSFBackend, DaskPBSBackend, QueueWorkerResources
-from evaluator.backends.dask import _Multiprocessor
+from evaluator.backends import QueueWorkerResources
+from evaluator.backends.dask import DaskLSFBackend, DaskPBSBackend, _Multiprocessor
 from evaluator.workflow.plugins import registered_workflow_protocols
 
 

--- a/evaluator/tests/test_client.py
+++ b/evaluator/tests/test_client.py
@@ -5,7 +5,7 @@ import tempfile
 
 import pytest
 
-from evaluator.backends import DaskLocalCluster
+from evaluator.backends.dask import DaskLocalCluster
 from evaluator.client import EvaluatorClient, Request, RequestResult
 from evaluator.datasets import PhysicalPropertyDataSet
 from evaluator.forcefield import (

--- a/evaluator/tests/test_layers/test_layers.py
+++ b/evaluator/tests/test_layers/test_layers.py
@@ -2,7 +2,7 @@ import json
 import tempfile
 from os import makedirs, path
 
-from evaluator.backends import DaskLocalCluster
+from evaluator.backends.dask import DaskLocalCluster
 from evaluator.client import RequestOptions
 from evaluator.layers import CalculationLayer, CalculationLayerSchema, calculation_layer
 from evaluator.layers.layers import CalculationLayerResult

--- a/evaluator/tests/test_layers/test_workflow_layer.py
+++ b/evaluator/tests/test_layers/test_workflow_layer.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 
 from evaluator import unit
-from evaluator.backends import DaskLocalCluster
+from evaluator.backends.dask import DaskLocalCluster
 from evaluator.client import RequestOptions
 from evaluator.forcefield import SmirnoffForceFieldSource
 from evaluator.layers.simulation import SimulationLayer, SimulationSchema

--- a/evaluator/tests/test_server.py
+++ b/evaluator/tests/test_server.py
@@ -4,7 +4,7 @@ Units tests for the evaluator.server module.
 import tempfile
 from time import sleep
 
-from evaluator.backends import DaskLocalCluster
+from evaluator.backends.dask import DaskLocalCluster
 from evaluator.client import RequestOptions
 from evaluator.datasets import PhysicalPropertyDataSet
 from evaluator.layers import CalculationLayer, CalculationLayerSchema, calculation_layer

--- a/evaluator/tests/test_workflow/test_protocols.py
+++ b/evaluator/tests/test_workflow/test_protocols.py
@@ -7,7 +7,8 @@ import tempfile
 import pytest
 
 from evaluator import unit
-from evaluator.backends import ComputeResources, DaskLocalCluster
+from evaluator.backends import ComputeResources
+from evaluator.backends.dask import DaskLocalCluster
 from evaluator.protocols.miscellaneous import AddValues
 from evaluator.tests.test_workflow.utils import DummyInputOutputProtocol
 from evaluator.utils.serialization import TypedJSONDecoder

--- a/evaluator/tests/test_workflow/test_workflow.py
+++ b/evaluator/tests/test_workflow/test_workflow.py
@@ -7,7 +7,8 @@ import pytest
 
 from evaluator import unit
 from evaluator.attributes import UNDEFINED
-from evaluator.backends import ComputeResources, DaskLocalCluster
+from evaluator.backends import ComputeResources
+from evaluator.backends.dask import DaskLocalCluster
 from evaluator.protocols.groups import ConditionalGroup
 from evaluator.tests.test_workflow.utils import DummyInputOutputProtocol
 from evaluator.thermodynamics import ThermodynamicState

--- a/examples/property_estimator/start_server.py
+++ b/examples/property_estimator/start_server.py
@@ -2,7 +2,8 @@
 import argparse
 import logging
 
-from evaluator.backends import ComputeResources, DaskLocalCluster
+from evaluator.backends import ComputeResources
+from evaluator.backends.dask import DaskLocalCluster
 from evaluator.server import EvaluatorServer
 from evaluator.utils import setup_timestamp_logging
 

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -1,12 +1,8 @@
 from enum import Enum
 
 from evaluator import server, unit
-from evaluator.backends import (
-    ComputeResources,
-    DaskLocalCluster,
-    DaskLSFBackend,
-    QueueWorkerResources,
-)
+from evaluator.backends import ComputeResources, QueueWorkerResources
+from evaluator.backends.dask import DaskLocalCluster, DaskLSFBackend
 
 
 class BackendType(Enum):


### PR DESCRIPTION
## Description
This PR aims to fix an issue whereby the `dask` backend module could not be imported in Google Colab. This includes making `dask_jobqueue` a local import, and removing `dask` from being directly imported from the `backend` module.

## Status
- [X] Ready to go