### PR TITLE
[WIP] Move Schema Provenance to Request Results

### DIFF
--- a/evaluator/client/client.py
+++ b/evaluator/client/client.py
@@ -285,7 +285,7 @@ class RequestResult(AttributeClass):
     )
 
     request_options = Attribute(
-        docstring="The "
+        docstring="The options used to make the request.", type_hint=RequestOptions,
     )
 
     def validate(self, attribute_type=None):

--- a/evaluator/client/client.py
+++ b/evaluator/client/client.py
@@ -284,6 +284,10 @@ class RequestResult(AttributeClass):
         default_value=[],
     )
 
+    request_options = Attribute(
+        docstring="The "
+    )
+
     def validate(self, attribute_type=None):
         super(RequestResult, self).validate(attribute_type)
         assert all((isinstance(x, EvaluatorException) for x in self.exceptions))

--- a/evaluator/datasets/provenance.py
+++ b/evaluator/datasets/provenance.py
@@ -3,7 +3,7 @@ of measured / estimated properties.
 """
 import abc
 
-from evaluator.attributes import AttributeClass, Attribute, UNDEFINED
+from evaluator.attributes import UNDEFINED, Attribute, AttributeClass
 
 
 class Source(AttributeClass, abc.ABC):
@@ -11,6 +11,7 @@ class Source(AttributeClass, abc.ABC):
     property was measured experimentally / estimated for simulation
     data.
     """
+
     pass
 
 
@@ -34,14 +35,14 @@ class MeasurementSource(Source):
         "measurement was obtained.",
         type_hint=str,
         default_value=UNDEFINED,
-        optional=True
+        optional=True,
     )
     reference = Attribute(
         docstring="An alternative identifier of the source from which this "
         "measurement was obtained, e.g. a URL.",
         type_hint=str,
         default_value=UNDEFINED,
-        optional=True
+        optional=True,
     )
 
     def __init__(self, doi=None, reference=None):

--- a/evaluator/server/server.py
+++ b/evaluator/server/server.py
@@ -177,6 +177,7 @@ class EvaluatorServer:
         self._finished_batches = {}
 
         self._batch_ids_per_client_id = {}
+        self._request_options_per_client_id = {}
 
     def _query_request_status(self, client_request_id):
         """Queries the the current state of an estimation request
@@ -197,6 +198,11 @@ class EvaluatorServer:
         """
 
         request_results = RequestResult()
+
+        # Set the request options as provenance.
+        request_results.request_options = self._request_options_per_client_id[
+            client_request_id
+        ]
 
         for batch_id in self._batch_ids_per_client_id[client_request_id]:
 
@@ -527,6 +533,9 @@ class EvaluatorServer:
                 request_id = str(uuid.uuid4()).replace("-", "")
 
             self._batch_ids_per_client_id[request_id] = []
+            self._request_options_per_client_id[request_id] = copy.deepcopy(
+                submission.options
+            )
 
         # Pass the id of the submitted requests back to the client
         # as well as any error which may have occurred.

--- a/evaluator/tests/test_datasets/test_datasets.py
+++ b/evaluator/tests/test_datasets/test_datasets.py
@@ -61,7 +61,7 @@ def test_serialization():
 def test_to_pandas():
     """A test to ensure that data sets are convertable to pandas objects."""
 
-    source = CalculationSource("Dummy", {})
+    source = CalculationSource("request_id", "ff_id", "Dummy")
 
     pure_substance = Substance.from_components("C")
     binary_substance = Substance.from_components("C", "O")

--- a/evaluator/tests/utils.py
+++ b/evaluator/tests/utils.py
@@ -71,7 +71,7 @@ def create_dummy_property(property_class):
         uncertainty=1.0 * property_class.default_unit(),
     )
 
-    dummy_property.source = CalculationSource(fidelity="dummy", provenance={})
+    dummy_property.source = CalculationSource("request_id", "ff_id", "Dummy")
 
     # Make sure the property has the meta data required for more
     # involved properties.
@@ -162,7 +162,7 @@ def create_filterable_data_set():
         The created data set.
     """
 
-    source = CalculationSource("Dummy", {})
+    source = CalculationSource("request_id", "ff_id", "Dummy")
     carbon_substance = create_dummy_substance(number_of_components=1, elements=["C"])
 
     density_property = Density(


### PR DESCRIPTION
## Description
This PR moves workflow schema provenance into the `RequestResult` object, rather than in individual property sources.

## Status
- [ ] Ready to go