### PR TITLE
Allow Filtering by Multiple Roles

### DIFF
--- a/evaluator/properties/binding.py
+++ b/evaluator/properties/binding.py
@@ -51,7 +51,7 @@ class HostGuestBindingAffinity(PhysicalProperty):
         filter_ligand = miscellaneous.FilterSubstanceByRole("filter_ligand")
         filter_ligand.input_substance = ProtocolPath("substance", "global")
 
-        filter_ligand.component_role = Component.Role.Ligand
+        filter_ligand.component_roles = [Component.Role.Ligand]
         # We only support substances with a single guest ligand.
         filter_ligand.expected_components = 1
 
@@ -62,7 +62,7 @@ class HostGuestBindingAffinity(PhysicalProperty):
         filter_receptor = miscellaneous.FilterSubstanceByRole("filter_receptor")
         filter_receptor.input_substance = ProtocolPath("substance", "global")
 
-        filter_receptor.component_role = Component.Role.Receptor
+        filter_receptor.component_roles = [Component.Role.Receptor]
         # We only support substances with a single host receptor.
         filter_receptor.expected_components = 1
 
@@ -83,7 +83,7 @@ class HostGuestBindingAffinity(PhysicalProperty):
         # Solvate the docked structure using packmol
         filter_solvent = miscellaneous.FilterSubstanceByRole("filter_solvent")
         filter_solvent.input_substance = ProtocolPath("substance", "global")
-        filter_solvent.component_role = Component.Role.Solvent
+        filter_solvent.component_roles = [Component.Role.Solvent]
 
         schema.protocols[filter_solvent.id] = filter_solvent.schema
 

--- a/evaluator/properties/solvation.py
+++ b/evaluator/properties/solvation.py
@@ -107,11 +107,11 @@ class SolvationFreeEnergy(PhysicalProperty):
         # vacuum phase simulations).
         filter_solvent = miscellaneous.FilterSubstanceByRole("filter_solvent")
         filter_solvent.input_substance = ProtocolPath("substance", "global")
-        filter_solvent.component_role = Component.Role.Solvent
+        filter_solvent.component_roles = [Component.Role.Solvent]
 
         filter_solute = miscellaneous.FilterSubstanceByRole("filter_solute")
         filter_solute.input_substance = ProtocolPath("substance", "global")
-        filter_solute.component_role = Component.Role.Solute
+        filter_solute.component_roles = [Component.Role.Solute]
 
         # Setup the solute in vacuum system.
         build_vacuum_coordinates = coordinates.BuildCoordinatesPackmol(

--- a/evaluator/protocols/miscellaneous.py
+++ b/evaluator/protocols/miscellaneous.py
@@ -224,9 +224,9 @@ class FilterSubstanceByRole(Protocol):
         default_value=UNDEFINED,
     )
 
-    component_role = InputAttribute(
-        docstring="The role to filter substance components against.",
-        type_hint=Component.Role,
+    component_roles = InputAttribute(
+        docstring="The roles to filter substance components against.",
+        type_hint=list,
         default_value=UNDEFINED,
     )
 
@@ -249,7 +249,7 @@ class FilterSubstanceByRole(Protocol):
 
         for component in self.input_substance.components:
 
-            if component.role != self.component_role:
+            if component.role not in self.component_roles:
                 continue
 
             filtered_components.append(component)
@@ -288,3 +288,8 @@ class FilterSubstanceByRole(Protocol):
                     amount = MoleFraction(amount.value * inverse_mole_fraction)
 
                 self.filtered_substance.add_component(component, amount)
+
+    def validate(self, attribute_type=None):
+
+        super(FilterSubstanceByRole, self).validate(attribute_type)
+        assert all(isinstance(x, Component.Role) for x in self.component_roles)

--- a/evaluator/tests/test_protocols/test_miscellaneous.py
+++ b/evaluator/tests/test_protocols/test_miscellaneous.py
@@ -198,7 +198,7 @@ def test_substance_filtering_protocol(filter_role):
     filter_protocol = FilterSubstanceByRole("filter_protocol")
     filter_protocol.input_substance = create_substance()
 
-    filter_protocol.component_role = filter_role
+    filter_protocol.component_roles = [filter_role]
     filter_protocol.execute("", ComputeResources())
 
     assert len(filter_protocol.filtered_substance.components) == 1


### PR DESCRIPTION
## Description
This PR expands the `FilterSubstanceByRole` to be able to filter by multiple roles at once.

## Status
- [X] Ready to go