### PR TITLE
Ensure Protocol Directory Path is Valid

### DIFF
--- a/evaluator/workflow/protocols.py
+++ b/evaluator/workflow/protocols.py
@@ -1061,7 +1061,11 @@ class ProtocolGraph:
             for dependency in dependencies[protocol_id]:
                 parent_outputs.append(protocol_outputs[dependency])
 
-            directory = os.path.join(root_directory, protocol_id)
+            directory_name = protocol_id.replace("|", "_")
+            directory_name = directory_name.replace(":", "_")
+            directory_name = directory_name.replace(";", "_")
+
+            directory = os.path.join(root_directory, directory_name)
 
             if calculation_backend is not None:
 


### PR DESCRIPTION
## Description
This PR fixes a bug whereby in some cases forbidden file name characters (e.g |, :, ; depending on the OS) were included in file paths.

## Status
- [X] Ready to go