### PR TITLE
Stabilise Documentation Builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,12 @@ autodoc_default_options = {
     'member-order': 'bysource',
 }
 
-autodoc_mock_imports = ['simtk']
+autodoc_mock_imports = [
+    'dask',
+    'dask_jobqueue',
+    'distributed',
+    'simtk'
+]
 
 # Autolabel settings
 autosectionlabel_maxdepth = 3
@@ -111,6 +116,8 @@ intersphinx_mapping = {
     'mdtraj': ('http://mdtraj.org/latest/', None),
     'dask': ('http://docs.dask.org/en/latest/', None),
     'dask.distributed': ('https://distributed.dask.org/en/latest/', None),
+    'distributed': ('https://distributed.dask.org/en/latest/', None),
+    'dask_jobqueue': ('https://jobqueue.dask.org/en/latest/', None),
     'openforcefield': ('https://open-forcefield-toolkit.readthedocs.io/en/latest/', None),
     'pint': ('https://pint.readthedocs.io/en/latest/', None)
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,6 +64,8 @@ autodoc_mock_imports = [
     'dask',
     'dask_jobqueue',
     'distributed',
+    'packmol',
+    'pymbar',
     'simtk'
 ]
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -22,7 +22,4 @@ dependencies:
     - pint >=0.10.1
     - packmol
     - pymbar >=3.0.5
-    - dask >=2.7.0
-    - distributed >=2.7.0
-    - dask-jobqueue >=0.7.0
     - uncertainties

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,7 +1,6 @@
 name: evaluator
 channels:
     - conda-forge
-    - omnia
 dependencies:
     # Base depends
     - python
@@ -20,6 +19,4 @@ dependencies:
     - icu 58*  # REQUIRED - DO NOT REMOVE.
     - networkx
     - pint >=0.10.1
-    - packmol
-    - pymbar >=3.0.5
     - uncertainties

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,7 +1,7 @@
 # .readthedocs.yml
 
 build:
-  image: latest
+  image: stable
 
 python:
   version: 3.6 


### PR DESCRIPTION
## Description
This PR aims to make building documentation more stable on RTD by:

- removing the number of conda dependencies which must be installed for the docs.
- swapping to the stable image.

## Status
- [X] Ready to go