### PR TITLE
Default Units

### DIFF
--- a/evaluator/datasets/datasets.py
+++ b/evaluator/datasets/datasets.py
@@ -203,7 +203,10 @@ class PhysicalProperty(AttributeClass, abc.ABC):
         assert self.value.units.dimensionality == self.default_unit().dimensionality
 
         if self.uncertainty != UNDEFINED:
-            assert self.uncertainty.units.dimensionality == self.default_unit().dimensionality
+            assert (
+                self.uncertainty.units.dimensionality
+                == self.default_unit().dimensionality
+            )
 
 
 class PhysicalPropertyDataSet(TypedBaseModel):
@@ -557,8 +560,8 @@ class PhysicalPropertyDataSet(TypedBaseModel):
         """Converts a `PhysicalPropertyDataSet` to a `pandas.DataFrame` object
         with columns of
 
-            - 'Temperature / K'
-            - 'Pressure / kPa'
+            - 'Temperature (K)'
+            - 'Pressure (kPa)'
             - 'Phase'
             - 'N Components'
             - 'Component 1'
@@ -570,11 +573,11 @@ class PhysicalPropertyDataSet(TypedBaseModel):
             - 'Role N'
             - 'Mole Fraction N'
             - 'Exact Amount N'
-            - '<Property 1> Value / <default unit>'
-            - '<Property 1> Uncertainty / <default unit>'
+            - '<Property 1> Value (<default unit>)'
+            - '<Property 1> Uncertainty / (<default unit>)'
             - ...
-            - '<Property N> Value / <default unit>'
-            - '<Property N> Uncertainty / <default unit>'
+            - '<Property N> Value / (<default unit>)'
+            - '<Property N> Uncertainty / (<default unit>)'
             - `'Source'`
 
         where 'Component X' is a column containing the smiles representation of component X.
@@ -661,8 +664,8 @@ class PhysicalPropertyDataSet(TypedBaseModel):
 
             # Create the data row.
             data_row = {
-                "Temperature / K": temperature,
-                "Pressure / kPa": pressure,
+                "Temperature (K)": temperature,
+                "Pressure (kPa)": pressure,
                 "Phase": phase,
                 "N Components": len(physical_property.substance),
             }
@@ -674,8 +677,12 @@ class PhysicalPropertyDataSet(TypedBaseModel):
                 data_row[f"Mole Fraction {index + 1}"] = amounts[index][MoleFraction]
                 data_row[f"Exact Amount {index + 1}"] = amounts[index][ExactAmount]
 
-            data_row[f"{type(physical_property).__name__} Value"] = value
-            data_row[f"{type(physical_property).__name__} Uncertainty"] = uncertainty
+            data_row[
+                f"{type(physical_property).__name__} Value ({default_unit:~})"
+            ] = value
+            data_row[
+                f"{type(physical_property).__name__} Uncertainty ({default_unit:~})"
+            ] = uncertainty
 
             data_row["Source"] = source
 
@@ -690,8 +697,8 @@ class PhysicalPropertyDataSet(TypedBaseModel):
             return None
 
         data_columns = [
-            "Temperature / K",
-            "Pressure / kPa",
+            "Temperature (K)",
+            "Pressure (kPa)",
             "Phase",
             "N Components",
         ]
@@ -706,8 +713,8 @@ class PhysicalPropertyDataSet(TypedBaseModel):
 
             default_unit = default_units[property_type]
 
-            data_columns.append(f"{property_type} Value / {default_unit:~}")
-            data_columns.append(f"{property_type} Uncertainty / {default_unit:~}")
+            data_columns.append(f"{property_type} Value ({default_unit:~})")
+            data_columns.append(f"{property_type} Uncertainty ({default_unit:~})")
 
         data_columns.append("Source")
 

--- a/evaluator/datasets/datasets.py
+++ b/evaluator/datasets/datasets.py
@@ -2,6 +2,7 @@
 An API for defining, storing, and loading sets of physical
 property data.
 """
+import abc
 import uuid
 from enum import IntFlag, unique
 
@@ -79,7 +80,7 @@ class PropertyPhase(IntFlag):
         return f"<PropertyPhase {str(self)}>"
 
 
-class PhysicalProperty(AttributeClass):
+class PhysicalProperty(AttributeClass, abc.ABC):
     """Represents the value of any physical property and it's uncertainty
     if provided.
 
@@ -88,6 +89,13 @@ class PhysicalProperty(AttributeClass):
     the composition of the observed system, and metadata about how the
     property was collected.
     """
+
+    @classmethod
+    @abc.abstractmethod
+    def default_unit(cls):
+        """pint.Unit: The default unit (e.g. g / mol) associated with this
+        class of property."""
+        raise NotImplementedError()
 
     id = Attribute(
         docstring="A unique identifier string assigned to this property",
@@ -188,6 +196,14 @@ class PhysicalProperty(AttributeClass):
             state["id"] = str(uuid.uuid4()).replace("-", "")
 
         super(PhysicalProperty, self).__setstate__(state)
+
+    def validate(self, attribute_type=None):
+        super(PhysicalProperty, self).validate(attribute_type)
+
+        assert self.value.units.dimensionality == self.default_unit().dimensionality
+
+        if self.uncertainty != UNDEFINED:
+            assert self.uncertainty.units.dimensionality == self.default_unit().dimensionality
 
 
 class PhysicalPropertyDataSet(TypedBaseModel):
@@ -541,8 +557,8 @@ class PhysicalPropertyDataSet(TypedBaseModel):
         """Converts a `PhysicalPropertyDataSet` to a `pandas.DataFrame` object
         with columns of
 
-            - 'Temperature'
-            - 'Pressure'
+            - 'Temperature / K'
+            - 'Pressure / kPa'
             - 'Phase'
             - 'N Components'
             - 'Component 1'
@@ -554,11 +570,11 @@ class PhysicalPropertyDataSet(TypedBaseModel):
             - 'Role N'
             - 'Mole Fraction N'
             - 'Exact Amount N'
-            - '<Property 1> Value'
-            - '<Property 1> Uncertainty'
+            - '<Property 1> Value / <default unit>'
+            - '<Property 1> Uncertainty / <default unit>'
             - ...
-            - '<Property N> Value'
-            - '<Property N> Uncertainty'
+            - '<Property N> Value / <default unit>'
+            - '<Property N> Uncertainty / <default unit>'
             - `'Source'`
 
         where 'Component X' is a column containing the smiles representation of component X.
@@ -579,19 +595,21 @@ class PhysicalPropertyDataSet(TypedBaseModel):
         data_rows = []
 
         # Extract the data from the data set.
+        default_units = {}
+
         for physical_property in self:
 
             # Extract the measured state.
             temperature = physical_property.thermodynamic_state.temperature.to(
                 unit.kelvin
-            )
+            ).magnitude
             pressure = None
 
             if physical_property.thermodynamic_state.pressure != UNDEFINED:
 
                 pressure = physical_property.thermodynamic_state.pressure.to(
                     unit.kilopascal
-                )
+                ).magnitude
 
             phase = str(physical_property.phase)
 
@@ -614,15 +632,18 @@ class PhysicalPropertyDataSet(TypedBaseModel):
                 roles.append(component.role.name)
 
             # Extract the value data as a string.
+            default_unit = physical_property.default_unit()
+            default_units[physical_property.__class__.__name__] = default_unit
+
             value = (
                 None
                 if physical_property.value == UNDEFINED
-                else str(physical_property.value)
+                else physical_property.value.to(default_unit).magnitude
             )
             uncertainty = (
                 None
                 if physical_property.uncertainty == UNDEFINED
-                else str(physical_property.uncertainty)
+                else physical_property.uncertainty.to(default_unit).magnitude
             )
 
             # Extract the data source.
@@ -640,8 +661,8 @@ class PhysicalPropertyDataSet(TypedBaseModel):
 
             # Create the data row.
             data_row = {
-                "Temperature": str(temperature),
-                "Pressure": str(pressure),
+                "Temperature / K": temperature,
+                "Pressure / kPa": pressure,
                 "Phase": phase,
                 "N Components": len(physical_property.substance),
             }
@@ -669,8 +690,8 @@ class PhysicalPropertyDataSet(TypedBaseModel):
             return None
 
         data_columns = [
-            "Temperature",
-            "Pressure",
+            "Temperature / K",
+            "Pressure / kPa",
             "Phase",
             "N Components",
         ]
@@ -682,8 +703,11 @@ class PhysicalPropertyDataSet(TypedBaseModel):
             data_columns.append(f"Exact Amount {index + 1}")
 
         for property_type in self.property_types:
-            data_columns.append(f"{property_type} Value")
-            data_columns.append(f"{property_type} Uncertainty")
+
+            default_unit = default_units[property_type]
+
+            data_columns.append(f"{property_type} Value / {default_unit:~}")
+            data_columns.append(f"{property_type} Uncertainty / {default_unit:~}")
 
         data_columns.append("Source")
 

--- a/evaluator/properties/binding.py
+++ b/evaluator/properties/binding.py
@@ -3,6 +3,7 @@ A collection of density physical property definitions.
 """
 import copy
 
+from evaluator import unit
 from evaluator.datasets import PhysicalProperty
 from evaluator.layers.simulation import SimulationSchema
 from evaluator.protocols import coordinates, forcefield, miscellaneous, yank
@@ -13,6 +14,10 @@ from evaluator.workflow.utils import ProtocolPath
 
 class HostGuestBindingAffinity(PhysicalProperty):
     """A class representation of a host-guest binding affinity property"""
+
+    @classmethod
+    def default_unit(cls):
+        return unit.kilojoule / unit.mole
 
     @staticmethod
     def default_simulation_schema(existing_schema=None):

--- a/evaluator/properties/density.py
+++ b/evaluator/properties/density.py
@@ -26,6 +26,10 @@ from evaluator.workflow.utils import ProtocolPath, ReplicatorValue
 class Density(PhysicalProperty):
     """A class representation of a density property"""
 
+    @classmethod
+    def default_unit(cls):
+        return unit.gram / unit.millilitre
+
     @staticmethod
     def default_simulation_schema(
         absolute_tolerance=UNDEFINED, relative_tolerance=UNDEFINED, n_molecules=1000
@@ -217,6 +221,10 @@ class Density(PhysicalProperty):
 @thermoml_property("Excess molar volume, m3/mol", supported_phases=PropertyPhase.Liquid)
 class ExcessMolarVolume(PhysicalProperty):
     """A class representation of an excess molar volume property"""
+
+    @classmethod
+    def default_unit(cls):
+        return unit.centimeter ** 3 / unit.mole
 
     @staticmethod
     def _get_simulation_protocols(

--- a/evaluator/properties/dielectric.py
+++ b/evaluator/properties/dielectric.py
@@ -347,6 +347,10 @@ class ReweightDielectricConstant(reweighting.BaseMBARProtocol):
 class DielectricConstant(PhysicalProperty):
     """A class representation of a dielectric property"""
 
+    @classmethod
+    def default_unit(cls):
+        return unit.dimensionless
+
     @staticmethod
     def default_simulation_schema(
         absolute_tolerance=UNDEFINED, relative_tolerance=UNDEFINED, n_molecules=1000

--- a/evaluator/properties/enthalpy.py
+++ b/evaluator/properties/enthalpy.py
@@ -31,6 +31,10 @@ from evaluator.workflow.utils import ProtocolPath, ReplicatorValue
 class EnthalpyOfMixing(PhysicalProperty):
     """A class representation of an enthalpy of mixing property"""
 
+    @classmethod
+    def default_unit(cls):
+        return unit.kilojoule / unit.mole
+
     EnthalpyWorkflow = namedtuple(
         "EnthalpySchema",
         "build_coordinates "
@@ -774,6 +778,10 @@ class EnthalpyOfMixing(PhysicalProperty):
 )
 class EnthalpyOfVaporization(PhysicalProperty):
     """A class representation of an enthalpy of vaporization property"""
+
+    @classmethod
+    def default_unit(cls):
+        return unit.kilojoule / unit.mole
 
     @staticmethod
     def _default_reweighting_storage_query():

--- a/evaluator/properties/solvation.py
+++ b/evaluator/properties/solvation.py
@@ -24,6 +24,10 @@ from evaluator.workflow.utils import ProtocolPath
 class SolvationFreeEnergy(PhysicalProperty):
     """A class representation of a solvation free energy property."""
 
+    @classmethod
+    def default_unit(cls):
+        return unit.kilojoule / unit.mole
+
     @staticmethod
     def default_simulation_schema(
         absolute_tolerance=UNDEFINED, relative_tolerance=UNDEFINED, n_molecules=2000

--- a/evaluator/tests/test_datasets/test_datasets.py
+++ b/evaluator/tests/test_datasets/test_datasets.py
@@ -123,8 +123,8 @@ def test_to_pandas():
     data_set_pandas = data_set.to_pandas()
 
     required_columns = [
-        "Temperature / K",
-        "Pressure / kPa",
+        "Temperature (K)",
+        "Pressure (kPa)",
         "Phase",
         "N Components",
         "Source",
@@ -141,7 +141,10 @@ def test_to_pandas():
     assert all(x in data_set_pandas for x in required_columns)
 
     assert data_set_pandas is not None
-    assert len(data_set_pandas) == 12
+    assert data_set_pandas.shape == (12, 21)
+
+    data_set_without_na = data_set_pandas.dropna(axis=1, how="all")
+    assert data_set_without_na.shape == (12, 19)
 
 
 def test_sources_substances():

--- a/evaluator/tests/test_datasets/test_datasets.py
+++ b/evaluator/tests/test_datasets/test_datasets.py
@@ -123,8 +123,8 @@ def test_to_pandas():
     data_set_pandas = data_set.to_pandas()
 
     required_columns = [
-        "Temperature",
-        "Pressure",
+        "Temperature / K",
+        "Pressure / kPa",
         "Phase",
         "N Components",
         "Source",

--- a/evaluator/tests/test_datasets/test_thermoml.py
+++ b/evaluator/tests/test_datasets/test_thermoml.py
@@ -19,7 +19,6 @@ register_default_plugins()
 
 @thermoml_property("Osmotic coefficient", supported_phases=PropertyPhase.Liquid)
 class OsmoticCoefficient(PhysicalProperty):
-
     def default_unit(cls):
         return unit.dimensionless
 
@@ -29,14 +28,12 @@ class OsmoticCoefficient(PhysicalProperty):
     supported_phases=PropertyPhase.Liquid | PropertyPhase.Gas,
 )
 class VaporPressure(PhysicalProperty):
-
     def default_unit(cls):
         return unit.kilopascal
 
 
 @thermoml_property("Activity coefficient", supported_phases=PropertyPhase.Liquid)
 class ActivityCoefficient(PhysicalProperty):
-
     def default_unit(cls):
         return unit.dimensionless
 

--- a/evaluator/tests/test_datasets/test_thermoml.py
+++ b/evaluator/tests/test_datasets/test_thermoml.py
@@ -4,6 +4,7 @@ Units tests for evaluator.datasets
 import pint
 import pytest
 
+from evaluator import unit
 from evaluator.datasets import PhysicalProperty, PropertyPhase
 from evaluator.datasets.thermoml.plugins import thermoml_property
 from evaluator.datasets.thermoml.thermoml import (
@@ -18,7 +19,9 @@ register_default_plugins()
 
 @thermoml_property("Osmotic coefficient", supported_phases=PropertyPhase.Liquid)
 class OsmoticCoefficient(PhysicalProperty):
-    pass
+
+    def default_unit(cls):
+        return unit.dimensionless
 
 
 @thermoml_property(
@@ -26,12 +29,16 @@ class OsmoticCoefficient(PhysicalProperty):
     supported_phases=PropertyPhase.Liquid | PropertyPhase.Gas,
 )
 class VaporPressure(PhysicalProperty):
-    pass
+
+    def default_unit(cls):
+        return unit.kilopascal
 
 
 @thermoml_property("Activity coefficient", supported_phases=PropertyPhase.Liquid)
 class ActivityCoefficient(PhysicalProperty):
-    pass
+
+    def default_unit(cls):
+        return unit.dimensionless
 
 
 supported_units = [

--- a/evaluator/tests/utils.py
+++ b/evaluator/tests/utils.py
@@ -51,7 +51,7 @@ def create_dummy_property(property_class):
 
     Parameters
     ----------
-    property_class : type
+    property_class : type of PhysicalProperty
         The type of property, e.g. Density, DielectricConstant...
 
     Returns
@@ -67,8 +67,8 @@ def create_dummy_property(property_class):
         ),
         phase=PropertyPhase.Liquid,
         substance=substance,
-        value=10 * unit.gram,
-        uncertainty=1 * unit.gram,
+        value=10.0 * property_class.default_unit(),
+        uncertainty=1.0 * property_class.default_unit(),
     )
 
     dummy_property.source = CalculationSource(fidelity="dummy", provenance={})


### PR DESCRIPTION
## Description
This PR enforces that all physical property sub-classes must define their expected unit. The `to_pandas()` function now uses this information so that unit types are stored in headers, rather than columns.

## Status
- [X] Ready to go