### PR TITLE
Exclude Exact Amount from Max Molecules Cap

### DIFF
--- a/openff/evaluator/substances/substances.py
+++ b/openff/evaluator/substances/substances.py
@@ -225,7 +225,9 @@ class Substance(AttributeClass):
 
         return self.amounts[identifier]
 
-    def get_molecules_per_component(self, maximum_molecules, tolerance=None):
+    def get_molecules_per_component(
+        self, maximum_molecules, tolerance=None, count_exact_amount=True
+    ):
         """Returns the number of molecules for each component in this substance,
         given a maximum total number of molecules.
 
@@ -238,6 +240,13 @@ class Substance(AttributeClass):
             an example, when converting a mole fraction into a number of molecules,
             the total number of molecules may not be sufficiently large enough to
             reproduce this amount.
+        count_exact_amount: bool
+            Whether components present in an exact amount (i.e. defined with an
+            ``ExactAmount``) should be considered when apply the maximum number
+             of molecules constraint. This may be set false, for example, when
+             building a separate solvated protein (n = 1) and solvated protein +
+             ligand complex (n = 2) system but wish for both systems to have the
+             same number of solvent molecules.
 
         Returns
         -------
@@ -255,7 +264,7 @@ class Substance(AttributeClass):
 
             for amount in amounts:
 
-                if not isinstance(amount, ExactAmount):
+                if not isinstance(amount, ExactAmount) or not count_exact_amount:
                     continue
 
                 remaining_molecule_slots -= amount.value

--- a/openff/evaluator/tests/test_protocols/test_coordinates.py
+++ b/openff/evaluator/tests/test_protocols/test_coordinates.py
@@ -86,6 +86,31 @@ def test_build_coordinates_packmol(input_substance, expected):
             assert assigned_name[:3] == "HOH"
 
 
+@pytest.mark.parametrize("count_exact_amount", [False, True])
+def test_build_coordinates_packmol_exact(count_exact_amount):
+    """Tests that the build coordinate protocol behaves correctly for substances
+    with exact amounts."""
+
+    import mdtraj
+
+    substance = Substance()
+    substance.add_component(Component("O"), MoleFraction(1.0))
+    substance.add_component(Component("C"), ExactAmount(1))
+
+    max_molecule = 11 if count_exact_amount else 10
+
+    build_coordinates = BuildCoordinatesPackmol("build_coordinates")
+    build_coordinates.max_molecules = max_molecule
+    build_coordinates.count_exact_amount = count_exact_amount
+    build_coordinates.substance = substance
+
+    with tempfile.TemporaryDirectory() as directory:
+        build_coordinates.execute(directory)
+        built_system = mdtraj.load_pdb(build_coordinates.coordinate_file_path)
+
+    assert built_system.n_residues == 11
+
+
 def test_solvate_existing_structure_protocol():
     """Tests solvating a single methanol molecule in water."""
 


### PR DESCRIPTION
## Description
This PR adds the option to not count exact numbers of molecules towards the maximum number of molecules cap when mapping substance amounts to exact numbers of molecules for a given target maximum.

This is useful, for example, when building a separate solvated protein (n = 1) and solvated protein + ligand complex (n = 2) system but wish for both systems to have the same number of solvent molecules.

## Status
- [X] Ready to go