### PR TITLE
Upgrade to isort 5.0.0 and Re-Lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Run isort
         run: |
-          isort --recursive --check-only openff
-          isort --recursive --check-only integration_tests
+          isort --check-only openff
+          isort --check-only integration_tests
 
       - name: Run black
         run: |

--- a/openff/evaluator/datasets/thermoml/thermoml.py
+++ b/openff/evaluator/datasets/thermoml/thermoml.py
@@ -850,8 +850,8 @@ class _PureOrMixtureData:
             The molecular weight.
         """
 
-        from simtk import unit as simtk_unit
         from openforcefield.topology import Molecule
+        from simtk import unit as simtk_unit
 
         try:
 

--- a/openff/evaluator/protocols/forcefield.py
+++ b/openff/evaluator/protocols/forcefield.py
@@ -1069,8 +1069,8 @@ class BuildTLeapSystem(TemplateBuildSystem):
         elif self.charge_backend == BuildTLeapSystem.ChargeBackend.AmberTools:
 
             from openforcefield.utils.toolkits import (
-                RDKitToolkitWrapper,
                 AmberToolsToolkitWrapper,
+                RDKitToolkitWrapper,
                 ToolkitRegistry,
             )
 

--- a/openff/evaluator/protocols/openmm.py
+++ b/openff/evaluator/protocols/openmm.py
@@ -684,8 +684,8 @@ class OpenMMReducedPotentials(BaseReducedPotentials):
 
     def _execute(self, directory, available_resources):
 
-        import openmmtools
         import mdtraj
+        import openmmtools
 
         trajectory = mdtraj.load_dcd(
             self.trajectory_file_path, self.coordinate_file_path

--- a/openff/evaluator/protocols/yank.py
+++ b/openff/evaluator/protocols/yank.py
@@ -118,8 +118,8 @@ class BaseYankProtocol(Protocol, abc.ABC):
             The identified residue names.
         """
 
-        from simtk.openmm import app
         from openforcefield.topology import Molecule, Topology
+        from simtk.openmm import app
 
         if role is None:
             return "all"
@@ -372,10 +372,9 @@ class BaseYankProtocol(Protocol, abc.ABC):
             The uncertainty in the free energy returned by yank.
         """
 
-        from yank.experiment import ExperimentBuilder
-        from yank.analyze import ExperimentAnalyzer
-
         from simtk import unit as simtk_unit
+        from yank.analyze import ExperimentAnalyzer
+        from yank.experiment import ExperimentBuilder
 
         with temporarily_change_directory(directory):
 


### PR DESCRIPTION
## Description
This PR updates to use the new `isort >=5.0.0` CLI syntax and re-lints the code base to apply the newer style of import sorting.

## Status
- [X] Ready to go