### PR TITLE
Fix Incorrect Version when Installing from Tarballs

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -18,6 +18,7 @@ Bugfixes
 
 * PR `#254 <https://github.com/openforcefield/propertyestimator/pull/254>`_: Fix incompatible protocols being merged due to an id replacement bug.
 * PR `#255 <https://github.com/openforcefield/propertyestimator/pull/255>`_: Fix recursive ``ThermodynamicState`` string representation.
+* PR `#256 <https://github.com/openforcefield/propertyestimator/pull/256>`_: Fix incorrect version when installing from tarballs.
 
 0.1.1
 -----

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,4 @@ style = pep440
 versionfile_source = openff/evaluator/_version.py
 versionfile_build = openff/evaluator/_version.py
 tag_prefix = ''
+parentdir_prefix = openff-evaluator-


### PR DESCRIPTION
## Description
This PR fixes an issue whereby `versioneer` could not detect the packages version from the parent directory when installing from a tarball.

## Status
- [X] Ready to go