### PR TITLE
Make Data Set Validation User Driven

### DIFF
--- a/evaluator/datasets/datasets.py
+++ b/evaluator/datasets/datasets.py
@@ -562,6 +562,13 @@ class PhysicalPropertyDataSet(TypedBaseModel):
 
         self.filter_by_function(filter_function)
 
+    def validate(self):
+        """Checks to ensure that all properties within
+        the set are valid physical property object.
+        """
+        for physical_property in self._properties:
+            physical_property.validate()
+
     def to_pandas(self):
         """Converts a `PhysicalPropertyDataSet` to a `pandas.DataFrame` object
         with columns of

--- a/evaluator/datasets/datasets.py
+++ b/evaluator/datasets/datasets.py
@@ -248,26 +248,31 @@ class PhysicalPropertyDataSet(TypedBaseModel):
         gathered."""
         return set([x.source for x in self._properties])
 
-    def merge(self, data_set):
+    def merge(self, data_set, validate=True):
         """Merge another data set into the current one.
 
         Parameters
         ----------
         data_set : PhysicalPropertyDataSet
             The secondary data set to merge into this one.
+        validate: bool
+            Whether to validate the other data set before merging.
         """
         if data_set is None:
             return
 
-        self.add_properties(*data_set)
+        self.add_properties(*data_set, validate=validate)
 
-    def add_properties(self, *physical_properties):
+    def add_properties(self, *physical_properties, validate=True):
         """Adds a physical property to the data set.
 
         Parameters
         ----------
         physical_properties: PhysicalProperty
             The physical property to add.
+        validate: bool
+            Whether to validate the properties before adding them
+            to the set.
         """
 
         all_ids = set(x.id for x in self)
@@ -275,7 +280,8 @@ class PhysicalPropertyDataSet(TypedBaseModel):
         # TODO: Do we need to check for adding the same property twice?
         for physical_property in physical_properties:
 
-            physical_property.validate()
+            if validate:
+                physical_property.validate()
 
             if physical_property.id in all_ids:
 
@@ -735,9 +741,6 @@ class PhysicalPropertyDataSet(TypedBaseModel):
         self._properties = state["properties"]
 
         assert all(isinstance(x, PhysicalProperty) for x in self)
-
-        for physical_property in self:
-            physical_property.validate()
 
         # Ensure each property has a unique id.
         all_ids = set(x.id for x in self)

--- a/evaluator/tests/test_datasets/test_datasets.py
+++ b/evaluator/tests/test_datasets/test_datasets.py
@@ -3,6 +3,8 @@ Units tests for evaluator.datasets
 """
 import json
 
+import pytest
+
 from evaluator import unit
 from evaluator.datasets import CalculationSource, PhysicalPropertyDataSet, PropertyPhase
 from evaluator.properties import (
@@ -345,3 +347,35 @@ def test_phase_from_string():
     ]
 
     assert all(x == PropertyPhase.from_string(str(x)) for x in phase_enums)
+
+
+def test_validate_data_set():
+
+    valid_property = Density(
+        ThermodynamicState(298 * unit.kelvin, 1 * unit.atmosphere),
+        PropertyPhase.Liquid,
+        Substance.from_components("O"),
+        0.0 * unit.gram / unit.milliliter,
+        0.0 * unit.gram / unit.milliliter
+    )
+
+    data_set = PhysicalPropertyDataSet()
+    data_set.add_properties(valid_property)
+
+    data_set.validate()
+
+    invalid_property = Density(
+        ThermodynamicState(-1 * unit.kelvin, 1 * unit.atmosphere),
+        PropertyPhase.Liquid,
+        Substance.from_components("O"),
+        0.0 * unit.gram / unit.milliliter,
+        0.0 * unit.gram / unit.milliliter
+    )
+
+    with pytest.raises(AssertionError):
+        data_set.add_properties(invalid_property)
+
+    data_set.add_properties(invalid_property, validate=False)
+
+    with pytest.raises(AssertionError):
+        data_set.validate()

--- a/evaluator/tests/test_datasets/test_datasets.py
+++ b/evaluator/tests/test_datasets/test_datasets.py
@@ -356,7 +356,7 @@ def test_validate_data_set():
         PropertyPhase.Liquid,
         Substance.from_components("O"),
         0.0 * unit.gram / unit.milliliter,
-        0.0 * unit.gram / unit.milliliter
+        0.0 * unit.gram / unit.milliliter,
     )
 
     data_set = PhysicalPropertyDataSet()
@@ -369,7 +369,7 @@ def test_validate_data_set():
         PropertyPhase.Liquid,
         Substance.from_components("O"),
         0.0 * unit.gram / unit.milliliter,
-        0.0 * unit.gram / unit.milliliter
+        0.0 * unit.gram / unit.milliliter,
     )
 
     with pytest.raises(AssertionError):


### PR DESCRIPTION
## Description
This PR removes the property validation from the `PhysicalPropertyDataSet` set state method and makes the property validation optional when adding / merging new properties.

The validation is currently slow on larger data sets (especially estimated data sets with a lot of provenance) and is sometimes called redundantly when properties / sets have already been validated. 

Note the user can still manually validate the data set with a call to `validate` where needed, and data sets are still automatically validated on user estimation requests.

## Status
- [X] Ready to go