### PR TITLE
Substance.get_molecules_per_component now allows adjustable component

### DIFF
--- a/openff/evaluator/protocols/coordinates.py
+++ b/openff/evaluator/protocols/coordinates.py
@@ -124,9 +124,16 @@ class BuildCoordinatesPackmol(Protocol):
             molecule = Molecule.from_smiles(component.smiles)
             molecules.append(molecule)
 
+        # TODO: make this optionally enabled
+        adjustable = None
+        for component in self.substance.components:
+            if component.role.name == 'Solvent':
+                adjustable = component.identifier
+
         # Determine how many molecules of each type will be present in the system.
         molecules_per_component = self.substance.get_molecules_per_component(
-            self.max_molecules, count_exact_amount=self.count_exact_amount
+            self.max_molecules, count_exact_amount=self.count_exact_amount,
+            adjustable=adjustable
         )
         number_of_molecules = [0] * self.substance.number_of_components
 

--- a/openff/evaluator/protocols/coordinates.py
+++ b/openff/evaluator/protocols/coordinates.py
@@ -127,13 +127,14 @@ class BuildCoordinatesPackmol(Protocol):
         # TODO: make this optionally enabled
         adjustable = None
         for component in self.substance.components:
-            if component.role.name == 'Solvent':
+            if component.role.name == "Solvent":
                 adjustable = component.identifier
 
         # Determine how many molecules of each type will be present in the system.
         molecules_per_component = self.substance.get_molecules_per_component(
-            self.max_molecules, count_exact_amount=self.count_exact_amount,
-            adjustable=adjustable
+            self.max_molecules,
+            count_exact_amount=self.count_exact_amount,
+            adjustable=adjustable,
         )
         number_of_molecules = [0] * self.substance.number_of_components
 

--- a/openff/evaluator/substances/components.py
+++ b/openff/evaluator/substances/components.py
@@ -22,6 +22,7 @@ class Component(AttributeClass):
         """
 
         Solvent = "solv"
+        Salt = "salt"
         Solute = "sol"
 
         Ligand = "lig"

--- a/openff/evaluator/substances/substances.py
+++ b/openff/evaluator/substances/substances.py
@@ -226,7 +226,8 @@ class Substance(AttributeClass):
         return self.amounts[identifier]
 
     def get_molecules_per_component(
-        self, maximum_molecules, tolerance=None, count_exact_amount=True
+        self, maximum_molecules, tolerance=None, count_exact_amount=True,
+        adjustable=None
     ):
         """Returns the number of molecules for each component in this substance,
         given a maximum total number of molecules.
@@ -247,6 +248,10 @@ class Substance(AttributeClass):
              building a separate solvated protein (n = 1) and solvated protein +
              ligand complex (n = 2) system but wish for both systems to have the
              same number of solvent molecules.
+        adjustable: str
+             Component identifier for the component that can be incremented or
+             decremented after all components are populated in order to arrive
+             at the desired `maximum_molecules`.
 
         Returns
         -------
@@ -285,6 +290,13 @@ class Substance(AttributeClass):
                 number_of_molecules[
                     component.identifier
                 ] += amount.to_number_of_molecules(remaining_molecule_slots, tolerance)
+
+        if adjustable is not None:
+            while sum(number_of_molecules.values()) > maximum_molecules:
+                number_of_molecules[adjustable] -= 1
+
+            while sum(number_of_molecules.values()) < maximum_molecules:
+                number_of_molecules[adjustable] += 1
 
         return number_of_molecules
 

--- a/openff/evaluator/substances/substances.py
+++ b/openff/evaluator/substances/substances.py
@@ -226,8 +226,11 @@ class Substance(AttributeClass):
         return self.amounts[identifier]
 
     def get_molecules_per_component(
-        self, maximum_molecules, tolerance=None, count_exact_amount=True,
-        adjustable=None
+        self,
+        maximum_molecules,
+        tolerance=None,
+        count_exact_amount=True,
+        adjustable=None,
     ):
         """Returns the number of molecules for each component in this substance,
         given a maximum total number of molecules.


### PR DESCRIPTION
Added an `adjustable` keyword argument to `substances.Substances.get_molecules_per_component` that allows specifying a component that can be incremented/decremented as needed at the end of the function to meet the exact `maximum_molecules` specified.

Also adds:
- `Component.Role.Salt` for ions that are not considered solute but we want to distinguish from adjustable solvent components

## Description
This addresses an issue raised by @jeff231li in which `protocols.coordinates.BuildCoordinatesPackmol._build_molecule_arrays` raises an error when `total_molecules > max_molecules`, which happens often enough with the existing implementation.

## Todos
- [ ] Add unit test exercising the new `adjustable` keyword argument
- [ ] Add an opt-in parameter to `BuildCoordinatesPackmol` for use of the `adjustable` keyword for component with role 'Solvent'

## Questions
- [ ] Should `adjustable` take in multiple identifiers and cycle through them somehow in the decrement/increment scheme?

## Status
- [ ] Ready to go