### PR TITLE
Decrease Gas Phase Coordinate Mass Density

### DIFF
--- a/evaluator/properties/enthalpy.py
+++ b/evaluator/properties/enthalpy.py
@@ -884,6 +884,9 @@ class EnthalpyOfVaporization(PhysicalProperty):
 
         # Create only a single molecule in vacuum
         gas_protocols.build_coordinates.max_molecules = 1
+        gas_protocols.build_coordinates.mass_density = (
+            0.01 * unit.gram / unit.milliliter
+        )
         gas_output_to_store.property_phase = PropertyPhase.Gas
 
         # Run the gas phase simulations in the NVT ensemble


### PR DESCRIPTION
## Description
This PR fixes a bug when attempting to compute the enthalpy of vaporization of larger molecules. The box size provided to packmol when generating the gas phase coordinates of longer chain molecules was too small leading to a runtime error.

Here the mass density is reduced to avoid this from happing. This will only affect the coordinate building, as the gas phase simulations are performed with PBC disabled.

## Status
- [X] Ready to go