### PR TITLE
Fix Installation Instruction Channels

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -14,7 +14,7 @@ Installation from Conda
 
 To install the ``openff-evaluator`` from the ``omnia`` channel, simply run::
 
-    conda install -c omnia/label/beta openff-evaluator
+    conda install -c conda-forge -c omnia -c omnia/label/beta openff-evaluator
 
 Recommended Dependencies
 ------------------------


### PR DESCRIPTION
## Description
This PR adds the missing channel labels to the install instructions.

## Status
- [X] Ready to go