### PR TITLE
Added Role.Salt usage for solvent ions in paprika taproom

### DIFF
--- a/openff/evaluator/datasets/taproom/taproom.py
+++ b/openff/evaluator/datasets/taproom/taproom.py
@@ -202,8 +202,8 @@ class TaproomDataSet(PhysicalPropertyDataSet):
         substance.add_component(component=host, amount=ExactAmount(1))
 
         water = Component(smiles="O", role=Component.Role.Solvent)
-        sodium = Component(smiles=positive_buffer_ion, role=Component.Role.Solvent)
-        chlorine = Component(smiles=negative_buffer_ion, role=Component.Role.Solvent)
+        sodium = Component(smiles=positive_buffer_ion, role=Component.Role.Salt)
+        chlorine = Component(smiles=negative_buffer_ion, role=Component.Role.Salt)
 
         water_mole_fraction = 1.0
 


### PR DESCRIPTION
## Description
Adds use of the new `Component.Role.Salt` role introduced in #273.

This eliminates the issue with:

    ValueError: The number of molecules to create (2501) is greater than the maximum number requested (2500).

that arises often through the paprika protocol.

## Status
- [ ] Ready to go