### PR TITLE
Extract DOI from ThermoML Archives if Available

### DIFF
--- a/openff/evaluator/datasets/thermoml/thermoml.py
+++ b/openff/evaluator/datasets/thermoml/thermoml.py
@@ -2210,15 +2210,15 @@ class ThermoMLDataSet(PhysicalPropertyDataSet):
         return return_value
 
     @classmethod
-    def from_xml(cls, xml, source):
+    def from_xml(cls, xml, default_source):
         """Load a ThermoML data set from an xml object.
 
         Parameters
         ----------
         xml: str
             The xml string to parse.
-        source: Source
-            The source of the xml object.
+        default_source: Source
+            The source to use if one cannot be parsed from the archive itself.
 
         Returns
         -------
@@ -2240,6 +2240,14 @@ class ThermoMLDataSet(PhysicalPropertyDataSet):
         # Extract the namespace that will prefix all type names
         namespace_string = re.search(r"{.*\}", root_node.tag).group(0)[1:-1]
         namespace = {"ThermoML": namespace_string}
+
+        # Attempt to find a DOI for this archive
+        doi_node = root_node.find("ThermoML:Citation/ThermoML:sDOI", namespace)
+
+        if doi_node is not None:
+            source = MeasurementSource(doi=doi_node.text)
+        else:
+            source = default_source
 
         return_value = ThermoMLDataSet()
         compounds = {}

--- a/openff/evaluator/tests/test_datasets/test_thermoml.py
+++ b/openff/evaluator/tests/test_datasets/test_thermoml.py
@@ -5,6 +5,7 @@ import pint
 import pytest
 
 from openff.evaluator import unit
+from openff.evaluator.attributes import UNDEFINED
 from openff.evaluator.datasets import PhysicalProperty, PropertyPhase
 from openff.evaluator.datasets.thermoml import thermoml_property
 from openff.evaluator.datasets.thermoml.thermoml import (
@@ -12,6 +13,7 @@ from openff.evaluator.datasets.thermoml.thermoml import (
     _unit_from_thermoml_string,
 )
 from openff.evaluator.plugins import register_default_plugins
+from openff.evaluator.properties import EnthalpyOfMixing
 from openff.evaluator.utils import get_data_filename
 
 register_default_plugins()
@@ -106,6 +108,18 @@ def test_thermoml_from_files():
 
     assert data_set is not None
     assert len(data_set) == 3
+
+    # Make sure the DOI was found from the enthalpy file
+    for physical_property in data_set:
+
+        if isinstance(physical_property, EnthalpyOfMixing):
+
+            assert physical_property.source.doi != UNDEFINED
+            assert physical_property.source.doi == "10.1016/j.jct.2008.12.004"
+
+        else:
+            assert physical_property.source.doi == ''
+            assert physical_property.source.reference != UNDEFINED
 
     data_set = ThermoMLDataSet.from_file("dummy_filename")
     assert data_set is None

--- a/openff/evaluator/tests/test_datasets/test_thermoml.py
+++ b/openff/evaluator/tests/test_datasets/test_thermoml.py
@@ -118,7 +118,7 @@ def test_thermoml_from_files():
             assert physical_property.source.doi == "10.1016/j.jct.2008.12.004"
 
         else:
-            assert physical_property.source.doi == ''
+            assert physical_property.source.doi == ""
             assert physical_property.source.reference != UNDEFINED
 
     data_set = ThermoMLDataSet.from_file("dummy_filename")


### PR DESCRIPTION
## Description
This PR expands the ThermoML parsing code to extract the archives DOI if it is available and use this as a source. Otherwise, it will use the file path / url as a fallback.

## Status
- [X] Ready to go