### PR TITLE
[WIP] Test Make OpenEye License Path Absolute

### DIFF
--- a/.github/workflows/continous_integration.yaml
+++ b/.github/workflows/continous_integration.yaml
@@ -76,6 +76,8 @@ jobs:
 
           ./devtools/scripts/decrypt_oe_license.sh
           conda install -c openeye openeye-toolkits
+          
+          python -c "from openeye import oechem; assert oechem.OEChemIsLicensed()"
 
         env:
           OE_LICENSE_PASSPHRASE: ${{ secrets.OE_LICENSE_PASSPHRASE }}

--- a/.github/workflows/continous_integration.yaml
+++ b/.github/workflows/continous_integration.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      OE_LICENSE: ./oe_license.txt
+      OE_LICENSE: ${{ github.workspace }}/oe_license.txt
 
     strategy:
 


### PR DESCRIPTION
## Description
This PR tests whether it is possible to set an absolute path to the OpenEye license using the GitHub actions provided variables.

In addition, this PR adds a test to make sure that OpenEye can find the license.

## Status
- [x] Ready to go