### PR TITLE
Check for Workflow Output Exception

### DIFF
--- a/evaluator/workflow/protocols.py
+++ b/evaluator/workflow/protocols.py
@@ -1150,10 +1150,12 @@ class ProtocolGraph:
                 with open(output_path) as file:
                     outputs = json.load(file, cls=TypedJSONDecoder)
 
-                for protocol_path, output in outputs.items():
+                if not isinstance(outputs, WorkflowException):
 
-                    protocol_path = ProtocolPath.from_string(protocol_path)
-                    protocol.set_value(protocol_path, output)
+                    for protocol_path, output in outputs.items():
+
+                        protocol_path = ProtocolPath.from_string(protocol_path)
+                        protocol.set_value(protocol_path, output)
 
                 return protocol.id, output_path
 


### PR DESCRIPTION
## Description
This PR fixes a bug introduced in #225 where no check was done to ensure that none of the executed protocols raised an exception before restoring outputs.

## Status
- [X] Ready to go