### PR TITLE
Refactor Packmol Utility

### DIFF
--- a/evaluator/protocols/coordinates.py
+++ b/evaluator/protocols/coordinates.py
@@ -261,6 +261,12 @@ class SolvateExistingStructure(BuildCoordinatesPackmol):
         type_hint=str,
         default_value=UNDEFINED,
     )
+    center_solute_in_box = InputAttribute(
+        docstring="If `True`, the solute to solvate will be centered in the "
+        "simulation box.",
+        type_hint=bool,
+        default_value=True,
+    )
 
     def _execute(self, directory, available_resources):
 
@@ -273,6 +279,7 @@ class SolvateExistingStructure(BuildCoordinatesPackmol):
             molecules=molecules,
             number_of_copies=number_of_molecules,
             structure_to_solvate=self.solute_coordinate_file,
+            center_solute=self.center_solute_in_box,
             mass_density=self.mass_density,
             verbose=self.verbose_packmol,
             working_directory=packmol_directory,

--- a/evaluator/tests/test_protocols/test_coordinates.py
+++ b/evaluator/tests/test_protocols/test_coordinates.py
@@ -70,9 +70,20 @@ def test_build_coordinates_packmol(input_substance, expected):
     build_coordinates.substance = input_substance
 
     with tempfile.TemporaryDirectory() as directory:
-        build_coordinates.execute(directory, None)
+        build_coordinates.execute(directory)
 
     assert build_coordinates.output_substance == expected
+
+    for component in input_substance:
+
+        assert component.identifier in build_coordinates.assigned_residue_names
+
+        if component.smiles == "O":
+
+            assigned_name = build_coordinates.assigned_residue_names[
+                component.identifier
+            ]
+            assert assigned_name[:3] == "HOH"
 
 
 def test_solvate_existing_structure_protocol():

--- a/evaluator/tests/test_protocols/test_coordinates.py
+++ b/evaluator/tests/test_protocols/test_coordinates.py
@@ -89,8 +89,12 @@ def test_build_coordinates_packmol(input_substance, expected):
 def test_solvate_existing_structure_protocol():
     """Tests solvating a single methanol molecule in water."""
 
+    import mdtraj
+
+    methanol_component = Component("CO")
+
     methanol_substance = Substance()
-    methanol_substance.add_component(Component("CO"), ExactAmount(1))
+    methanol_substance.add_component(methanol_component, ExactAmount(1))
 
     water_substance = Substance()
     water_substance.add_component(Component("O"), MoleFraction(1.0))
@@ -102,6 +106,10 @@ def test_solvate_existing_structure_protocol():
         build_methanol_coordinates.substance = methanol_substance
         build_methanol_coordinates.execute(temporary_directory, ComputeResources())
 
+        methanol_residue_name = build_methanol_coordinates.assigned_residue_names[
+            methanol_component.identifier
+        ]
+
         solvate_coordinates = SolvateExistingStructure("solvate_methanol")
         solvate_coordinates.max_molecules = 9
         solvate_coordinates.substance = water_substance
@@ -109,9 +117,10 @@ def test_solvate_existing_structure_protocol():
             build_methanol_coordinates.coordinate_file_path
         )
         solvate_coordinates.execute(temporary_directory, ComputeResources())
-        solvated_pdb = PDBFile(solvate_coordinates.coordinate_file_path)
+        solvated_system = mdtraj.load_pdb(solvate_coordinates.coordinate_file_path)
 
-        assert solvated_pdb.topology.getNumResidues() == 10
+        assert solvated_system.n_residues == 10
+        assert solvated_system.top.residue(0).name == methanol_residue_name
 
 
 def test_build_docked_coordinates_protocol():

--- a/evaluator/tests/test_utils/test_packmol.py
+++ b/evaluator/tests/test_utils/test_packmol.py
@@ -6,78 +6,157 @@ import pytest
 
 from evaluator import unit
 from evaluator.utils import packmol
+from evaluator.utils.packmol import PackmolRuntimeException
 
 
-def _validate_water_results(topology, positions):
-    """Performs a simple check that the positions and topology
-    is consistent with a box of 10 water molecules"""
-    assert topology is not None and positions is not None
+def test_packmol_box_size():
 
-    assert len(positions) == 30
-    assert (
-        unit.get_base_units(unit.angstrom)[-1]
-        == unit.get_base_units(positions.units)[-1]
-    )
-
-    assert topology.getNumChains() == 1
-    assert topology.getNumResidues() == 10
-    assert topology.getNumAtoms() == 30
-    assert topology.getNumBonds() == 20
-
-
-def _validate_paracetamol_results(topology, positions):
-    """Performs a simple check that the positions and topology
-    is consistent with a box of 10 water molecules"""
-    assert topology is not None and positions is not None
-
-    assert len(positions) == 20
-    assert (
-        unit.get_base_units(unit.angstrom)[-1]
-        == unit.get_base_units(positions.units)[-1]
-    )
-
-    assert topology.getNumChains() == 1
-    assert topology.getNumResidues() == 1
-    assert topology.getNumAtoms() == 20
-    assert topology.getNumBonds() == 20
-
-
-def test_packmol_packbox():
     from openforcefield.topology import Molecule
-    from simtk import unit as simtk_unit
 
     molecules = [Molecule.from_smiles("O")]
 
-    topology, positions = packmol.pack_box(
-        molecules, [10], mass_density=1.0 * unit.grams / unit.milliliters
-    )
-    _validate_water_results(topology, positions)
+    trajectory = packmol.pack_box(molecules, [10], box_size=([20] * 3) * unit.angstrom)
 
-    topology, positions = packmol.pack_box(
-        molecules, [10], box_size=([20] * 3) * unit.angstrom
-    )
-    _validate_water_results(topology, positions)
+    assert trajectory is not None
 
-    assert np.allclose(
-        topology.getPeriodicBoxVectors()[0].value_in_unit(simtk_unit.angstrom),
-        (22, 0, 0),
-    )
-    assert np.allclose(
-        topology.getPeriodicBoxVectors()[1].value_in_unit(simtk_unit.angstrom),
-        (0, 22, 0),
-    )
-    assert np.allclose(
-        topology.getPeriodicBoxVectors()[2].value_in_unit(simtk_unit.angstrom),
-        (0, 0, 22),
-    )
+    assert trajectory.n_chains == 1
+    assert trajectory.n_residues == 10
+    assert trajectory.n_atoms == 30
+    assert trajectory.topology.n_bonds == 20
+
+    assert all(x.name == "HOH" for x in trajectory.top.residues)
+
+    assert np.allclose(trajectory.unitcell_lengths, 2.2)
+
+
+def test_packmol_bad_input():
+
+    from openforcefield.topology import Molecule
+
+    molecules = [Molecule.from_smiles("O")]
 
     with pytest.raises(ValueError):
         packmol.pack_box(molecules, [10, 20], box_size=([20] * 3) * unit.angstrom)
 
+
+def test_packmol_failed():
+
+    from openforcefield.topology import Molecule
+
+    molecules = [Molecule.from_smiles("O")]
+
+    with pytest.raises(PackmolRuntimeException):
+        packmol.pack_box(molecules, [10], box_size=([0.1] * 3) * unit.angstrom)
+
+
+def test_packmol_water():
+
+    from openforcefield.topology import Molecule
+
+    molecules = [Molecule.from_smiles("O")]
+
+    trajectory = packmol.pack_box(
+        molecules, [10], mass_density=1.0 * unit.grams / unit.milliliters,
+    )
+
+    assert trajectory is not None
+
+    assert trajectory.n_chains == 1
+    assert trajectory.n_residues == 10
+    assert trajectory.n_atoms == 30
+    assert trajectory.topology.n_bonds == 20
+
+    assert all(x.name == "HOH" for x in trajectory.top.residues)
+
+
+def test_packmol_ions():
+
+    from openforcefield.topology import Molecule
+
+    molecules = [
+        Molecule.from_smiles("[Na+]"),
+        Molecule.from_smiles("[Cl-]"),
+        Molecule.from_smiles("[K+]"),
+    ]
+
+    trajectory = packmol.pack_box(
+        molecules, [1, 1, 1], box_size=([20] * 3) * unit.angstrom
+    )
+
+    assert trajectory is not None
+
+    assert trajectory.n_chains == 3
+    assert trajectory.n_residues == 3
+    assert trajectory.n_atoms == 3
+    assert trajectory.topology.n_bonds == 0
+
+    assert trajectory.top.residue(0).name == "Na+"
+    assert trajectory.top.residue(1).name == "Cl-"
+    assert trajectory.top.residue(2).name == "K+"
+
+    assert trajectory.top.atom(0).name == "Na+"
+    assert trajectory.top.atom(1).name == "Cl-"
+    assert trajectory.top.atom(2).name == "K+"
+
+
+def test_packmol_paracetamol():
+
+    from openforcefield.topology import Molecule
+
     # Test something a bit more tricky than water
     molecules = [Molecule.from_smiles("CC(=O)NC1=CC=C(C=C1)O")]
 
-    topology, positions = packmol.pack_box(
-        molecules, [1], box_size=([20] * 3) * unit.angstrom
+    trajectory = packmol.pack_box(molecules, [1], box_size=([20] * 3) * unit.angstrom)
+
+    assert trajectory is not None
+
+    assert trajectory.n_chains == 1
+    assert trajectory.n_residues == 1
+    assert trajectory.n_atoms == 20
+    assert trajectory.topology.n_bonds == 20
+
+
+def test_amino_acids():
+
+    amino_residues = {
+        "C[C@H](N)C(=O)O": "ALA",
+        # Undefined stereochemistry error.
+        # "N=C(N)NCCC[C@H](N)C(=O)O": "ARG",
+        "NC(=O)C[C@H](N)C(=O)O": "ASN",
+        "N[C@@H](CC(=O)O)C(=O)O": "ASP",
+        "N[C@@H](CS)C(=O)O": "CYS",
+        "N[C@@H](CCC(=O)O)C(=O)O": "GLU",
+        "NC(=O)CC[C@H](N)C(=O)O": "GLN",
+        "NCC(=O)O": "GLY",
+        "N[C@@H](Cc1c[nH]cn1)C(=O)O": "HIS",
+        "CC[C@H](C)[C@H](N)C(=O)O": "ILE",
+        "CC(C)C[C@H](N)C(=O)O": "LEU",
+        "NCCCC[C@H](N)C(=O)O": "LYS",
+        "CSCC[C@H](N)C(=O)O": "MET",
+        "N[C@@H](Cc1ccccc1)C(=O)O": "PHE",
+        "O=C(O)[C@@H]1CCCN1": "PRO",
+        "N[C@@H](CO)C(=O)O": "SER",
+        "C[C@@H](O)[C@H](N)C(=O)O": "THR",
+        "N[C@@H](Cc1c[nH]c2ccccc12)C(=O)O": "TRP",
+        "N[C@@H](Cc1ccc(O)cc1)C(=O)O": "TYR",
+        "CC(C)[C@H](N)C(=O)O": "VAL",
+    }
+
+    smiles = [*amino_residues]
+
+    from openforcefield.topology import Molecule
+
+    molecules = [Molecule.from_smiles(x) for x in smiles]
+    counts = [1] * len(smiles)
+
+    trajectory = packmol.pack_box(
+        molecules, counts, box_size=([1000] * 3) * unit.angstrom
     )
-    _validate_paracetamol_results(topology, positions)
+
+    assert trajectory is not None
+
+    assert trajectory.n_chains == len(smiles)
+    assert trajectory.n_residues == len(smiles)
+
+    for index, smiles in enumerate(smiles):
+        assert trajectory.top.residue(index).name == amino_residues[smiles]

--- a/evaluator/tests/test_utils/test_packmol.py
+++ b/evaluator/tests/test_utils/test_packmol.py
@@ -15,7 +15,9 @@ def test_packmol_box_size():
 
     molecules = [Molecule.from_smiles("O")]
 
-    trajectory, _ = packmol.pack_box(molecules, [10], box_size=([20] * 3) * unit.angstrom)
+    trajectory, _ = packmol.pack_box(
+        molecules, [10], box_size=([20] * 3) * unit.angstrom
+    )
 
     assert trajectory is not None
 
@@ -106,7 +108,9 @@ def test_packmol_paracetamol():
     # Test something a bit more tricky than water
     molecules = [Molecule.from_smiles("CC(=O)NC1=CC=C(C=C1)O")]
 
-    trajectory, _ = packmol.pack_box(molecules, [1], box_size=([20] * 3) * unit.angstrom)
+    trajectory, _ = packmol.pack_box(
+        molecules, [1], box_size=([20] * 3) * unit.angstrom
+    )
 
     assert trajectory is not None
 

--- a/evaluator/tests/test_utils/test_packmol.py
+++ b/evaluator/tests/test_utils/test_packmol.py
@@ -15,7 +15,7 @@ def test_packmol_box_size():
 
     molecules = [Molecule.from_smiles("O")]
 
-    trajectory = packmol.pack_box(molecules, [10], box_size=([20] * 3) * unit.angstrom)
+    trajectory, _ = packmol.pack_box(molecules, [10], box_size=([20] * 3) * unit.angstrom)
 
     assert trajectory is not None
 
@@ -55,7 +55,7 @@ def test_packmol_water():
 
     molecules = [Molecule.from_smiles("O")]
 
-    trajectory = packmol.pack_box(
+    trajectory, _ = packmol.pack_box(
         molecules, [10], mass_density=1.0 * unit.grams / unit.milliliters,
     )
 
@@ -79,7 +79,7 @@ def test_packmol_ions():
         Molecule.from_smiles("[K+]"),
     ]
 
-    trajectory = packmol.pack_box(
+    trajectory, _ = packmol.pack_box(
         molecules, [1, 1, 1], box_size=([20] * 3) * unit.angstrom
     )
 
@@ -106,7 +106,7 @@ def test_packmol_paracetamol():
     # Test something a bit more tricky than water
     molecules = [Molecule.from_smiles("CC(=O)NC1=CC=C(C=C1)O")]
 
-    trajectory = packmol.pack_box(molecules, [1], box_size=([20] * 3) * unit.angstrom)
+    trajectory, _ = packmol.pack_box(molecules, [1], box_size=([20] * 3) * unit.angstrom)
 
     assert trajectory is not None
 
@@ -149,7 +149,7 @@ def test_amino_acids():
     molecules = [Molecule.from_smiles(x) for x in smiles]
     counts = [1] * len(smiles)
 
-    trajectory = packmol.pack_box(
+    trajectory, _ = packmol.pack_box(
         molecules, counts, box_size=([1000] * 3) * unit.angstrom
     )
 

--- a/evaluator/utils/packmol.py
+++ b/evaluator/utils/packmol.py
@@ -421,7 +421,7 @@ def _build_input_file(
                 f"  number 1",
                 f"  fixed "
                 f"{box_size[0] / 2.0} "
-                f"{box_size[1 / 2.0]} "
+                f"{box_size[1] / 2.0} "
                 f"{box_size[2] / 2.0} 0. 0. 0.",
                 f"  centerofmass",
                 f"end structure",

--- a/evaluator/utils/packmol.py
+++ b/evaluator/utils/packmol.py
@@ -379,7 +379,7 @@ def _build_input_file(
         The lengths of each box vector.
     tolerance: pint.Quantity
         The packmol convergence tolerance.
-    output_file_name:
+    output_file_name: str
         The path to save the packed pdb to.
 
     Returns

--- a/evaluator/utils/packmol.py
+++ b/evaluator/utils/packmol.py
@@ -579,6 +579,9 @@ def pack_box(
     -------
     mdtraj.Trajectory
         The packed box encoded in an mdtraj trajectory.
+    list of str
+        The residue names which were assigned to each of the
+        molecules in the `molecules` list.
 
     Raises
     ------
@@ -632,6 +635,8 @@ def pack_box(
 
         structure_to_solvate = "solvate.pdb"
 
+    assigned_residue_names = []
+
     with temporarily_change_directory(working_directory):
 
         # Create PDB files for all of the molecules.
@@ -647,6 +652,9 @@ def pack_box(
 
             mdtraj_trajectory.save_pdb(pdb_file_name)
             mdtraj_topologies.append(mdtraj_trajectory.topology)
+
+            residue_name = mdtraj_trajectory.topology.residue(0).name
+            assigned_residue_names.append(residue_name)
 
         # Generate the input file.
         output_file_name = "packmol_output.pdb"
@@ -702,6 +710,7 @@ def pack_box(
             output_file_name, mdtraj_topologies, number_of_copies, structure_to_solvate
         )
         trajectory.unitcell_lengths = box_size
+        trajectory.unitcell_angles = [90.0] * 3
 
         if not retain_working_files:
             os.unlink(output_file_name)
@@ -709,4 +718,4 @@ def pack_box(
     if temporary_directory and not retain_working_files:
         shutil.rmtree(working_directory)
 
-    return trajectory
+    return trajectory, assigned_residue_names

--- a/evaluator/utils/packmol.py
+++ b/evaluator/utils/packmol.py
@@ -18,50 +18,522 @@ from distutils.spawn import find_executable
 from functools import reduce
 
 import numpy as np
-from simtk import openmm
 
 from evaluator import unit
+from evaluator.substances import Component
 from evaluator.utils.openmm import openmm_quantity_to_pint
 from evaluator.utils.utils import temporarily_change_directory
 
 logger = logging.getLogger(__name__)
 
 
-_PACKMOL_PATH = (
-    find_executable("packmol") or shutil.which("packmol") or None
-    if "PACKMOL" not in os.environ
-    else os.environ["PACKMOL"]
-)
+class PackmolRuntimeException(Exception):
+    """An exception raised when packmol fails to
+    execute / converge for some reason.
+    """
 
-_HEADER_TEMPLATE = """
-# Mixture
-tolerance {0:f}
-filetype pdb
-output {1:s}
-"""
-# add_amber_ter
+    pass
 
-_BOX_TEMPLATE = """
-structure {0:s}
-  number {1:d}
-  inside box 0. 0. 0. {2:f} {3:f} {4:f}
-end structure
-"""
 
-_SOLVATE_TEMPLATE = """
-structure {0:s}
-  number 1
-  fixed {1:f} {2:f} {3:f} 0. 0. 0.
-  centerofmass
-end structure
-"""
+def _find_packmol():
+    """Attempts to find the path to the `packmol` binary.
+
+    Returns
+    -------
+    str, optional
+        The path to the packmol binary if it could be found, otherwise
+        `None`.
+    """
+
+    return (
+        find_executable("packmol") or shutil.which("packmol") or None
+        if "PACKMOL" not in os.environ
+        else os.environ["PACKMOL"]
+    )
+
+
+def _validate_inputs(
+    molecules,
+    number_of_copies,
+    structure_to_solvate,
+    box_aspect_ratio,
+    box_size,
+    mass_density,
+):
+    """Validate the inputs which were passed to the main pack method.
+
+    Parameters
+    ----------
+    molecules : list of openforcefield.topology.Molecule
+        The molecules in the system.
+    number_of_copies : list of int
+        A list of the number of copies of each molecule type, of length
+        equal to the length of `molecules`.
+    structure_to_solvate: str, optional
+        A file path to the PDB coordinates of the structure to be solvated.
+    box_size : pint.Quantity, optional
+        The size of the box to generate in units compatible with angstroms.
+        If `None`, `mass_density` must be provided.
+    mass_density : pint.Quantity, optional
+        Target mass density for final system with units compatible with g / mL.
+         If `None`, `box_size` must be provided.
+    box_aspect_ratio: list of float, optional
+        The aspect ratio of the simulation box, used in conjunction with
+        the `mass_density` parameter.
+    """
+
+    if box_size is None and mass_density is None:
+        raise ValueError("Either a `box_size` or `mass_density` must be specified.")
+
+    if box_size is not None and len(box_size) != 3:
+        raise ValueError("`box_size` must be a pint.Quantity wrapped list of length 3")
+
+    if box_aspect_ratio is not None:
+
+        # noinspection PyTypeChecker
+        assert len(box_aspect_ratio) == 3
+        assert all(x > 0.0 for x in box_aspect_ratio)
+
+    # noinspection PyTypeChecker
+    if len(molecules) != len(number_of_copies):
+
+        raise ValueError(
+            "The length of `molecules` and `number_of_copies` must be identical."
+        )
+
+    if structure_to_solvate is not None:
+        assert os.path.isfile(structure_to_solvate)
+
+
+def _approximate_box_size_by_density(
+    molecules, n_copies, mass_density, box_aspect_ratio, box_scaleup_factor=1.1,
+):
+    """Generate an approximate box size based on the number and molecular
+    weight of the molecules present, and a target density for the final
+    solvated mixture.
+
+    Parameters
+    ----------
+    molecules : list of openforcefield.topology.Molecule
+        The molecules in the system.
+    n_copies : list of int
+        The number of copies of each molecule.
+    mass_density : pint.Quantity
+        The target mass density for final system. It should have units
+        compatible with g / mL.
+    box_aspect_ratio: List of float
+        The aspect ratio of the simulation box, used in conjunction with
+        the `mass_density` parameter.
+    box_scaleup_factor : float
+        The factor by which the estimated box size should be
+        increased.
+
+    Returns
+    -------
+    pint.Quantity
+        A list of the three box lengths in units compatible with angstroms.
+    """
+
+    volume = 0.0 * unit.angstrom ** 3
+
+    for (molecule, number) in zip(molecules, n_copies):
+
+        molecule_mass = reduce(
+            (lambda x, y: x + y), [atom.mass for atom in molecule.atoms]
+        )
+        molecule_mass = openmm_quantity_to_pint(molecule_mass) / unit.avogadro_constant
+
+        molecule_volume = molecule_mass / mass_density
+
+        volume += molecule_volume * number
+
+    box_length = volume ** (1.0 / 3.0) * box_scaleup_factor
+    box_length_angstrom = box_length.to(unit.angstrom).magnitude
+
+    aspect_ratio_normalizer = (
+        box_aspect_ratio[0] * box_aspect_ratio[1] * box_aspect_ratio[2]
+    ) ** (1.0 / 3.0)
+
+    box_size = [
+        box_length_angstrom * box_aspect_ratio[0],
+        box_length_angstrom * box_aspect_ratio[1],
+        box_length_angstrom * box_aspect_ratio[2],
+    ] * unit.angstrom
+
+    box_size /= aspect_ratio_normalizer
+
+    return box_size
+
+
+def _generate_residue_name(residue, smiles):
+    """Generates residue name for a particular residue which
+    corresponds to a particular smiles pattern.
+
+    Where possible (i.e for amino acids and ions) a standard residue
+    name will be returned, otherwise a random name will be used.
+
+    Parameters
+    ----------
+    residue: mdtraj.core.topology.Residue
+        The residue to assign the name to.
+    smiles: str
+        The SMILES pattern to generate a resiude name for.
+    """
+    from mdtraj.core import residue_names
+    from openforcefield.topology import Molecule
+
+    # Define the set of residue names which should be discarded
+    # if randomly generated as they have a reserved meaning.
+    # noinspection PyProtectedMember
+    forbidden_residue_names = [
+        *residue_names._AMINO_ACID_CODES,
+        *residue_names._SOLVENT_TYPES,
+        *residue_names._WATER_RESIDUES,
+        "ADE",
+        "CYT",
+        "CYX",
+        "DAD",
+        "DGU",
+        "FOR",
+        "GUA",
+        "HID",
+        "HIE",
+        "HIH",
+        "HSD",
+        "HSH",
+        "HSP",
+        "NMA",
+        "THY",
+        "URA",
+    ]
+
+    amino_residue_mappings = {
+        "C[C@H](N)C(=O)O": "ALA",
+        "N=C(N)NCCC[C@H](N)C(=O)O": "ARG",
+        "NC(=O)C[C@H](N)C(=O)O": "ASN",
+        "N[C@@H](CC(=O)O)C(=O)O": "ASP",
+        "N[C@@H](CS)C(=O)O": "CYS",
+        "N[C@@H](CCC(=O)O)C(=O)O": "GLU",
+        "NC(=O)CC[C@H](N)C(=O)O": "GLN",
+        "NCC(=O)O": "GLY",
+        "N[C@@H](Cc1c[nH]cn1)C(=O)O": "HIS",
+        "CC[C@H](C)[C@H](N)C(=O)O": "ILE",
+        "CC(C)C[C@H](N)C(=O)O": "LEU",
+        "NCCCC[C@H](N)C(=O)O": "LYS",
+        "CSCC[C@H](N)C(=O)O": "MET",
+        "N[C@@H](Cc1ccccc1)C(=O)O": "PHE",
+        "O=C(O)[C@@H]1CCCN1": "PRO",
+        "N[C@@H](CO)C(=O)O": "SER",
+        "C[C@@H](O)[C@H](N)C(=O)O": "THR",
+        "N[C@@H](Cc1c[nH]c2ccccc12)C(=O)O": "TRP",
+        "N[C@@H](Cc1ccc(O)cc1)C(=O)O": "TYR",
+        "CC(C)[C@H](N)C(=O)O": "VAL",
+    }
+
+    standardized_smiles = Component(smiles=smiles).smiles
+
+    # Check for amino acids.
+    if standardized_smiles in amino_residue_mappings:
+        residue.name = amino_residue_mappings[standardized_smiles]
+        return
+
+    # Check for water
+    if standardized_smiles == "O":
+
+        residue.name = "HOH"
+
+        # Re-assign the water atom names. These need to be set to get
+        # correct CONECT statements.
+        h_counter = 1
+
+        for atom in residue.atoms:
+
+            if atom.element.symbol == "O":
+                atom.name = "O1"
+            else:
+                atom.name = f"H{h_counter}"
+                h_counter += 1
+
+        return
+
+    # Check for ions
+    openff_molecule = Molecule.from_smiles(smiles, allow_undefined_stereo=True)
+
+    if openff_molecule.n_atoms == 1:
+        residue.name = _ion_residue_name(openff_molecule)
+        residue.atom(0).name = residue.name
+
+        return
+
+    # Randomly generate a name
+    random_residue_name = "".join(
+        [random.choice(string.ascii_uppercase) for _ in range(3)]
+    )
+
+    while random_residue_name in forbidden_residue_names:
+        # Re-choose the residue name until we find a safe one.
+        random_residue_name = "".join(
+            [random.choice(string.ascii_uppercase) for _ in range(3)]
+        )
+
+    residue.name = random_residue_name
+
+    # Assign unique atom names.
+    element_counter = defaultdict(int)
+
+    for atom in residue.atoms:
+        atom.name = f"{atom.element.symbol}{element_counter[atom.element.symbol] + 1}"
+        element_counter[atom.element.symbol] += 1
+
+
+def _ion_residue_name(molecule):
+    """Generates a residue name for a monatomic ion.
+
+    Parameters
+    ----------
+    molecule: openforcefield.topology.Molecule
+        The monoatomic ion to generate a resiude name for.
+
+    Returns
+    -------
+    str
+        The residue name of the ion
+    """
+
+    element_symbol = molecule.atoms[0].element.symbol
+    charge_symbol = ""
+
+    formal_charge = int(molecule.atoms[0].formal_charge)
+
+    if formal_charge != 0:
+
+        charge_symbol = "-" if formal_charge < 0 else "+"
+        formal_charge = abs(formal_charge)
+
+        if formal_charge > 1:
+            charge_symbol = f"{formal_charge}{charge_symbol}"
+
+    residue_name = f"{element_symbol}{charge_symbol}"
+    residue_name = residue_name[:3]
+
+    return residue_name
+
+
+def _create_trajectory(molecule):
+    """Create an `mdtraj` topology from a molecule object.
+
+    Parameters
+    ----------
+    molecule: openforcefield.topology.Molecule
+        The SMILES pattern.
+
+    Returns
+    -------
+    mdtraj.Trajectory
+        The created trajectory.
+    """
+    import mdtraj
+
+    # Check whether the molecule has a configuration defined, and if not,
+    # define one.
+    if molecule.n_conformers <= 0:
+        molecule.generate_conformers(n_conformers=1)
+
+    # We need to save out the molecule and then reload it as the toolkit
+    # will not always save the atoms in the same order that they are
+    # present in the molecule object.
+    with tempfile.NamedTemporaryFile(suffix=".pdb") as file:
+
+        molecule.to_file(file.name, "PDB")
+        # Load the pdb into an mdtraj object.
+        mdtraj_trajectory = mdtraj.load_pdb(file.name)
+
+    # Change the assigned residue name (sometimes molecules are assigned
+    # an amino acid residue name even if that molecule is not an amino acid,
+    # e.g. C(CO)N is not Gly) and save the altered object as a pdb.
+    for residue in mdtraj_trajectory.topology.residues:
+        _generate_residue_name(residue, molecule.to_smiles())
+
+    return mdtraj_trajectory
+
+
+def _build_input_file(
+    molecule_file_names,
+    molecule_counts,
+    structure_to_solvate,
+    box_size,
+    tolerance,
+    output_file_name,
+):
+    """Construct the packmol input file.
+
+    Parameters
+    ----------
+    molecule_file_names: list of str
+        The paths to the molecule pdb files.
+    molecule_counts: list of int
+        The number of each molecule to add.
+    structure_to_solvate: str, optional
+        The path to the structure to solvate.
+    box_size: pint.Quantity
+        The lengths of each box vector.
+    tolerance: pint.Quantity
+        The packmol convergence tolerance.
+    output_file_name:
+        The path to save the packed pdb to.
+
+    Returns
+    -------
+    str
+        The path to the input file.
+    """
+
+    box_size = box_size.to(unit.angstrom).magnitude
+    tolerance = tolerance.to(unit.angstrom).magnitude
+
+    # Add the global header options.
+    input_lines = [
+        f"tolerance {tolerance:f}",
+        f"filetype pdb",
+        f"output {output_file_name}",
+        "",
+    ]
+
+    # Add a section for each type of molecule to add.
+    for file_name, count in zip(molecule_file_names, molecule_counts):
+
+        input_lines.extend(
+            [
+                f"structure {file_name}",
+                f"  number {count}",
+                f"  inside box 0. 0. 0. {box_size[0]} {box_size[1]} {box_size[2]}",
+                f"end structure",
+                "",
+            ]
+        )
+
+    # Add the section of the molecule to solvate if provided.
+    if structure_to_solvate is not None:
+
+        input_lines.extend(
+            [
+                f"structure {structure_to_solvate}",
+                f"  number 1",
+                f"  fixed "
+                f"{box_size[0] / 2.0} "
+                f"{box_size[1 / 2.0]} "
+                f"{box_size[2] / 2.0} 0. 0. 0.",
+                f"  centerofmass",
+                f"end structure",
+                "",
+            ]
+        )
+
+    packmol_input = "\n".join(input_lines)
+
+    # Write packmol input
+    packmol_file_name = "packmol_input.txt"
+
+    with open(packmol_file_name, "w") as file_handle:
+        file_handle.write(packmol_input)
+
+    return packmol_file_name
+
+
+def _correct_packmol_output(
+    file_path, molecule_topologies, number_of_copies, structure_to_solvate
+):
+    """Corrects the PDB file output by packmol, namely be
+    adding full connectivity information.
+
+    Parameters
+    ----------
+    file_path: str
+        The file path to the packmol output file.
+    molecule_topologies: list of mdtraj.Topology
+        A list of topologies for the molecules which packmol has
+        added.
+    number_of_copies: list of int
+        The total number of each molecule which packmol should have
+        created.
+    structure_to_solvate: str, optional
+        The file path to a preexisting structure which packmol
+        has solvated.
+
+    Returns
+    -------
+    mdtraj.Trajectory
+        A trajectory containing the packed system with full connectivity.
+    """
+    import mdtraj
+
+    trajectory = mdtraj.load(file_path)
+
+    all_topologies = [*molecule_topologies]
+    all_copies = [*number_of_copies]
+
+    if structure_to_solvate is not None:
+
+        solvated_trajectory = mdtraj.load(structure_to_solvate)
+
+        all_topologies.append(solvated_trajectory.topology)
+        all_copies.append(1)
+
+    all_bonds = []
+    offset = 0
+
+    for (molecule_topology, count) in zip(all_topologies, all_copies):
+
+        _, molecule_bonds = molecule_topology.to_dataframe()
+
+        for i in range(count):
+
+            for bond in molecule_bonds:
+                all_bonds.append(
+                    [int(bond[0].item()) + offset, int(bond[1].item()) + offset]
+                )
+
+            offset += molecule_topology.n_atoms
+
+    if len(all_bonds) > 0:
+        all_bonds = np.unique(all_bonds, axis=0).tolist()
+
+    # We have to check whether there are any existing bonds, because mdtraj
+    # will sometimes automatically detect some based on residue names (e.g HOH),
+    # and this behaviour cannot be disabled.
+    existing_bonds = []
+
+    for bond in trajectory.topology.bonds:
+        existing_bonds.append(bond)
+
+    for bond in all_bonds:
+
+        atom_a = trajectory.topology.atom(bond[0])
+        atom_b = trajectory.topology.atom(bond[1])
+
+        bond_exists = False
+
+        for existing_bond in existing_bonds:
+
+            if (existing_bond.atom1 == atom_a and existing_bond.atom2 == atom_b) or (
+                existing_bond.atom2 == atom_a and existing_bond.atom1 == atom_b
+            ):
+                bond_exists = True
+                break
+
+        if bond_exists:
+            continue
+
+        trajectory.topology.add_bond(atom_a, atom_b)
+
+    return trajectory
 
 
 def pack_box(
     molecules,
     number_of_copies,
     structure_to_solvate=None,
-    tolerance=2.0,
+    tolerance=2.0 * unit.angstrom,
     box_size=None,
     mass_density=None,
     box_aspect_ratio=None,
@@ -81,17 +553,19 @@ def pack_box(
         equal to the length of `molecules`.
     structure_to_solvate: str, optional
         A file path to the PDB coordinates of the structure to be solvated.
-    tolerance : float
-        The minimum spacing between molecules during packing in angstroms.
+    tolerance : pint.Quantity
+        The minimum spacing between molecules during packing in units
+         compatible with angstroms.
     box_size : pint.Quantity, optional
-        The size of the box to generate in units compatible with angstroms. If `None`,
-        `mass_density` must be provided.
+        The size of the box to generate in units compatible with angstroms.
+        If `None`, `mass_density` must be provided.
     mass_density : pint.Quantity, optional
-        Target mass density for final system with units compatible with g/mL. If `None`,
-        `box_size` must be provided.
+        Target mass density for final system with units compatible with g / mL.
+         If `None`, `box_size` must be provided.
     box_aspect_ratio: list of float, optional
-        The aspect ratio of the simulation box, used in conjunction with the `mass_density`
-        parameter. If none, an isotropic ratio (i.e. [1.0, 1.0, 1.0]) is used.
+        The aspect ratio of the simulation box, used in conjunction with
+        the `mass_density` parameter. If none, an isotropic ratio (i.e.
+        [1.0, 1.0, 1.0]) is used.
     verbose : bool
         If True, verbose output is written.
     working_directory: str, optional
@@ -103,34 +577,42 @@ def pack_box(
 
     Returns
     -------
-    topology : simtk.openmm.Topology
-        Topology of the resulting system
-    positions : pint.Quantity
-        A `pint.Quantity` wrapped `numpy.ndarray` (shape=[natoms,3]) which contains
-        the created positions with units compatible with angstroms.
+    mdtraj.Trajectory
+        The packed box encoded in an mdtraj trajectory.
+
+    Raises
+    ------
+    PackmolRuntimeException
+        When packmol fails to execute / converge.
     """
-
-    if box_size is None and mass_density is None:
-        raise ValueError("Either a `box_size` or `mass_density` must be specified.")
-
-    if box_size is not None and len(box_size) != 3:
-        raise ValueError("`box_size` must be a pint.Quantity wrapped list of length 3")
 
     if mass_density is not None and box_aspect_ratio is None:
         box_aspect_ratio = [1.0, 1.0, 1.0]
 
-    if box_aspect_ratio is not None:
+    # Make sure packmol can be found.
+    packmol_path = _find_packmol()
 
-        assert len(box_aspect_ratio) == 3
-        assert all(x > 0.0 for x in box_aspect_ratio)
+    if packmol_path is None:
+        raise IOError("Packmol not found, cannot run pack_box()")
 
-    # noinspection PyTypeChecker
-    if len(molecules) != len(number_of_copies):
+    # Validate the inputs.
+    _validate_inputs(
+        molecules,
+        number_of_copies,
+        structure_to_solvate,
+        box_aspect_ratio,
+        box_size,
+        mass_density,
+    )
 
-        raise ValueError(
-            "Length of `molecules` and `number_of_copies` must be identical."
+    # Estimate the box_size from mass density if one is not provided.
+    if box_size is None:
+
+        box_size = _approximate_box_size_by_density(
+            molecules, number_of_copies, mass_density, box_aspect_ratio
         )
 
+    # Set up the directory to create the working files in.
     temporary_directory = False
 
     if working_directory is None:
@@ -138,109 +620,50 @@ def pack_box(
         working_directory = tempfile.mkdtemp()
         temporary_directory = True
 
-    elif not os.path.isdir(working_directory):
-        os.mkdir(working_directory)
+    if len(working_directory) > 0:
+        os.makedirs(working_directory, exist_ok=True)
 
-    # Create PDB files for all components.
-    pdb_file_paths = []
-    pdb_file_names = []
-
-    mdtraj_topologies = []
-
-    # Packmol does not like long file paths, so we need to store just file names
-    # and do a temporary cd into the working directory to get around this.
-    for index, molecule in enumerate(molecules):
-
-        tmp_file_name = f"{index}.pdb"
-        tmp_file_path = os.path.join(working_directory, tmp_file_name)
-
-        pdb_file_paths.append(tmp_file_path)
-        pdb_file_names.append(tmp_file_name)
-
-        mdtraj_topologies.append(_create_pdb_and_topology(molecule, tmp_file_path))
-
-    structure_to_solvate_file_name = None
-
+    # Copy the structure to solvate if one is provided.
     if structure_to_solvate is not None:
 
-        if not os.path.isfile(structure_to_solvate):
-            raise ValueError(
-                f"The structure to solvate ({structure_to_solvate}) does not exist."
-            )
-
-        structure_to_solvate_file_name = os.path.basename(structure_to_solvate)
         shutil.copyfile(
-            structure_to_solvate,
-            os.path.join(working_directory, structure_to_solvate_file_name),
+            structure_to_solvate, os.path.join(working_directory, "solvate.pdb"),
         )
 
-    # Run packmol
-    if _PACKMOL_PATH is None:
-        raise IOError("Packmol not found, cannot run pack_box()")
-
-    output_file_name = "packmol_output.pdb"
-    output_file_path = os.path.join(working_directory, output_file_name)
-
-    # Approximate volume to initialize box
-    if box_size is None:
-
-        # Estimate box_size from mass density.
-        initial_box_length = _approximate_volume_by_density(
-            molecules, number_of_copies, mass_density
-        )
-
-        initial_box_length_angstrom = initial_box_length.to(unit.angstrom).magnitude
-
-        aspect_ratio_normalizer = (
-            box_aspect_ratio[0] * box_aspect_ratio[1] * box_aspect_ratio[2]
-        ) ** (1.0 / 3.0)
-
-        box_size = [
-            initial_box_length_angstrom * box_aspect_ratio[0],
-            initial_box_length_angstrom * box_aspect_ratio[1],
-            initial_box_length_angstrom * box_aspect_ratio[2],
-        ] * unit.angstrom
-
-        box_size /= aspect_ratio_normalizer
-
-    unitless_box_angstrom = box_size.to(unit.angstrom).magnitude
-
-    packmol_input = _HEADER_TEMPLATE.format(tolerance, output_file_name)
-
-    for (pdb_file_name, molecule, count) in zip(
-        pdb_file_names, molecules, number_of_copies
-    ):
-
-        packmol_input += _BOX_TEMPLATE.format(
-            pdb_file_name,
-            count,
-            unitless_box_angstrom[0],
-            unitless_box_angstrom[1],
-            unitless_box_angstrom[2],
-        )
-
-    if structure_to_solvate_file_name is not None:
-
-        packmol_input += _SOLVATE_TEMPLATE.format(
-            structure_to_solvate_file_name,
-            unitless_box_angstrom[0] / 2.0,
-            unitless_box_angstrom[1] / 2.0,
-            unitless_box_angstrom[2] / 2.0,
-        )
-
-    # Write packmol input
-    packmol_file_name = "packmol_input.txt"
-    packmol_file_path = os.path.join(working_directory, packmol_file_name)
-
-    with open(packmol_file_path, "w") as file_handle:
-        file_handle.write(packmol_input)
+        structure_to_solvate = "solvate.pdb"
 
     with temporarily_change_directory(working_directory):
 
-        with open(packmol_file_name) as file_handle:
+        # Create PDB files for all of the molecules.
+        pdb_file_names = []
+        mdtraj_topologies = []
+
+        for index, molecule in enumerate(molecules):
+
+            mdtraj_trajectory = _create_trajectory(molecule)
+
+            pdb_file_name = f"{index}.pdb"
+            pdb_file_names.append(pdb_file_name)
+
+            mdtraj_trajectory.save_pdb(pdb_file_name)
+            mdtraj_topologies.append(mdtraj_trajectory.topology)
+
+        # Generate the input file.
+        output_file_name = "packmol_output.pdb"
+
+        input_file_path = _build_input_file(
+            pdb_file_names,
+            number_of_copies,
+            structure_to_solvate,
+            box_size,
+            tolerance,
+            output_file_name,
+        )
+
+        with open(input_file_path) as file_handle:
 
             result = subprocess.check_output(
-                _PACKMOL_PATH, stdin=file_handle, stderr=subprocess.STDOUT
+                packmol_path, stdin=file_handle, stderr=subprocess.STDOUT
             ).decode("utf-8")
 
             if verbose:
@@ -248,353 +671,42 @@ def pack_box(
 
             packmol_succeeded = result.find("Success!") > 0
 
-    if not retain_working_files:
+        if not retain_working_files:
 
-        os.unlink(packmol_file_path)
+            os.unlink(input_file_path)
 
-        for file_path in pdb_file_paths:
-            os.unlink(file_path)
+            for file_path in pdb_file_names:
+                os.unlink(file_path)
 
-    if not packmol_succeeded:
+        if not packmol_succeeded:
 
-        if verbose:
-            logger.info("Packmol failed to converge")
+            if verbose:
+                logger.info("Packmol failed to converge")
 
-        if os.path.isfile(output_file_path):
-            os.unlink(output_file_path)
+            if os.path.isfile(output_file_name):
+                os.unlink(output_file_name)
 
-        if temporary_directory and not retain_working_files:
-            shutil.rmtree(working_directory)
+            if temporary_directory and not retain_working_files:
+                shutil.rmtree(working_directory)
 
-        return None, None
+            raise PackmolRuntimeException(result)
 
-    # Append missing connect statements to the end of the
-    # output file.
-    positions, topology = _correct_packmol_output(
-        output_file_path, mdtraj_topologies, number_of_copies, structure_to_solvate
-    )
-
-    if not retain_working_files:
-
-        os.unlink(output_file_path)
-
-        if temporary_directory:
-            shutil.rmtree(working_directory)
-
-    # Add a 2 angstrom buffer to help alleviate PBC issues.
-    box_vectors = [
-        openmm.Vec3(
-            (box_size[0] + 2.0 * unit.angstrom).to(unit.nanometers).magnitude, 0, 0
-        ),
-        openmm.Vec3(
-            0, (box_size[1] + 2.0 * unit.angstrom).to(unit.nanometers).magnitude, 0
-        ),
-        openmm.Vec3(
-            0, 0, (box_size[2] + 2.0 * unit.angstrom).to(unit.nanometers).magnitude
-        ),
-    ]
-
-    # Set the periodic box vectors.
-    from simtk import unit as simtk_unit
-
-    topology.setPeriodicBoxVectors(box_vectors * simtk_unit.nanometers)
-
-    return topology, positions
-
-
-def _approximate_volume_by_density(
-    molecules,
-    n_copies,
-    mass_density=1.0 * unit.grams / unit.milliliters,
-    box_scaleup_factor=1.1,
-):
-    """Generate an approximate box size based on the number and molecular weight of molecules present, and a target
-    density for the final solvated mixture. If no density is specified, the target density is assumed to be 1 g/ml.
-
-    Parameters
-    ----------
-    molecules : list of OEMol
-        Molecules in the system (with 3D geometries)
-    n_copies : list of int (same length as 'molecules')
-        Number of copies of the molecules.
-    box_scaleup_factor : float, optional, default = 1.1
-        Factor by which the estimated box size is increased
-    mass_density : pint.Quantity, optional
-        The target mass density for final system, if available.
-        It should have units compatible with grams/milliliters.
-
-    Returns
-    -------
-    box_edge : pint.Quantity
-        The size (edge length) of the box to generate in units
-        compatible with angstroms.
-
-    Notes
-    -----
-    By default, boxes are only modestly large. This approach has not been
-    extensively tested for stability but has been used in the Mobley lab
-    for perhaps ~100 different systems without substantial problems.
-    """
-
-    # Load molecules to get molecular weights
-    volume = 0.0 * unit.angstrom ** 3
-
-    for (molecule, number) in zip(molecules, n_copies):
-
-        molecule_mass = reduce(
-            (lambda x, y: x + y), [atom.mass for atom in molecule.atoms]
-        )
-        molecule_mass = openmm_quantity_to_pint(molecule_mass) / unit.avogadro_constant
-
-        molecule_volume = molecule_mass / mass_density
-
-        volume += molecule_volume * number
-
-    box_edge = volume ** (1.0 / 3.0) * box_scaleup_factor
-    return box_edge
-
-
-def _correct_packmol_output(
-    file_path, molecule_topologies, number_of_copies, structure_to_solvate
-):
-    """Corrects the PDB file output by packmol (i.e adds full connectivity
-    information, and extracts the topology and positions.
-
-    Parameters
-    ----------
-    file_path: str
-        The file path to the packmol output file.
-    molecule_topologies: list of mdtraj.Topology
-        A list of topologies for the molecules which packmol has
-        added.
-    number_of_copies: list of int
-        The total number of each molecule which packmol should have
-        created.
-    structure_to_solvate: str
-        The file path to a preexisting structure which packmol
-        has solvated.
-
-    Returns
-    -------
-    list
-        The positions determined by packmol.
-    simtk.openmm.app.Topology
-        The topology of the created system with full connectivity.
-    """
-
-    import mdtraj
-    from simtk import unit as simtk_unit
-
-    trajectory = mdtraj.load(file_path)
-
-    atoms_data_frame, _ = trajectory.topology.to_dataframe()
-
-    all_bonds = []
-    all_positions = (
-        trajectory.openmm_positions(0).value_in_unit(simtk_unit.angstrom)
-        * unit.angstrom
-    )
-
-    all_topologies = []
-    all_copies = []
-
-    all_topologies.extend(molecule_topologies)
-    all_copies.extend(number_of_copies)
-
-    if structure_to_solvate is not None:
-
-        solvated_trajectory = mdtraj.load(structure_to_solvate)
-
-        all_topologies.append(solvated_trajectory.topology)
-        all_copies.append(1)
-
-    offset = 0
-
-    for (molecule_topology, count) in zip(all_topologies, all_copies):
-
-        _, molecule_bonds = molecule_topology.to_dataframe()
-
-        for i in range(count):
-
-            for bond in molecule_bonds:
-
-                all_bonds.append(
-                    [int(bond[0].item()) + offset, int(bond[1].item()) + offset]
-                )
-
-            offset += molecule_topology.n_atoms
-
-    if len(all_bonds) > 0:
-        all_bonds = np.unique(all_bonds, axis=0).tolist()
-
-    # We have to check whether there are any existing bonds, because mdtraj will
-    # sometimes automatically detect some based on residue names (e.g HOH), and
-    # this behaviour cannot be disabled.
-    existing_bonds = []
-
-    for bond in trajectory.topology.bonds:
-        existing_bonds.append(bond)
-
-    for bond in all_bonds:
-
-        atom_a = trajectory.topology.atom(bond[0])
-        atom_b = trajectory.topology.atom(bond[1])
-
-        bond_exists = False
-
-        for existing_bond in existing_bonds:
-
-            if (existing_bond.atom1 == atom_a and existing_bond.atom2 == atom_b) or (
-                existing_bond.atom2 == atom_a and existing_bond.atom1 == atom_b
-            ):
-
-                bond_exists = True
-                break
-
-        if bond_exists:
-            continue
-
-        trajectory.topology.add_bond(atom_a, atom_b)
-
-    return all_positions, trajectory.topology.to_openmm()
-
-
-def _create_pdb_and_topology(molecule, file_path):
-    """Creates a uniform PDB file and `mdtraj.Topology` from an
-    openeye molecule.
-    Parameters
-    ----------
-    molecule: openforcefield.topology.Molecule
-        The component to create the PDB and topology for.
-    file_path: str
-        The path pointing to where the PDB file should be created.
-    Returns
-    -------
-    mdtraj.Topology
-        The topology of the created PDB file.
-    """
-    import mdtraj
-    from mdtraj.core import residue_names
-    from openforcefield.topology import Topology
-    from simtk.openmm.app import PDBFile
-
-    # Check whether the molecule has a configuration defined, and if not,
-    # define one.
-    if molecule.n_conformers <= 0:
-        molecule.generate_conformers(n_conformers=1)
-
-    # Create a temporary pdb file then reload it using mdtraj. This is a
-    # necessary workaround as sometimes the PDB saved by the toolkit will
-    # have a different atom ordering to the original molecule object.
-    topology = Topology.from_molecules([molecule])
-
-    with tempfile.NamedTemporaryFile(mode="r+", suffix=".pdb") as pdb_file:
-
-        PDBFile.writeFile(topology.to_openmm(), molecule.conformers[0], pdb_file)
-        pdb_file.flush()
-        mdtraj_molecule = mdtraj.load_pdb(pdb_file.name)
-
-    # Change the assigned residue name (sometimes molecules are assigned
-    # an amino acid residue name even if that molecule is not an amino acid,
-    # e.g. C(CO)N is not Gly) and save the altered object as a pdb.
-    smiles = molecule.to_smiles()
-
-    # Choose a random residue name.
-    residue_map = {}
-
-    for residue in mdtraj_molecule.topology.residues:
-
-        residue_map[residue.name] = None
-
-        if smiles == "[H]O[H]":
-
-            residue_map[residue.name] = "HOH"
-
-            # Re-assign the water atom names. These need to be set to get
-            # correct CONECT statements.
-            h_counter = 1
-
-            for atom in residue.atoms:
-
-                if atom.element.symbol == "O":
-                    atom.name = "O1"
-                else:
-                    atom.name = f"H{h_counter}"
-                    h_counter += 1
-
-        elif smiles == "[Cl-]":
-
-            residue_map[residue.name] = "Cl-"
-
-            for atom in residue.atoms:
-                atom.name = "Cl-"
-
-        elif smiles == "[Na+]":
-
-            residue_map[residue.name] = "Na+"
-
-            for atom in residue.atoms:
-                atom.name = "Na+"
-
-        else:
-
-            # Assign unique atom names as the OpenFF toolkit does not.
-            element_counter = defaultdict(int)
-
-            for atom in residue.atoms:
-
-                atom.name = (
-                    f"{atom.element.symbol}{element_counter[atom.element.symbol] + 1}"
-                )
-                element_counter[atom.element.symbol] += 1
-
-    for original_residue_name in residue_map:
-
-        if residue_map[original_residue_name] is not None:
-            continue
-
-        # Make sure the residue name is not already reserved as this can
-        # occasionally result in bonds being automatically added in the wrong
-        # places when loading the pdb file either through mdtraj or openmm
-
-        # noinspection PyProtectedMember
-        forbidden_residue_names = [
-            *residue_names._AMINO_ACID_CODES,
-            *residue_names._SOLVENT_TYPES,
-            *residue_names._WATER_RESIDUES,
-            "ADE",
-            "CYT",
-            "CYX",
-            "DAD",
-            "DGU",
-            "FOR",
-            "GUA",
-            "HID",
-            "HIE",
-            "HIH",
-            "HSD",
-            "HSH",
-            "HSP",
-            "NMA",
-            "THY",
-            "URA",
+        # Add a 2 angstrom buffer to help alleviate PBC issues.
+        box_size = [
+            (x + 2.0 * unit.angstrom).to(unit.nanometer).magnitude for x in box_size
         ]
 
-        new_residue_name = "".join(
-            [random.choice(string.ascii_uppercase) for _ in range(3)]
+        # Append missing connect statements to the end of the
+        # output file.
+        trajectory = _correct_packmol_output(
+            output_file_name, mdtraj_topologies, number_of_copies, structure_to_solvate
         )
+        trajectory.unitcell_lengths = box_size
 
-        while new_residue_name in forbidden_residue_names:
-            # Re-choose the residue name until we find a safe one.
-            new_residue_name = "".join(
-                [random.choice(string.ascii_uppercase) for _ in range(3)]
-            )
+        if not retain_working_files:
+            os.unlink(output_file_name)
 
-        residue_map[original_residue_name] = new_residue_name
+    if temporary_directory and not retain_working_files:
+        shutil.rmtree(working_directory)
 
-    for residue in mdtraj_molecule.topology.residues:
-        residue.name = residue_map[residue.name]
-
-    # Create the final pdb file.
-    mdtraj_molecule.save_pdb(file_path)
-    return mdtraj_molecule.topology
+    return trajectory


### PR DESCRIPTION
## Description
This PR constitutes a significant refactoring of the `packmol` utility:

- It introduces much better support for residue name generation, no supporting amino acid residue names, and monatomic (ion) residue names.
- Completely removes the dependence on OpenMM.
- Splits up monolithic methods into more logical, smaller functions.
- Adds a custom exception for `packmol` execution failures.
- Exposes the option of whether to center the structure to solvate or leave it in its original position.

This should in general make the utility much easier to maintain, debug, and use in a wider range of situations.

In addition, the residue names which have been assigned to each component in the system is now exposed by the `BuildCoordinatesPackmol` protocol.

## Status
- [x] Ready to go