### PR TITLE
Workaround for N Substance Molecules > Maximum

### DIFF
--- a/openff/evaluator/substances/substances.py
+++ b/openff/evaluator/substances/substances.py
@@ -312,7 +312,11 @@ class Substance(AttributeClass):
 
         # Attempt to fix rounding issues which lead to more molecules being added than
         # the maximum.
-        total_molecules = sum(n_molecules.values()) if count_exact_amount else sum(n_mole_fractions.values())
+        total_molecules = (
+            sum(n_molecules.values())
+            if count_exact_amount
+            else sum(n_mole_fractions.values())
+        )
 
         max_truncation_attempts = len(self.components)
         n_truncation_attempts = 0
@@ -331,7 +335,11 @@ class Substance(AttributeClass):
             n_molecules[largest_component] -= 1
             n_mole_fractions[largest_component] -= 1
 
-            total_molecules = sum(n_molecules.values()) if count_exact_amount else sum(n_mole_fractions.values())
+            total_molecules = (
+                sum(n_molecules.values())
+                if count_exact_amount
+                else sum(n_mole_fractions.values())
+            )
 
             n_truncation_attempts += 1
 

--- a/openff/evaluator/tests/test_substances.py
+++ b/openff/evaluator/tests/test_substances.py
@@ -75,10 +75,12 @@ def test_truncate_n_molecules():
     substance = Substance()
 
     substance.add_component(
-        component=Component(smiles="[Na+]"), amount=MoleFraction(0.00267),
+        component=Component(smiles="[Na+]"),
+        amount=MoleFraction(0.00267),
     )
     substance.add_component(
-        component=Component(smiles="[Cl-]"), amount=MoleFraction(0.00267),
+        component=Component(smiles="[Cl-]"),
+        amount=MoleFraction(0.00267),
     )
     substance.add_component(
         component=Component(smiles="O"), amount=MoleFraction(1.0 - 2.0 * 0.00267)

--- a/openff/evaluator/tests/test_substances.py
+++ b/openff/evaluator/tests/test_substances.py
@@ -70,6 +70,32 @@ def test_multiple_amounts():
     assert molecule_counts[chloride.identifier] == 2
 
 
+def test_truncate_n_molecules():
+
+    substance = Substance()
+
+    substance.add_component(
+        component=Component(smiles="[Na+]"), amount=MoleFraction(0.00267),
+    )
+    substance.add_component(
+        component=Component(smiles="[Cl-]"), amount=MoleFraction(0.00267),
+    )
+    substance.add_component(
+        component=Component(smiles="O"), amount=MoleFraction(1.0 - 2.0 * 0.00267)
+    )
+
+    # Attempt to get the number of molecules without truncating.
+    with pytest.raises(ValueError):
+        substance.get_molecules_per_component(1000, truncate_n_molecules=False)
+
+    # Attempt to get the number of molecules with truncating.
+    molecule_counts = substance.get_molecules_per_component(
+        1000, truncate_n_molecules=True
+    )
+
+    assert molecule_counts == {"[Na+]{solv}": 3, "[Cl-]{solv}": 3, "O{solv}": 994}
+
+
 def test_substance_len():
 
     substance = Substance.from_components("C", "CC", "CCC", "CCC")


### PR DESCRIPTION
## Description
This PR adds a workaround for an edge case whereby the total number of molecules returned by `Substance.get_molecules_per_component` is greater than the specified maximum due to unfortunate rounding.

The workaround simply attempts to remove one molecule from the predominant component until either a sensible number of tries have been attempted or the issue is resolved. This PR replaces #273 and #274.

## Status
- [ ] Ready to go