### PR TITLE
Add Missing .gitattributes File

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+openff/evaluator/_version.py export-subst


### PR DESCRIPTION
## Description
This PR adds the missing `.gitattributes` file which is required by `versioneer` to provide a correct version after `git archive` is ran.

## Status
- [ ] Ready to go