### PR TITLE
Include the Unique ID of Properties in Exported Pandas Data Frames

### DIFF
--- a/openff/evaluator/datasets/datasets.py
+++ b/openff/evaluator/datasets/datasets.py
@@ -712,6 +712,7 @@ class PhysicalPropertyDataSet(TypedBaseModel):
             return None
 
         data_columns = [
+            "Id",
             "Temperature (K)",
             "Pressure (kPa)",
             "Phase",

--- a/openff/evaluator/datasets/datasets.py
+++ b/openff/evaluator/datasets/datasets.py
@@ -573,6 +573,7 @@ class PhysicalPropertyDataSet(TypedBaseModel):
         """Converts a `PhysicalPropertyDataSet` to a `pandas.DataFrame` object
         with columns of
 
+            - 'Id'
             - 'Temperature (K)'
             - 'Pressure (kPa)'
             - 'Phase'
@@ -677,6 +678,7 @@ class PhysicalPropertyDataSet(TypedBaseModel):
 
             # Create the data row.
             data_row = {
+                "Id": physical_property.id,
                 "Temperature (K)": temperature,
                 "Pressure (kPa)": pressure,
                 "Phase": phase,

--- a/openff/evaluator/tests/test_datasets/test_datasets.py
+++ b/openff/evaluator/tests/test_datasets/test_datasets.py
@@ -132,6 +132,7 @@ def test_to_pandas():
     data_set_pandas = data_set.to_pandas()
 
     required_columns = [
+        "Id",
         "Temperature (K)",
         "Pressure (kPa)",
         "Phase",

--- a/openff/evaluator/tests/test_datasets/test_datasets.py
+++ b/openff/evaluator/tests/test_datasets/test_datasets.py
@@ -151,10 +151,10 @@ def test_to_pandas():
     assert all(x in data_set_pandas for x in required_columns)
 
     assert data_set_pandas is not None
-    assert data_set_pandas.shape == (12, 21)
+    assert data_set_pandas.shape == (12, 22)
 
     data_set_without_na = data_set_pandas.dropna(axis=1, how="all")
-    assert data_set_without_na.shape == (12, 19)
+    assert data_set_without_na.shape == (12, 20)
 
 
 def test_sources_substances():


### PR DESCRIPTION
## Description
This PR ensures that the unique id of a physical property is included when converting a data set object to a pandas data frame.

## Status
- [x] Ready to go