### PR TITLE
Server Property Batching

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -18,6 +18,7 @@ dependencies:
   - numpy
   - pandas
   - openmm
+  - networkx
   - pint >= 0.10.1
   - packmol
   - pymbar >=3.0.5

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,8 +11,9 @@ Client Side API
     :nosignatures:
     :toctree: api/generated/
 
-    ConnectionOptions
     EvaluatorClient
+    BatchMode
+    ConnectionOptions
     Request
     RequestOptions
     RequestResult

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -18,6 +18,7 @@ dependencies:
     - pandas
     - lxml
     - icu 58*  # REQUIRED - DO NOT REMOVE.
+    - networkx
     - pint >=0.10.1
     - packmol
     - pymbar >=3.0.5

--- a/docs/gettingstarted/server.rst
+++ b/docs/gettingstarted/server.rst
@@ -3,6 +3,10 @@
 
 .. |local_file_storage|    replace:: :py:class:`~evaluator.storage.LocalFileStorage`
 
+.. |same_components|        replace:: :py:attr:`~evaluator.client.BatchMode.SameComponents`
+.. |shared_components|     replace:: :py:attr:`~evaluator.client.BatchMode.SharedComponents`
+.. |batch_mode_attr|       replace:: :py:attr:`~evaluator.client.RequestOptions.batch_mode`
+
 Evaluator Server
 ================
 
@@ -55,11 +59,20 @@ it can be interacted with directly by a client in the same script::
 
 Estimation Batches
 ------------------
-By default when a server recieves a request from a client, it will attempt to split the requested set of properties into
-smaller batches, represented by the |batch| object. The current behaviour is to batch together all properties which
-were measured for the same substance.
+When a server recieves a request from a client, it will attempt to split the requested set of properties into
+smaller batches, represented by the |batch| object. The server is currently only able to mark entire batches of
+estimated properties as being completed, as opposed to individual properties.
 
-This splitting into smaller batches allows the server to return back batches of properties as they complete, rather than
-needing to wait for a full request to complete.
+Currently the server supports two ways of batching properties:
 
-.. note:: This batching behaviour will be built upon and expanded in future versions of the evaluator framework.
+.. rst-class:: spaced-list
+
+    * |same_components|: All properties measured for the substance containing the *same* components will be batched
+      together. As an example, the density of a 80:20 and a 20:80 mix of ethanol and water would be batched together,
+      but the density of pure ethanol and the density of pure water would be placed into separate batches.
+
+    * |shared_components|: All properties measured for substances containing at least one common component will be
+      batched together. As an example, the densities of 80:20 and 20:80 mixtures of ethanol and water, and the pure
+      densities of ethanol and water would be batched together.
+
+The mode of batching is set by the client using the |batch_mode_attr| attribute of the request options.

--- a/evaluator/client/__init__.py
+++ b/evaluator/client/__init__.py
@@ -1,4 +1,5 @@
 from .client import (
+    BatchMode,
     ConnectionOptions,
     EvaluatorClient,
     Request,
@@ -7,6 +8,7 @@ from .client import (
 )
 
 __all__ = [
+    BatchMode,
     ConnectionOptions,
     EvaluatorClient,
     Request,

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party=cmiles,dask,dask_jobqueue,dateutil,distributed,mdtraj,numpy,openforcefield,openmmtools,packmol,pandas,pint,pymbar,pytest,requests,scipy,simtk,uncertainties,yaml,yank
+known_third_party=cmiles,dask,dask_jobqueue,dateutil,distributed,mdtraj,networkx,numpy,openforcefield,openmmtools,packmol,pandas,pint,pymbar,pytest,requests,scipy,simtk,uncertainties,yaml,yank
 
 [versioneer]
 # Automatic version numbering scheme


### PR DESCRIPTION
## Description
This PR implements different modes for how the server will batch similar properties to be estimated together. 

The main change here is that the server will now place all properties measured for substance which share common components in the same batch by default. 

This is predominantly to allow batching of cases such as when estimating the enthalpy of mixing of `CO` and `O` at the same time as the density of `CO` and the density of `O` (allowing all three properties to share single simulations). Previously the pure properties would be placed into their own batches, and hence would not be able to share simulations with the mixture calculations.

## Status
- [X] Ready to go