### PR TITLE
Improve Workflow Graph Construction Performance

### DIFF
--- a/docs/workflows/workflowgraphs.rst
+++ b/docs/workflows/workflowgraphs.rst
@@ -20,8 +20,7 @@ same state point, for the same substance, and using the same force field paramet
     print(len(density_workflow.protocols), len(dielectric_workflow.protocols))
 
     workflow_graph = WorkflowGraph()
-    workflow_graph.add_workflow(density_workflow)
-    workflow_graph.add_workflow(dielectric_workflow)
+    workflow_graph.add_workflows(density_workflow, dielectric_workflow)
 
     print(len(workflow_graph.protocols))
 

--- a/evaluator/layers/workflow.py
+++ b/evaluator/layers/workflow.py
@@ -107,8 +107,9 @@ class WorkflowCalculationLayer(CalculationLayer, abc.ABC):
         options: RequestOptions
             The options to run the workflows with.
         """
-        workflow_graph = WorkflowGraph()
+
         provenance = {}
+        workflows = []
 
         for index, physical_property in enumerate(properties):
 
@@ -147,11 +148,14 @@ class WorkflowCalculationLayer(CalculationLayer, abc.ABC):
 
             workflow = Workflow(global_metadata, physical_property.id)
             workflow.schema = schema.workflow_schema
-            workflow_graph.add_workflow(workflow)
+            workflows.append(workflow)
 
             provenance[physical_property.id] = CalculationSource(
                 fidelity=cls.__name__, provenance=workflow.schema
             )
+
+        workflow_graph = WorkflowGraph()
+        workflow_graph.add_workflow(*workflows)
 
         return workflow_graph, provenance
 

--- a/evaluator/layers/workflow.py
+++ b/evaluator/layers/workflow.py
@@ -155,7 +155,7 @@ class WorkflowCalculationLayer(CalculationLayer, abc.ABC):
             )
 
         workflow_graph = WorkflowGraph()
-        workflow_graph.add_workflow(*workflows)
+        workflow_graph.add_workflows(*workflows)
 
         return workflow_graph, provenance
 

--- a/evaluator/tests/test_properties/test_properties.py
+++ b/evaluator/tests/test_properties/test_properties.py
@@ -96,9 +96,16 @@ def test_workflow_schema_merging(calculation_layer, property_type):
     workflow_graph_a = workflow_a.to_graph()
     workflow_graph_b = workflow_b.to_graph()
 
-    ordered_dict_a = OrderedDict(sorted(workflow_graph_a.dependants_graph.items()))
+    dependants_graph_a = workflow_graph_a._protocol_graph._build_dependants_graph(
+        workflow_graph_a.protocols, False, apply_reduction=True
+    )
+    dependants_graph_b = workflow_graph_b._protocol_graph._build_dependants_graph(
+        workflow_graph_b.protocols, False, apply_reduction=True
+    )
+
+    ordered_dict_a = OrderedDict(sorted(dependants_graph_a.items()))
     ordered_dict_a = {key: sorted(value) for key, value in ordered_dict_a.items()}
-    ordered_dict_b = OrderedDict(sorted(workflow_graph_b.dependants_graph.items()))
+    ordered_dict_b = OrderedDict(sorted(dependants_graph_b.items()))
     ordered_dict_b = {key: sorted(value) for key, value in ordered_dict_b.items()}
 
     merge_order_a = graph.topological_sort(ordered_dict_a)
@@ -168,8 +175,15 @@ def test_density_dielectric_merging():
     density_workflow_graph = density_workflow.to_graph()
     dielectric_workflow_graph = dielectric_workflow.to_graph()
 
-    merge_order_a = graph.topological_sort(density_workflow_graph.dependants_graph)
-    merge_order_b = graph.topological_sort(dielectric_workflow_graph.dependants_graph)
+    dependants_graph_a = density_workflow_graph._protocol_graph._build_dependants_graph(
+        density_workflow_graph.protocols, False, apply_reduction=True
+    )
+    dependants_graph_b = dielectric_workflow_graph._protocol_graph._build_dependants_graph(
+        dielectric_workflow_graph.protocols, False, apply_reduction=True
+    )
+
+    merge_order_a = graph.topological_sort(dependants_graph_a)
+    merge_order_b = graph.topological_sort(dependants_graph_b)
 
     for protocol_id_A, protocol_id_B in zip(merge_order_a, merge_order_b):
 

--- a/evaluator/tests/test_properties/test_properties.py
+++ b/evaluator/tests/test_properties/test_properties.py
@@ -37,15 +37,15 @@ def workflow_merge_functions():
 
         workflow_graph = WorkflowGraph()
 
-        workflow_graph.add_workflow(workflow_a)
-        workflow_graph.add_workflow(workflow_b)
+        workflow_graph.add_workflows(workflow_a)
+        workflow_graph.add_workflows(workflow_b)
 
         return workflow_graph
 
     def function_b(workflow_a, workflow_b):
 
         workflow_graph = WorkflowGraph()
-        workflow_graph.add_workflow(workflow_a, workflow_b)
+        workflow_graph.add_workflows(workflow_a, workflow_b)
 
         return workflow_graph
 

--- a/evaluator/tests/test_properties/test_properties.py
+++ b/evaluator/tests/test_properties/test_properties.py
@@ -28,6 +28,30 @@ def calculation_schema_generator():
             yield calculation_layer, property_type
 
 
+def workflow_merge_functions():
+    """Returns functions which will merge two work flows into
+    a single graph.
+    """
+
+    def function_a(workflow_a, workflow_b):
+
+        workflow_graph = WorkflowGraph()
+
+        workflow_graph.add_workflow(workflow_a)
+        workflow_graph.add_workflow(workflow_b)
+
+        return workflow_graph
+
+    def function_b(workflow_a, workflow_b):
+
+        workflow_graph = WorkflowGraph()
+        workflow_graph.add_workflow(workflow_a, workflow_b)
+
+        return workflow_graph
+
+    return [function_a, function_b]
+
+
 @pytest.mark.parametrize(
     "calculation_layer, property_type", calculation_schema_generator()
 )
@@ -64,7 +88,10 @@ def test_schema_serialization(calculation_layer, property_type):
 @pytest.mark.parametrize(
     "calculation_layer, property_type", calculation_schema_generator()
 )
-def test_workflow_schema_merging(calculation_layer, property_type):
+@pytest.mark.parametrize("workflow_merge_function", workflow_merge_functions())
+def test_workflow_schema_merging(
+    calculation_layer, property_type, workflow_merge_function
+):
     """Tests that two of the exact the same calculations get merged into one
     by the `WorkflowGraph`."""
 
@@ -88,10 +115,7 @@ def test_workflow_schema_merging(calculation_layer, property_type):
     workflow_b = Workflow(global_metadata, "workflow_b")
     workflow_b.schema = schema.workflow_schema
 
-    workflow_graph = WorkflowGraph()
-
-    workflow_graph.add_workflow(workflow_a)
-    workflow_graph.add_workflow(workflow_b)
+    workflow_graph = workflow_merge_function(workflow_a, workflow_b)
 
     workflow_graph_a = workflow_a.to_graph()
     workflow_graph_b = workflow_b.to_graph()
@@ -126,7 +150,8 @@ def test_workflow_schema_merging(calculation_layer, property_type):
         )
 
 
-def test_density_dielectric_merging():
+@pytest.mark.parametrize("workflow_merge_function", workflow_merge_functions())
+def test_density_dielectric_merging(workflow_merge_function):
 
     substance = Substance.from_components("C")
 
@@ -167,10 +192,7 @@ def test_density_dielectric_merging():
     dielectric_workflow = Workflow(dielectric_metadata)
     dielectric_workflow.schema = dielectric_schema
 
-    workflow_graph = WorkflowGraph()
-
-    workflow_graph.add_workflow(density_workflow)
-    workflow_graph.add_workflow(dielectric_workflow)
+    workflow_merge_function(density_workflow, dielectric_workflow)
 
     density_workflow_graph = density_workflow.to_graph()
     dielectric_workflow_graph = dielectric_workflow.to_graph()

--- a/evaluator/tests/test_workflow/test_protocols.py
+++ b/evaluator/tests/test_workflow/test_protocols.py
@@ -211,14 +211,22 @@ def test_protocol_graph_simple(protocols_a, protocols_b):
     protocol_graph = ProtocolGraph()
     protocol_graph.add_protocols(*protocols_a)
 
+    dependants_graph = protocol_graph._build_dependants_graph(
+        protocol_graph.protocols, False, apply_reduction=True
+    )
+
     assert len(protocol_graph.protocols) == len(protocols_a)
-    assert len(protocol_graph.dependants_graph) == len(protocols_a)
+    assert len(dependants_graph) == len(protocols_a)
     n_root_protocols = len(protocol_graph.root_protocols)
 
     protocol_graph.add_protocols(*protocols_b)
 
+    dependants_graph = protocol_graph._build_dependants_graph(
+        protocol_graph.protocols, False, apply_reduction=False
+    )
+
     assert len(protocol_graph.protocols) == len(protocols_a)
-    assert len(protocol_graph.dependants_graph) == len(protocols_a)
+    assert len(dependants_graph) == len(protocols_a)
     assert len(protocol_graph.root_protocols) == n_root_protocols
 
     # Currently the graph shouldn't merge with an
@@ -226,8 +234,12 @@ def test_protocol_graph_simple(protocols_a, protocols_b):
     protocol_graph = ProtocolGraph()
     protocol_graph.add_protocols(*protocols_a, *protocols_b)
 
+    dependants_graph = protocol_graph._build_dependants_graph(
+        protocol_graph.protocols, False, apply_reduction=False
+    )
+
     assert len(protocol_graph.protocols) == len(protocols_a) + len(protocols_b)
-    assert len(protocol_graph.dependants_graph) == len(protocols_a) + len(protocols_b)
+    assert len(dependants_graph) == len(protocols_a) + len(protocols_b)
     assert len(protocol_graph.root_protocols) == 2 * n_root_protocols
 
 

--- a/evaluator/tests/test_workflow/test_protocols.py
+++ b/evaluator/tests/test_workflow/test_protocols.py
@@ -117,7 +117,7 @@ def build_merge(prefix):
     protocol_b = DummyInputOutputProtocol(prefix + "protocol_b")
     protocol_b.input_value = ProtocolPath("output_value", protocol_a.id)
     protocol_c = DummyInputOutputProtocol(prefix + "protocol_c")
-    protocol_c.input_value = 1
+    protocol_c.input_value = 2
     protocol_d = DummyInputOutputProtocol(prefix + "protocol_d")
     protocol_d.input_value = ProtocolPath("output_value", protocol_c.id)
     protocol_e = DummyInputOutputProtocol(prefix + "protocol_e")
@@ -143,7 +143,7 @@ def build_fork(prefix):
     # g - h - |
     #          \ k - l
     protocol_g = DummyInputOutputProtocol(prefix + "protocol_g")
-    protocol_g.input_value = 1
+    protocol_g.input_value = 3
     protocol_h = DummyInputOutputProtocol(prefix + "protocol_h")
     protocol_h.input_value = ProtocolPath("output_value", protocol_g.id)
     protocol_i = DummyInputOutputProtocol(prefix + "protocol_i")

--- a/evaluator/tests/test_workflow/utils.py
+++ b/evaluator/tests/test_workflow/utils.py
@@ -28,14 +28,27 @@ def create_dummy_metadata(dummy_property, calculation_layer):
         for key, query in schema.storage_queries.items():
 
             fake_data = [
-                (f"data_path_{index}", f"ff_path_{index}") for index in range(3)
+                (f"data_path_{index}_{key}", f"ff_path_{index}_{key}")
+                for index in range(3)
             ]
 
             if (
                 query.substance_query != UNDEFINED
                 and query.substance_query.components_only
             ):
-                fake_data = [fake_data for _ in dummy_property.substance.components]
+                fake_data = []
+
+                for component_index in enumerate(dummy_property.substance.components):
+
+                    fake_data.append(
+                        [
+                            (
+                                f"data_path_{index}_{key}_{component_index}",
+                                f"ff_path_{index}_{key}",
+                            )
+                            for index in range(3)
+                        ]
+                    )
 
             global_metadata[key] = fake_data
 

--- a/evaluator/workflow/workflow.py
+++ b/evaluator/workflow/workflow.py
@@ -750,7 +750,7 @@ class Workflow:
             The graph representation of this workflow.
         """
         graph = WorkflowGraph()
-        graph.add_workflow(self)
+        graph.add_workflows(self)
         return graph
 
     @classmethod
@@ -882,7 +882,7 @@ class WorkflowGraph:
         self._workflows_to_execute = {}
         self._protocol_graph = ProtocolGraph()
 
-    def add_workflow(self, *workflows):
+    def add_workflows(self, *workflows):
         """Insert a set of workflows into the workflow graph.
 
         Parameters

--- a/evaluator/workflow/workflow.py
+++ b/evaluator/workflow/workflow.py
@@ -874,14 +874,6 @@ class WorkflowGraph:
         take input from the other grouped protocols."""
         return self._protocol_graph.root_protocols
 
-    @property
-    def dependants_graph(self):
-        """dict of str and str: A dictionary of which stores which grouped protocols
-        are dependant on other grouped protocols. Each key in the dictionary is the
-        id of a grouped protocol, and each value is the id of a protocol which depends
-        on the protocol by the key."""
-        return self._protocol_graph.dependants_graph
-
     def __init__(self):
 
         super(WorkflowGraph, self).__init__()


### PR DESCRIPTION
## Description
This PR improves the performance of constructing `WorkflowGraph` objects from many individual `Workflow` objects. In particular, it allows batches of `Workflow` objects to be added to a graph in one go which removes the need to constantly be rebuilding the dependency graph (an expensive step).

This PR also removes the cached dependency graph (and the exposed attribute to access it) - this was not safe to cache as mutable protocols could have their inputs redirected to depend on a different protocol after the initial dependency graph is constructed.

## Notable Behaviour Changes

- `ProtocolGraph` objects no longer expose their dependency graph.
- `ProtocolGraph` objects will always use an up to date dependency graph, even after its constituent protocols are mutated.
- The merge order of protocols is no longer deterministic (nor should it ever have been considered to be).
- Previously `ProtocolGroup` objects could only be merged if all root protocols could be merged - this has now been relaxed to ensure that at least one root protocol could be merged.

## API Changes

- `Workflow.add_workflow()` has been renamed to `Workflow.add_workflows()` to reflect that multiple workflows can now be added at once.

## Status
- [x] Ready to go