### PR TITLE
Fix Protocol Outputs Not Set on Resume

### DIFF
--- a/evaluator/workflow/protocols.py
+++ b/evaluator/workflow/protocols.py
@@ -1099,6 +1099,15 @@ class ProtocolGraph:
             # Check if the output of this protocol already exists and
             # whether we allow returning the found output.
             if os.path.isfile(output_path) and enable_checkpointing:
+
+                with open(output_path) as file:
+                    outputs = json.load(file, cls=TypedJSONDecoder)
+
+                for protocol_path, output in outputs.items():
+
+                    protocol_path = ProtocolPath.from_string(protocol_path)
+                    protocol.set_value(protocol_path, output)
+
                 return protocol.id, output_path
 
             # Store the results of the relevant previous protocols in a


### PR DESCRIPTION
## Description

This PR fixes a bug in the protocol graph / group code whereby if a protocol group was 'safely' killed (i.e. without exception) before it finished executing (e.g. the worker it was executed on hit a queueing system wall clock limit), the outputs of the other protocols in the graph / group were not properly restored when checkpointing was enabled.

This lead to undefined protocol outputs for the killed group even though the outputs had been computed, which in turn lead to dependant protocols receiving undefined inputs (and seemingly unrelated exceptions).

## Status
- [x] Ready to go