### PR TITLE
Added utility `isfile_notempty`; addresses failure modes with openmm

### DIFF
--- a/openff/evaluator/protocols/openmm.py
+++ b/openff/evaluator/protocols/openmm.py
@@ -29,7 +29,7 @@ from openff.evaluator.utils.openmm import (
 )
 from openff.evaluator.utils.serialization import TypedJSONDecoder, TypedJSONEncoder
 from openff.evaluator.utils.statistics import ObservableType, StatisticsArray
-from openff.evaulator.utils.utils import isfile_notempty
+from openff.evaluator.utils.utils import isfile_notempty
 from openff.evaluator.workflow import workflow_protocol
 
 logger = logging.getLogger(__name__)

--- a/openff/evaluator/protocols/openmm.py
+++ b/openff/evaluator/protocols/openmm.py
@@ -29,6 +29,7 @@ from openff.evaluator.utils.openmm import (
 )
 from openff.evaluator.utils.serialization import TypedJSONDecoder, TypedJSONEncoder
 from openff.evaluator.utils.statistics import ObservableType, StatisticsArray
+from openff.evaulator.utils.utils import isfile_notempty
 from openff.evaluator.workflow import workflow_protocol
 
 logger = logging.getLogger(__name__)
@@ -192,7 +193,7 @@ class OpenMMSimulation(BaseSimulation):
         # Save a copy of the starting configuration if it doesn't already exist
         local_input_coordinate_path = os.path.join(directory, "input.pdb")
 
-        if not os.path.isfile(local_input_coordinate_path):
+        if not isfile_notempty(local_input_coordinate_path):
 
             input_pdb_file = app.PDBFile(self.input_coordinate_file)
 
@@ -471,14 +472,14 @@ class OpenMMSimulation(BaseSimulation):
         current_step_number = 0
 
         # Check whether the checkpoint files actually exists.
-        if not os.path.isfile(self._checkpoint_path) or not os.path.isfile(
+        if not isfile_notempty(self._checkpoint_path) or not isfile_notempty(
             self._state_path
         ):
 
             logger.info("No checkpoint files were found.")
             return current_step_number
 
-        if not os.path.isfile(self._local_statistics_path) or not os.path.isfile(
+        if not isfile_notempty(self._local_statistics_path) or not isfile_notempty(
             self._local_trajectory_path
         ):
 
@@ -599,7 +600,7 @@ class OpenMMSimulation(BaseSimulation):
 
         # Build the reporters which we will use to report the state
         # of the simulation.
-        append_trajectory = os.path.isfile(self._local_trajectory_path)
+        append_trajectory = isfile_notempty(self._local_trajectory_path)
         dcd_reporter = app.DCDReporter(
             self._local_trajectory_path, 0, append_trajectory
         )

--- a/openff/evaluator/protocols/openmm.py
+++ b/openff/evaluator/protocols/openmm.py
@@ -472,16 +472,16 @@ class OpenMMSimulation(BaseSimulation):
         current_step_number = 0
 
         # Check whether the checkpoint files actually exists.
-        if not is_file_and_not_empty(self._checkpoint_path) or not is_file_and_not_empty(
-            self._state_path
-        ):
+        if not is_file_and_not_empty(
+            self._checkpoint_path
+        ) or not is_file_and_not_empty(self._state_path):
 
             logger.info("No checkpoint files were found.")
             return current_step_number
 
-        if not is_file_and_not_empty(self._local_statistics_path) or not is_file_and_not_empty(
-            self._local_trajectory_path
-        ):
+        if not is_file_and_not_empty(
+            self._local_statistics_path
+        ) or not is_file_and_not_empty(self._local_trajectory_path):
 
             raise ValueError(
                 "Checkpoint files were correctly found, but the trajectory "

--- a/openff/evaluator/protocols/openmm.py
+++ b/openff/evaluator/protocols/openmm.py
@@ -29,7 +29,7 @@ from openff.evaluator.utils.openmm import (
 )
 from openff.evaluator.utils.serialization import TypedJSONDecoder, TypedJSONEncoder
 from openff.evaluator.utils.statistics import ObservableType, StatisticsArray
-from openff.evaluator.utils.utils import isfile_notempty
+from openff.evaluator.utils.utils import is_file_and_not_empty
 from openff.evaluator.workflow import workflow_protocol
 
 logger = logging.getLogger(__name__)
@@ -193,7 +193,7 @@ class OpenMMSimulation(BaseSimulation):
         # Save a copy of the starting configuration if it doesn't already exist
         local_input_coordinate_path = os.path.join(directory, "input.pdb")
 
-        if not isfile_notempty(local_input_coordinate_path):
+        if not is_file_and_not_empty(local_input_coordinate_path):
 
             input_pdb_file = app.PDBFile(self.input_coordinate_file)
 
@@ -472,14 +472,14 @@ class OpenMMSimulation(BaseSimulation):
         current_step_number = 0
 
         # Check whether the checkpoint files actually exists.
-        if not isfile_notempty(self._checkpoint_path) or not isfile_notempty(
+        if not is_file_and_not_empty(self._checkpoint_path) or not is_file_and_not_empty(
             self._state_path
         ):
 
             logger.info("No checkpoint files were found.")
             return current_step_number
 
-        if not isfile_notempty(self._local_statistics_path) or not isfile_notempty(
+        if not is_file_and_not_empty(self._local_statistics_path) or not is_file_and_not_empty(
             self._local_trajectory_path
         ):
 
@@ -600,7 +600,7 @@ class OpenMMSimulation(BaseSimulation):
 
         # Build the reporters which we will use to report the state
         # of the simulation.
-        append_trajectory = isfile_notempty(self._local_trajectory_path)
+        append_trajectory = is_file_and_not_empty(self._local_trajectory_path)
         dcd_reporter = app.DCDReporter(
             self._local_trajectory_path, 0, append_trajectory
         )

--- a/openff/evaluator/tests/test_utils/test_utils.py
+++ b/openff/evaluator/tests/test_utils/test_utils.py
@@ -75,7 +75,8 @@ def test_is_file_and_not_empty(tmpdir):
     assert not is_file_and_not_empty(path)
 
     path = "testfile2"
-    with tempfile.TemporaryDirectory() as directory:
+
+    with tempfile.TemporaryDirectory():
         with open(path, "w") as f:
             f.write("ubiquitous mendacious polyglottal")
 

--- a/openff/evaluator/tests/test_utils/test_utils.py
+++ b/openff/evaluator/tests/test_utils/test_utils.py
@@ -66,7 +66,7 @@ def test_get_nested_attribute():
 
 def test_is_file_and_not_empty(tmpdir):
     path = "testfile"
-    with tempfile.TemporaryDirectory() as directory:
+    with tempfile.TemporaryDirectory():
         with open(path, "w") as f:
             pass
 

--- a/openff/evaluator/tests/test_utils/test_utils.py
+++ b/openff/evaluator/tests/test_utils/test_utils.py
@@ -63,20 +63,21 @@ def test_get_nested_attribute():
     assert get_nested_attribute(dummy_object, "object_b[b].object_b[0].object_a") == "a"
     assert get_nested_attribute(dummy_object, "object_b[b].object_b[0].object_b") == "b"
 
+
 def test_is_file_and_not_empty(tmpdir):
-    path = 'testfile'
+    path = "testfile"
     with tempfile.TemporaryDirectory() as directory:
-        with open(path, 'w') as f:
+        with open(path, "w") as f:
             pass
 
     assert os.path.isfile(path)
     assert os.path.getsize(path) == 0
     assert not is_file_and_not_empty(path)
 
-    path = 'testfile2'
+    path = "testfile2"
     with tempfile.TemporaryDirectory() as directory:
-        with open(path, 'w') as f:
-           f.write("ubiquitous mendacious polyglottal")
+        with open(path, "w") as f:
+            f.write("ubiquitous mendacious polyglottal")
 
     assert os.path.isfile(path)
     assert os.path.getsize(path) != 0

--- a/openff/evaluator/tests/test_utils/test_utils.py
+++ b/openff/evaluator/tests/test_utils/test_utils.py
@@ -1,7 +1,10 @@
 """
 Units tests for openff.evaluator.utils.exceptions
 """
-from openff.evaluator.utils.utils import get_nested_attribute
+import os
+import tempfile
+
+from openff.evaluator.utils.utils import get_nested_attribute, is_file_and_not_empty
 
 
 class DummyNestedClass:
@@ -59,3 +62,22 @@ def test_get_nested_attribute():
     assert get_nested_attribute(dummy_object, "object_b[b].object_a") == 2
     assert get_nested_attribute(dummy_object, "object_b[b].object_b[0].object_a") == "a"
     assert get_nested_attribute(dummy_object, "object_b[b].object_b[0].object_b") == "b"
+
+def test_is_file_and_not_empty(tmpdir):
+    path = 'testfile'
+    with tempfile.TemporaryDirectory() as directory:
+        with open(path, 'w') as f:
+            pass
+
+    assert os.path.isfile(path)
+    assert os.path.getsize(path) == 0
+    assert not is_file_and_not_empty(path)
+
+    path = 'testfile2'
+    with tempfile.TemporaryDirectory() as directory:
+        with open(path, 'w') as f:
+           f.write("ubiquitous mendacious polyglottal")
+
+    assert os.path.isfile(path)
+    assert os.path.getsize(path) != 0
+    assert is_file_and_not_empty(path)

--- a/openff/evaluator/utils/__init__.py
+++ b/openff/evaluator/utils/__init__.py
@@ -1,7 +1,8 @@
-from .utils import get_data_filename, has_openeye, setup_timestamp_logging
+from .utils import get_data_filename, has_openeye, setup_timestamp_logging, is_file_and_not_empty
 
 __all__ = [
     get_data_filename,
     has_openeye,
     setup_timestamp_logging,
+    is_file_and_not_empty
 ]

--- a/openff/evaluator/utils/__init__.py
+++ b/openff/evaluator/utils/__init__.py
@@ -1,8 +1,13 @@
-from .utils import get_data_filename, has_openeye, setup_timestamp_logging, is_file_and_not_empty
+from .utils import (
+    get_data_filename,
+    has_openeye,
+    setup_timestamp_logging,
+    is_file_and_not_empty,
+)
 
 __all__ = [
     get_data_filename,
     has_openeye,
     setup_timestamp_logging,
-    is_file_and_not_empty
+    is_file_and_not_empty,
 ]

--- a/openff/evaluator/utils/__init__.py
+++ b/openff/evaluator/utils/__init__.py
@@ -1,8 +1,8 @@
 from .utils import (
     get_data_filename,
     has_openeye,
-    setup_timestamp_logging,
     is_file_and_not_empty,
+    setup_timestamp_logging,
 )
 
 __all__ = [

--- a/openff/evaluator/utils/utils.py
+++ b/openff/evaluator/utils/utils.py
@@ -258,3 +258,7 @@ def has_openeye():
         available = False
 
     return available
+
+
+def isfile_notempty(path):
+    return os.path.isfile(path) and (os.path.getsize(path) != 0)

--- a/openff/evaluator/utils/utils.py
+++ b/openff/evaluator/utils/utils.py
@@ -281,5 +281,17 @@ def has_openeye():
     return available
 
 
-def is_file_and_not_empty(path):
-    return os.path.isfile(path) and (os.path.getsize(path) != 0)
+def is_file_and_not_empty(file_path):
+    """Checks that a file both exists at the specified ``path`` and is not empty.
+
+    Parameters
+    ----------
+    file_path: str
+        The file path to check.
+
+    Returns
+    -------
+    bool
+        That a file both exists at the specified ``path`` and is not empty.
+    """
+    return os.path.isfile(file_path) and (os.path.getsize(file_path) != 0)

--- a/openff/evaluator/utils/utils.py
+++ b/openff/evaluator/utils/utils.py
@@ -281,5 +281,5 @@ def has_openeye():
     return available
 
 
-def isfile_notempty(path):
+def is_file_and_not_empty(path):
     return os.path.isfile(path) and (os.path.getsize(path) != 0)


### PR DESCRIPTION
## Description
Provide a brief description of the PR's purpose here.

Addresses #258.

Adds an additional check for file existence in the `openmm` protocol; if an output file is empty, we treat it as if it doesn't exist.

## Todos

  - [x] Determine correct place for this logic to live; currently in `openff.evaluator.utils.utils`
  - [x] Create an MCVE that can be used for tests

## Status
- [x] Ready to go