### PR TITLE
Fix bug when solvating structures and print simulation speed

### DIFF
--- a/evaluator/protocols/coordinates.py
+++ b/evaluator/protocols/coordinates.py
@@ -281,6 +281,7 @@ class SolvateExistingStructure(BuildCoordinatesPackmol):
             structure_to_solvate=self.solute_coordinate_file,
             center_solute=self.center_solute_in_box,
             mass_density=self.mass_density,
+            box_aspect_ratio=self.box_aspect_ratio,
             verbose=self.verbose_packmol,
             working_directory=packmol_directory,
             retain_working_files=self.retain_packmol_files,

--- a/evaluator/protocols/openmm.py
+++ b/evaluator/protocols/openmm.py
@@ -540,7 +540,7 @@ class OpenMMSimulation(BaseSimulation):
         return checkpoint.current_step_number
 
     def _save_final_statistics(self, path, temperature, pressure):
-        """Converts the openmm statistic csv file into a evaluator
+        """Converts the openmm statistic csv file into an evaluator
         StatisticsArray csv file, making sure to fill in any missing entries.
 
         Parameters
@@ -616,6 +616,7 @@ class OpenMMSimulation(BaseSimulation):
             temperature=True,
             volume=True,
             density=True,
+            speed=True
         )
 
         # Create the object which will transfer simulation output to the

--- a/evaluator/protocols/openmm.py
+++ b/evaluator/protocols/openmm.py
@@ -616,7 +616,7 @@ class OpenMMSimulation(BaseSimulation):
             temperature=True,
             volume=True,
             density=True,
-            speed=True
+            speed=True,
         )
 
         # Create the object which will transfer simulation output to the

--- a/evaluator/utils/packmol.py
+++ b/evaluator/utils/packmol.py
@@ -541,7 +541,7 @@ def pack_box(
     number_of_copies,
     structure_to_solvate=None,
     center_solute=True,
-    tolerance=2.0 * unit.angstrom,
+    tolerance=2.4 * unit.angstrom,
     box_size=None,
     mass_density=None,
     box_aspect_ratio=None,

--- a/evaluator/utils/packmol.py
+++ b/evaluator/utils/packmol.py
@@ -541,7 +541,7 @@ def pack_box(
     number_of_copies,
     structure_to_solvate=None,
     center_solute=True,
-    tolerance=2.4 * unit.angstrom,
+    tolerance=2.0 * unit.angstrom,
     box_size=None,
     mass_density=None,
     box_aspect_ratio=None,


### PR DESCRIPTION
## Description
* Fixed bug when creating systems with packmol through the `SolvateExistingStructure` class. The box aspect ratio was not set properly. [Problematic for HG systems, the solvate function creates a cubic box for the attach-pull calculations instead of a rectangular box]
* ~Increased the default tolerance for packmol to 2.4 angstrom up from 2.0 angstrom. [Sometimes simulations for HG systems with the default tolerance crashes after minimization even with a 1 fs timestep. Increasing the tolerance to 2.4 angstroms seems to alleviate this issue.]~
* The simulation speed will now be printed in `openmm_statistics.csv`. [benchmarking purposes]

