### PR TITLE
Wrap Antechamber Charge Lines

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -16,12 +16,13 @@ A patch release offering minor bug fixes and quality of life improvements.
 Bugfixes
 """"""""
 
-* PR `#249 <https://github.com/openforcefield/propertyestimator/pull/249>`_: Replacing Protocols of Non-existent Workflow Schema.
+* PR `#249 <https://github.com/openforcefield/propertyestimator/pull/249>`_: Fix replacing protocols of non-existent workflow schema.
+* PR `#253 <https://github.com/openforcefield/propertyestimator/pull/253>`_: Fix `antechamber` truncating charge file.
 
 Documentation
 """""""""""""
 
-* PR `#252 <https://github.com/openforcefield/propertyestimator/pull/249>`_: Use `conda-forge` for `ambertools` installation.
+* PR `#252 <https://github.com/openforcefield/propertyestimator/pull/252>`_: Use `conda-forge` for `ambertools` installation.
 
 0.1.0 - OpenFF Evaluator
 ------------------------

--- a/openff/evaluator/protocols/forcefield.py
+++ b/openff/evaluator/protocols/forcefield.py
@@ -8,6 +8,7 @@ import logging
 import os
 import re
 import subprocess
+import textwrap
 from enum import Enum
 
 import numpy as np
@@ -894,7 +895,7 @@ class BuildTLeapSystem(TemplateBuildSystem):
             ]
 
             with open("charges.txt", "w") as file:
-                file.write(" ".join(map(str, charges)))
+                file.write(textwrap.fill(" ".join(map(str, charges)), width=70))
 
             if force_field_source.leap_source == "leaprc.gaff2":
                 amber_type = "gaff2"

--- a/openff/evaluator/tests/test_protocols/test_forcefield.py
+++ b/openff/evaluator/tests/test_protocols/test_forcefield.py
@@ -51,7 +51,7 @@ def test_build_tleap_system():
         with open(force_field_path, "w") as file:
             file.write(TLeapForceFieldSource().json())
 
-        substance = Substance.from_components("C", "O", "C(=O)N")
+        substance = Substance.from_components("CCCCCCCC", "O", "C(=O)N")
 
         build_coordinates = BuildCoordinatesPackmol("build_coordinates")
         build_coordinates.max_molecules = 9


### PR DESCRIPTION
## Description
This PR fixes a bug where antechamber truncated the text file containing the charges it should apply, and thus leading to non-zero charges.

This is fixed by simply wrapping the charges to have a maximum length of 70 characters.

## Status
- [X] Ready to go