### PR TITLE
Fix Protocol Id Replacement on ProtocolPath Objects

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -8,6 +8,16 @@ Releases follow the ``major.minor.micro`` scheme recommended by
 * ``minor`` increments add features but do not break API compatibility
 * ``micro`` increments represent bugfix releases or improvements in documentation
 
+0.1.2
+-----
+
+A patch release offering minor bug fixes and quality of life improvements. 
+
+Bugfixes
+""""""""
+
+* PR `#254 <https://github.com/openforcefield/propertyestimator/pull/254>`_: Fix incompatible protocols being merged due to an id replacement bug.
+
 0.1.1
 -----
 

--- a/openff/evaluator/tests/test_workflow/test_utils.py
+++ b/openff/evaluator/tests/test_workflow/test_utils.py
@@ -1,0 +1,19 @@
+from openff.evaluator.workflow.utils import ProtocolPath
+
+
+def test_protocol_path_id_replacement():
+    """Tests that the protocol id function on the protocol path
+    behaves as expected."""
+
+    protocol_path = ProtocolPath("", "protocol_id_1", "protocol_id_11")
+    assert protocol_path.full_path == "protocol_id_1/protocol_id_11."
+
+    # Make sure only full matches lead to id replacement
+    protocol_path.replace_protocol("protocol_id_", "new_id_1")
+    assert protocol_path.full_path == "protocol_id_1/protocol_id_11."
+
+    protocol_path.replace_protocol("rotocol_id_1", "new_id_1")
+    assert protocol_path.full_path == "protocol_id_1/protocol_id_11."
+
+    protocol_path.replace_protocol("protocol_id_1", "new_id_1")
+    assert protocol_path.full_path == "new_id_1/protocol_id_11."

--- a/openff/evaluator/workflow/utils.py
+++ b/openff/evaluator/workflow/utils.py
@@ -223,7 +223,7 @@ class ProtocolPath(PlaceholderValue):
             The id of the new protocol to use.
         """
         self._protocol_ids = tuple(
-            x.replace(old_id, new_id) for x in self._protocol_ids
+            new_id if x == old_id else x for x in self._protocol_ids
         )
         self._update_string_paths()
 


### PR DESCRIPTION
## Description
This PR fixes a bug whereby protocol ids in a protocol path were sometimes replaced if the protocol id to replace partially matched an id in the path.

## Status
- [x] Ready to go