### PR TITLE
[PAPRIKA] Use Flat Bottom Wall and Symmetry Restraints

### DIFF
--- a/openff/evaluator/protocols/paprika/restraints.py
+++ b/openff/evaluator/protocols/paprika/restraints.py
@@ -389,6 +389,7 @@ class ApplyRestraints(Protocol):
                     restraint,
                     self.phase,
                     self.window_index,
+                    flat_bottom=restraint_type in ["symmetry", "wall"],
                     force_group=force_groups[restraint_type],
                 )
 


### PR DESCRIPTION
## Description
This PR enables the flat bottom restraint option when applying wall and symmetry restraints. This was missed when the `paprika.setup` module was partially refactored into the new protocol.

## Status
- [X] Ready to go