### PR TITLE
Ensure Dask Worker Header is Only Printed Once

### DIFF
--- a/evaluator/backends/dask.py
+++ b/evaluator/backends/dask.py
@@ -86,16 +86,21 @@ class _Multiprocessor:
                     worker_logger.setLevel(logging.INFO)
                     worker_logger.addHandler(logger_handler)
 
-                    worker_logger.info(f"============================================")
-                    worker_logger.info(f"HOSTNAME: {platform.node()}")
-                    worker_logger.info(f"PLATFORM: {platform.platform()}")
-                    worker_logger.info(f"--------------------------------------------")
-                    worker_logger.info(
-                        f"PYTHON VERSION: "
-                        f"{platform.python_version()} - "
-                        f"{platform.python_implementation()}"
-                    )
-                    worker_logger.info(f"============================================")
+                    if (
+                        not os.path.exists(logger_path)
+                        or os.stat(logger_path).st_size == 0
+                    ):
+
+                        worker_logger.info(f"=========================================")
+                        worker_logger.info(f"HOSTNAME: {platform.node()}")
+                        worker_logger.info(f"PLATFORM: {platform.platform()}")
+                        worker_logger.info(f"-----------------------------------------")
+                        worker_logger.info(
+                            f"PYTHON VERSION: "
+                            f"{platform.python_version()} - "
+                            f"{platform.python_implementation()}"
+                        )
+                        worker_logger.info(f"=========================================")
 
             return_value = func(*args, **kwargs)
             queue.put(return_value)
@@ -454,7 +459,8 @@ class BaseDaskJobQueueBackend(BaseDaskBackend):
             )
 
             logger.info(
-                f"Launching a job with access to GPUs {available_resources._gpu_device_indices}"
+                f"Launching a job with access to GPUs "
+                f"{available_resources._gpu_device_indices}"
             )
 
         return_value = _Multiprocessor.run(function, *args, **kwargs)


### PR DESCRIPTION
## Description
This PR fixes a bug introduced in #227 where information about the worker runtime is printed once per task, rather than once at the top of the log.

## Status
- [X] Ready to go