### PR TITLE
Fix Entry Point Module Name

### DIFF
--- a/evaluator/plugins.py
+++ b/evaluator/plugins.py
@@ -36,7 +36,7 @@ def register_external_plugins():
     plugin system.
     """
 
-    for entry_point in pkg_resources.iter_entry_points("openff-evaluator.plugins"):
+    for entry_point in pkg_resources.iter_entry_points("openff_evaluator.plugins"):
 
         try:
             entry_point.load()

--- a/evaluator/tests/test_plugins.py
+++ b/evaluator/tests/test_plugins.py
@@ -38,7 +38,7 @@ def test_register_external_plugins(caplog):
 
     # Add the mapping to the fake EntryPoint
     distribution._ep_map = {
-        "openff-evaluator.plugins": {
+        "openff_evaluator.plugins": {
             "dummy_1": valid_entry_point,
             "dummy_2": bad_entry_point,
         }


### PR DESCRIPTION
## Description
This PR implements a fix for the plugin entry point name containing a forbidden - character.

## Status
- [X] Ready to go