### PR TITLE
Initial Pass at Physical Property Documentation

### DIFF
--- a/docs/_static/css/theme_overrides.css
+++ b/docs/_static/css/theme_overrides.css
@@ -44,6 +44,9 @@ table.clean-table.property-table td:not(:first-child) {
 ul.spaced-list li {
     margin-bottom: 10px;
 }
+ol.spaced-list li {
+    margin-bottom: 10px;
+}
 
 .green-font {
     color: mediumseagreen;

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -427,6 +427,14 @@ Built-in Workflow Protocols
     ExtractUncorrelatedTrajectoryData
     ExtractUncorrelatedStatisticsData
 
+
+.. currentmodule:: openff.evaluator.properties.dielectric
+.. autosummary::
+    :nosignatures:
+    :toctree: api/generated/
+
+    ExtractAverageDielectric
+
 **Coordinate Generation**
 
 .. currentmodule:: openff.evaluator.protocols.coordinates
@@ -507,6 +515,14 @@ Built-in Workflow Protocols
     BaseReducedPotentials
     BaseMBARProtocol
     ReweightStatistics
+
+.. currentmodule:: openff.evaluator.properties.dielectric
+.. autosummary::
+    :nosignatures:
+    :toctree: api/generated/
+
+    ReweightDielectricConstant
+
 
 **Simulation**
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ release = ''
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinxcontrib.bibtex',
     'sphinx.ext.napoleon',
     'sphinx.ext.autosummary',
     'sphinx.ext.autosectionlabel',
@@ -128,6 +129,8 @@ intersphinx_mapping = {
     'pint': ('https://pint.readthedocs.io/en/latest/', None)
 }
 
+# Set up mathjax.
+mathjax_path = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -9,6 +9,7 @@ dependencies:
     # Sphinx specific
     - nbsphinx
     - sphinx_rtd_theme
+    - sphinxcontrib-bibtex
     - pandoc
     - ipython
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,6 +90,8 @@ field optimisation.
 
 *\* Entries marked with an asterisk are supported but have not yet been extensively tested and validated.*
 
+See the :doc:`physical properties overview page <properties/properties>` for more details.
+
 .. Setup the side-pane table of contents.
 
 .. toctree::
@@ -124,9 +126,18 @@ field optimisation.
   :hidden:
   :caption: Data Sets
 
-  datasets/physicalproperties
+  Overview <datasets/physicalproperties>
   datasets/thermomldatasets
   datasets/curation
+
+.. toctree::
+  :maxdepth: 2
+  :hidden:
+  :caption: Physical Properties
+
+  Overview <properties/properties>
+  properties/commonworkflows
+  properties/gradients
 
 .. toctree::
   :maxdepth: 2

--- a/docs/properties/commonworkflows.bib
+++ b/docs/properties/commonworkflows.bib
@@ -1,0 +1,20 @@
+@article{2016:chodera,
+  title={A simple method for automated equilibration detection in molecular simulations},
+  author={Chodera, John D},
+  journal={Journal of chemical theory and computation},
+  volume={12},
+  number={4},
+  pages={1799--1805},
+  year={2016},
+  publisher={ACS Publications}
+}
+@article{2018:messerly-a,
+  title={Configuration-sampling-based surrogate models for rapid parameterization of non-bonded interactions},
+  author={Messerly, Richard A and Razavi, S Mostafa and Shirts, Michael R},
+  journal={Journal of Chemical Theory and Computation},
+  volume={14},
+  number={6},
+  pages={3144--3162},
+  year={2018},
+  publisher={ACS Publications}
+}

--- a/docs/properties/commonworkflows.rst
+++ b/docs/properties/commonworkflows.rst
@@ -1,0 +1,99 @@
+.. |build_coordinates_packmol|    replace:: :py:class:`~openff.evaluator.protocols.coordinates.BuildCoordinatesPackmol`
+
+.. |build_smirnoff_system|        replace:: :py:class:`~openff.evaluator.protocols.forcefield.BuildSmirnoffSystem`
+.. |build_tleap_system|           replace:: :py:class:`~openff.evaluator.protocols.forcefield.BuildTLeapSystem`
+.. |build_lig_par_gen_system|     replace:: :py:class:`~openff.evaluator.protocols.forcefield.BuildLigParGenSystem`
+
+.. |openmm_energy_minimisation|   replace:: :py:class:`~openff.evaluator.protocols.openmm.OpenMMEnergyMinimisation`
+.. |openmm_simulation|            replace:: :py:class:`~openff.evaluator.protocols.openmm.OpenMMSimulation`
+.. |openmm_reduced_potentials|    replace:: :py:class:`~openff.evaluator.protocols.openmm.OpenMMReducedPotentials`
+
+.. |extract_average_statistic|              replace:: :py:class:`~openff.evaluator.protocols.analysis.ExtractAverageStatistic`
+.. |extract_uncorrelated_statistics_data|   replace:: :py:class:`~openff.evaluator.protocols.analysis.ExtractUncorrelatedStatisticsData`
+.. |extract_uncorrelated_trajectory_data|   replace:: :py:class:`~openff.evaluator.protocols.analysis.ExtractUncorrelatedTrajectoryData`
+
+.. |concatenate_trajectories|          replace:: :py:class:`~openff.evaluator.protocols.reweighting.ConcatenateTrajectories`
+.. |concatenate_statistics|            replace:: :py:class:`~openff.evaluator.protocols.reweighting.ConcatenateStatistics`
+.. |reweight_statistics|               replace:: :py:class:`~openff.evaluator.protocols.reweighting.ReweightStatistics`
+
+.. |unpack_stored_simulation_data|          replace:: :py:class:`~openff.evaluator.protocols.storage.UnpackStoredSimulationData`
+
+.. |generate_base_simulation_protocols|   replace:: :py:meth:`~openff.evaluator.protocols.utils.generate_base_simulation_protocols`
+.. |generate_base_reweighting_protocols|  replace:: :py:meth:`~openff.evaluator.protocols.utils.generate_base_reweighting_protocols`
+
+.. |simulation_layer|    replace:: :doc:`Direct Simulation <../layers/simulationlayer>`
+.. |reweighting_layer|   replace:: :doc:`MBAR Reweighting <../layers/reweightinglayer>`
+
+Common Workflows
+================
+
+As may be expected, most of the workflows used to estimate the physical properties within the framework make use
+of very similar workflows. This page aims to document the built-in 'template' workflows from which the more complex
+physical property estimation workflows are constructed.
+
+|simulation_layer|
+------------------
+
+Properties being estimated using the :doc:`direct simulation <../layers/simulationlayer>` calculation layer typically
+base their workflows off of the |generate_base_simulation_protocols| template.
+
+.. note:: This template currently assumes that a liquid phase property is being computed.
+
+The workflow produced by this template proceeds as follows:
+
+.. rst-class:: spaced-list
+
+    1) 1000 molecules are inserted into a simulation box with an approximate density of 0.95 g / mL. property substance
+       using packmol (|build_coordinates_packmol|).
+
+    2) the system is parameterized using either the `OpenFF toolkit <#>`_, `TLeap <#>`_ or `LigParGen <#>`_ depending on the force field being employed (|build_smirnoff_system|, |build_tleap_system| or |build_lig_par_gen_system|).
+
+    3) an energy minimization is performed using the default OpenMM energy minimizer (|openmm_energy_minimisation|).
+
+    4) the system is equilibrated by running a short NPT simulation for 100000 steps using a timestep of 2 fs and using the OpenMM simulation engine (|openmm_simulation|).
+
+    5) while the uncertainty in the average observable is greater than the requested tolerance (if specified):
+
+        5a) a longer NPT production simulation is run for 1000000 steps using a timestep of 2 fs and using the OpenMM simulation engine (|openmm_simulation|).
+
+        5b) the correlated samples are removed from the simulation outputs and the average value of the observable of interest are computed by bootstrapping with replacement for 250 iterations (|extract_average_statistic|).  See :cite:`2016:chodera` for details of the decorrelation procedure.
+
+        5c) 5a) and 5b) are repeated until the uncertainty condition is met.
+
+The decorrelated simulation outputs are then made available ready to be cached by a
+:doc:`storage backend <../storage/storagebackend>` (|extract_uncorrelated_statistics_data|, |extract_uncorrelated_trajectory_data|).
+
+|reweighting_layer|
+-------------------
+
+Properties being estimated using the :doc:`MBAR reweighting <../layers/reweightinglayer>` calculation layer typically
+base their workflows off of the |generate_base_reweighting_protocols| template.
+
+The workflow produced by this template proceeds as follows:
+
+.. rst-class:: spaced-list
+
+    1) for each stored simulation data:
+
+        1a) the cached data is retrieved from disk (|unpack_stored_simulation_data|)
+
+        1b) the cached data is subsampled so that the data which will be reweighted is decorrelated (|extract_average_statistic|, |extract_uncorrelated_statistics_data|, |extract_uncorrelated_trajectory_data|). See :cite:`2016:chodera` for details of the decorrelation procedure.
+
+    2) the cached data from is concatenated together to form a single trajectory of configurations and observables (|concatenate_trajectories|, |concatenate_statistics|).
+
+    3) for each stored simulation data:
+
+        3a) the system is parameterized using the force field parameters which were used when originally generating the cached data i.e. one of the reference states (|build_smirnoff_system|, |build_tleap_system| or |build_lig_par_gen_system|).
+
+        3b) the reduced potential of each configuration in the concatenated trajectory is evaluated using the parameterized system (|openmm_reduced_potentials|).
+
+    4) the system is parameterized using the force field parameters with which the property of interest should be calculated using i.e. of the target state (|build_smirnoff_system|, |build_tleap_system| or |build_lig_par_gen_system|) and the reduced potential of each configuration in the concatenated trajectory is evaluated using the parameterized system (|openmm_reduced_potentials|).
+
+    5) the MBAR method is employed to compute the average value of the observable of interest at the target state, taking the reference state reduced potentials as input. See :cite:`2018:messerly-a` for the theory behind this approach. An exception is raised if there are not enough effective samples to reweight (|reweight_statistics|).
+
+References
+----------
+
+.. bibliography:: commonworkflows.bib
+    :cited:
+    :style: unsrt

--- a/docs/properties/commonworkflows.rst
+++ b/docs/properties/commonworkflows.rst
@@ -54,11 +54,11 @@ The workflow produced by this template proceeds as follows:
 
     5) while the uncertainty in the average observable is greater than the requested tolerance (if specified):
 
-        5a) a longer NPT production simulation is run for 1000000 steps using a timestep of 2 fs and using the OpenMM simulation engine (|openmm_simulation|).
+        5a) a longer NPT production simulation is run for 1000000 steps with a timestep of 2 fs and using the OpenMM simulation protocol (|openmm_simulation|) with its default Langevin integrator and Monte Carlo barostat.
 
-        5b) the correlated samples are removed from the simulation outputs and the average value of the observable of interest are computed by bootstrapping with replacement for 250 iterations (|extract_average_statistic|).  See :cite:`2016:chodera` for details of the decorrelation procedure.
+        5b) the correlated samples are removed from the simulation outputs and the average value of the observable of interest and its uncertainty are computed by bootstrapping with replacement for 250 iterations (|extract_average_statistic|).  See :cite:`2016:chodera` for details of the decorrelation procedure.
 
-        5c) 5a) and 5b) are repeated until the uncertainty condition is met.
+        5c) steps 5a) and 5b) are repeated until the uncertainty condition (if applicable) is met.
 
 The decorrelated simulation outputs are then made available ready to be cached by a
 :doc:`storage backend <../storage/storagebackend>` (|extract_uncorrelated_statistics_data|, |extract_uncorrelated_trajectory_data|).
@@ -89,7 +89,7 @@ The workflow produced by this template proceeds as follows:
 
     4) the system is parameterized using the force field parameters with which the property of interest should be calculated using i.e. of the target state (|build_smirnoff_system|, |build_tleap_system| or |build_lig_par_gen_system|) and the reduced potential of each configuration in the concatenated trajectory is evaluated using the parameterized system (|openmm_reduced_potentials|).
 
-    5) the MBAR method is employed to compute the average value of the observable of interest at the target state, taking the reference state reduced potentials as input. See :cite:`2018:messerly-a` for the theory behind this approach. An exception is raised if there are not enough effective samples to reweight (|reweight_statistics|).
+    5) the MBAR method is employed to compute the average value of the observable of interest and its uncertainty at the target state, taking the reference state reduced potentials as input. See :cite:`2018:messerly-a` for the theory behind this approach. An exception is raised if there are not enough effective samples to reweight (|reweight_statistics|).
 
 References
 ----------

--- a/docs/properties/gradients.bib
+++ b/docs/properties/gradients.bib
@@ -1,0 +1,20 @@
+@article{2008:shirts,
+  title={Statistically optimal analysis of samples from multiple equilibrium states},
+  author={Shirts, Michael R and Chodera, John D},
+  journal={The Journal of chemical physics},
+  volume={129},
+  number={12},
+  pages={124105},
+  year={2008},
+  publisher={American Institute of Physics}
+}
+@article{2018:messerly-b,
+  title={Configuration-sampling-based surrogate models for rapid parameterization of non-bonded interactions},
+  author={Messerly, Richard A and Razavi, S Mostafa and Shirts, Michael R},
+  journal={Journal of Chemical Theory and Computation},
+  volume={14},
+  number={6},
+  pages={3144--3162},
+  year={2018},
+  publisher={ACS Publications}
+}

--- a/docs/properties/gradients.rst
+++ b/docs/properties/gradients.rst
@@ -1,0 +1,43 @@
+.. |openmm_gradient_potentials|    replace:: :py:class:`~openff.evaluator.protocols.openmm.OpenMMGradientPotentials`
+
+Gradients
+=========
+
+A most fundamental feature of this framework is its ability to rapidly compute the gradients of physical properties with
+respect to the force field parameters used to estimate them.
+
+Theory
+------
+
+The framework currently employs the central finite difference approach to computing gradients:
+
+.. math::
+
+    \dfrac {d \left<X \left( \theta \right) \right>}{d \theta_i} = \dfrac { \left<X \left( \theta_i + h \right) \right> - \left<X \left( \theta_i - h \right) \right> }{ 2 h}
+
+where :math:`\left<X\right>` is used to denote the ensemble average of an observable :math:`X`, :math:`\theta_i` is
+the force field parameter of interest, and by default :math:`h = 1 \times 10^{-4} \times \theta_i`. Although more
+expensive than computing either the forward or backwards derivative, the central difference method should give a more
+accurate estimate of the gradient at the minima, maxima and transition points.
+
+Rather than running an entirely new simulation to compute the values of :math:`\left<X \left( \theta_i + h \right) \right>`
+and :math:`\left<X \left( \theta_i - h \right) \right>`, these values are directly estimated using the MBAR reweighting
+method :cite:`2008:shirts`, :cite:`2018:messerly-b`. This approach has several advantages:
+
+.. rst-class:: spaced-list
+
+- there is a convenient cancellation of errors when computing the finite difference as the average value of the
+  observables at the perturbed parameters are computed from the same set of configurations and hence have errors which
+  are highly correlated. This thus avoids the need to run prohibitively long simulations to compute the average
+  observables to within a low enough error to produce meaningful differences between similar numbers.
+
+- the reduced potentials of the configurations that the observable of interest was computed from can be rapidly
+  re-evaluated by only re-computing the energy terms which have changed upon perturbing the parameters (see the
+  |openmm_gradient_potentials| protocol).
+
+References
+----------
+
+.. bibliography:: gradients.bib
+    :cited:
+    :style: unsrt

--- a/docs/properties/properties.bib
+++ b/docs/properties/properties.bib
@@ -1,0 +1,30 @@
+@article{2002:glattli,
+  title={Derivation of an improved simple point charge model for liquid water: SPC/A and SPC/L},
+  author={Gl{\"a}ttli, Alice and Daura, Xavier and van Gunsteren, Wilfred F},
+  journal={The Journal of chemical physics},
+  volume={116},
+  number={22},
+  pages={9811--9828},
+  year={2002},
+  publisher={American Institute of Physics}
+}
+@article{2011:wang,
+  title={Application of molecular dynamics simulations in molecular property prediction. 1. Density and heat of vaporization},
+  author={Wang, Junmei and Hou, Tingjun},
+  journal={Journal of chemical theory and computation},
+  volume={7},
+  number={7},
+  pages={2151--2165},
+  year={2011},
+  publisher={ACS Publications}
+}
+@article{2015:beauchamp,
+  title={Toward automated benchmarking of atomistic force fields: neat liquid densities and static dielectric constants from the ThermoML data archive},
+  author={Beauchamp, Kyle A and Behr, Julie M and Rustenburg, Ari{\"e}n S and Bayly, Christopher I and Kroenlein, Kenneth and Chodera, John D},
+  journal={The Journal of Physical Chemistry B},
+  volume={119},
+  number={40},
+  pages={12912--12920},
+  year={2015},
+  publisher={ACS Publications}
+}

--- a/docs/properties/properties.rst
+++ b/docs/properties/properties.rst
@@ -1,0 +1,258 @@
+.. |extract_average_statistic|    replace:: :py:class:`~openff.evaluator.protocols.analysis.ExtractAverageStatistic`
+
+.. |reweight_statistics|          replace:: :py:class:`~openff.evaluator.protocols.reweighting.ReweightStatistics`
+
+.. |add_values|                   replace:: :py:class:`~openff.evaluator.protocols.miscellaneous.AddValues`
+.. |subtract_values|              replace:: :py:class:`~openff.evaluator.protocols.miscellaneous.SubtractValues`
+.. |divide_value|                 replace:: :py:class:`~openff.evaluator.protocols.miscellaneous.DivideValue`
+.. |weight_by_mole_fraction|      replace:: :py:class:`~openff.evaluator.protocols.miscellaneous.WeightByMoleFraction`
+
+.. |extract_average_dielectric|   replace:: :py:class:`~openff.evaluator.properties.dielectric.ExtractAverageDielectric`
+.. |reweight_dielectric_constant| replace:: :py:class:`~openff.evaluator.properties.dielectric.ReweightDielectricConstant`
+
+.. |simulation_layer|    replace:: :doc:`Direct Simulation <../layers/simulationlayer>`
+.. |reweighting_layer|   replace:: :doc:`MBAR Reweighting <../layers/reweightinglayer>`
+
+Physical Properties
+===================
+
+A core philosophy of this framework is that users should be able to seamlessly curate data sets of physical properties
+and then estimate that data set using computational methods without significant user intervention and using sensible,
+well validated workflows.
+
+This page aims to provide an overview of which physical properties are supported by the framework and how they
+are computed using the different :doc:`calculation layers <../layers/calculationlayers>`.
+
+In this document :math:`\left<X\right>` will be used to denote the ensemble average of an observable :math:`X`.
+
+Density
+"""""""
+
+The density (:math:`\rho`) is computed according to
+
+.. math::
+
+    \rho = \left<\dfrac{M}{V}\right>
+
+where :math:`M` and :math:`V` are the total molar mass and volume the system respectively.
+
+|simulation_layer|
+*******************
+
+The density is estimated using the default :ref:`simulation workflow <properties/commonworkflows:|simulation_layer|>` without
+modification. The estimation of liquid densities is assumed.
+
+|reweighting_layer|
+*******************
+
+The density is estimated using the default :ref:`reweighting workflow <properties/commonworkflows:|reweighting_layer|>` without
+modification. The estimation of liquid densities is assumed.
+
+Dielectric Constant
+"""""""""""""""""""
+
+The dielectric constant (:math:`\varepsilon`) can be computed from fluctuations in a systems dipole moment (see Equation
+7 of :cite:`2002:glattli`) according to:
+
+.. math::
+
+    \varepsilon = 1 + \dfrac{\left<\vec{\mu}^2\right> - \left<\vec{\mu}\right>^2} {3\varepsilon_0\left<V\right>k_bT}
+
+where :math:`\vec{\mu}`, :math:`V` are the systems dipole moment and volume respectively, :math:`k_b` the Boltzmann
+constant, :math:`T` the temperature, and :math:`\varepsilon_0` the permittivity of free space.
+
+The framework currently computes :math:`\varepsilon` according to
+
+.. math::
+
+    \varepsilon = 1 + \dfrac{\left<{\left(\vec{\mu} - \left<\vec{\mu}\right>\right)}^2\right>} {3\varepsilon_0\left<V\right>k_bT}
+
+making use of the fact that
+
+.. math::
+
+    \left<\vec{\mu}^2\right> - \left<\vec{\mu}\right>^2 = \left<{\left(\vec{\mu} - \left<\vec{\mu}\right>\right)}^2\right>
+
+in order to match the `mdtraj <http://mdtraj.org/>`_ implementation which has been used in previous studies by the
+OpenFF Consortium (see for example :cite:`2015:beauchamp`).
+
+|simulation_layer|
+******************
+
+The dielectric is estimated using the default :ref:`simulation workflow <properties/commonworkflows:|simulation_layer|>`
+which has been modified to use the specialized |extract_average_dielectric| protocol in place of the default |extract_average_statistic|.
+The estimation of liquid dielectric constants is assumed.
+
+|reweighting_layer|
+*******************
+
+The dielectric is estimated using the default :ref:`reweighting workflow <properties/commonworkflows:|reweighting_layer|>`
+which has been modified to use the specialized |reweight_dielectric_constant| protocol in place of the default |reweight_statistics|.
+The estimation of liquid dielectric constants is assumed.
+
+Enthalpy of Vaporization
+""""""""""""""""""""""""
+
+The enthalpy of vaporization :math:`\Delta H_{vap}` (see :cite:`2011:wang`) can be computed according to
+
+.. math::
+
+    \Delta H_{vap} = \left<H_{gas}\right> - \left<H_{liquid}\right> = \left<E_{gas}\right> - \left<E_{liquid}\right> + p\left(\left<V_{gas}\right>-\left<V_{liquid}\right>\right)
+
+where :math:`H`, :math:`E`, and :math:`V` are the enthalpy, total energy and volume respectively.
+
+Under the assumtion that :math:`V_{gas} >> V_{liquid}` and that the gas is ideal the above expression can be simplified
+to
+
+.. math::
+
+    \Delta H_{vap} = \left<U_{gas}\right> - \left<U_{liquid}\right> + RT
+
+where :math:`U` is the potential energy, :math:`T` the temperature and :math:`R` the universal gas constant. This
+simplified expression is computed by default by this framework.
+
+|simulation_layer|
+******************
+
+.. rst-class:: spaced-list
+
+    - **Liquid phase**: The potential energy of the liquid phase is estimated using the default :ref:`simulation workflow <properties/commonworkflows:|simulation_layer|>`,
+      and divided by the number of molecules in the simulation box using the ``divisor`` input of the
+      |extract_average_statistic| protocol.
+
+    - **Gas phase**: The potential energy of the gas phase is estimated using the default :ref:`simulation workflow <properties/commonworkflows:|simulation_layer|>`,
+      which has been modified so that
+
+        - the simulation box only contains a single molecule.
+        - all periodic boundary conditions have been disabled.
+        - all simulations are performed in the NVT ensemble.
+        - the production simulation is run for 15000000 steps at a time (rather than 1000000 steps).
+        - all simulations are run using the OpenMM reference platform (CPU only) regardless of whether a GPU is
+          available. This is fastest platform to use when simulating a single molecule in vacuum with OpenMM.
+
+The final enthalpy is then computed by subtracting the gas potential energy from the liquid potential energy
+(|subtract_values|) and adding the :math:`RT` term (|add_values|).
+
+|reweighting_layer|
+*******************
+
+.. rst-class:: spaced-list
+
+    - **Liquid phase**: The potential energy of the liquid phase is estimated using the default :ref:`reweighting workflow <properties/commonworkflows:|reweighting_layer|>`,
+      and divided by the number of molecules in the simulation box using an extra |divide_value| protocol.
+
+    - **Gas phase**: The potential energy of the gas phase is estimated using the default :ref:`reweighting workflow <properties/commonworkflows:|reweighting_layer|>`,
+      which has been modified so that all periodic boundary conditions have been disabled.
+
+The final enthalpy is then computed by subtracting the gas potential energy from the liquid potential energy
+(|subtract_values|) and adding the :math:`RT` term (|add_values|).
+
+
+Enthalpy of Mixing
+""""""""""""""""""
+
+The enthalpy of mixing :math:`\Delta H_{mix}\left(x_0, \cdots, x_{M-1}\right)` for a system of :math:`M` components
+is computed according to
+
+.. math::
+
+    \Delta H_{mix}\left(x_0, \cdots, x_{M-1}\right) = \dfrac{\left<H_{mix}\right>}{N_{mix}} - \sum_i^M x_i \dfrac{\left<H_i\right>}{N_i}
+
+where :math:`H_{mix}` is the enthalpy of the full mixture, and :math:`H_i`, :math:`x_i` are the enthalpy and the mole
+fraction of component :math:`i` respectively. :math:`N_{mix}` and :math:`N_i` are the total number of molecules used in
+the full mixture simulations and the simulations of each individual component respectively.
+
+|simulation_layer|
+******************
+
+.. rst-class:: spaced-list
+
+    - **Mixture**: The enthalpy of the full mixture is estimated using the default :ref:`simulation workflow <properties/commonworkflows:|simulation_layer|>`
+      and divided by the number of molecules in the simulation box using the ``divisor`` input of the
+      |extract_average_statistic| protocol.
+
+    - **Components**: The enthalpy of each of the components is estimated using the default :ref:`simulation workflow <properties/commonworkflows:|simulation_layer|>`,
+      divided by the number of molecules in the simulation box using the ``divisor`` input of the
+      |extract_average_statistic| protocol, and weighted by their mole fraction *in the mixture simulation box* using
+      the |weight_by_mole_fraction| protocol.
+
+The final enthalpy is then computed by summing the component enthalpies (|add_values|) and subtracting these from
+the mixture enthalpy (|subtract_values|).
+
+|reweighting_layer|
+*******************
+
+.. rst-class:: spaced-list
+
+    - **Mixture**: The enthalpy of the full mixture is estimated using the default :ref:`reweighting workflow <properties/commonworkflows:|reweighting_layer|>`
+      and divided by the number of molecules in the reweighting box using an extra |divide_value| protocol.
+
+    - **Components**: The enthalpy of each of the components is estimated using the default :ref:`reweighting workflow <properties/commonworkflows:|reweighting_layer|>`,
+      divided by the number of molecules in the reweighting box using an extra |divide_value| protocol, and weighted by
+      their mole fraction using the |weight_by_mole_fraction| protocol.
+
+The final enthalpy is then computed by summing the component enthalpies (|add_values|) and subtracting these from
+the mixture enthalpy (|subtract_values|).
+
+Excess Molar Volume
+"""""""""""""""""""
+
+The excess molar volume :math:`\Delta V_{excess}\left(x_0, \cdots, x_{M-1}\right)` for a system of :math:`M` components
+is computed according to
+
+.. math::
+
+    \Delta V_{excess}\left(x_0, \cdots, x_{M-1}\right) = N_A \left( \dfrac{\left<V_{mix}\right>}{N_{mix}} - \sum_i^M x_i \dfrac{\left<V_i\right>}{N_i} \right)
+
+where :math:`V_{mix}` is the volume of the full mixture, and :math:`V_i`, :math:`x_i` are the volume and the mole
+fraction of component :math:`i` respectively. :math:`N_{mix}` and :math:`N_i` are the total number of molecules used in
+the full mixture simulations and the simulations of each individual component respectively, and :math:`N_A` is the
+Avogadro constant.
+
+|simulation_layer|
+******************
+
+.. rst-class:: spaced-list
+
+    - **Mixture**: The molar volume of the full mixture is estimated using the default :ref:`simulation workflow <properties/commonworkflows:|simulation_layer|>`
+      and divided by the molar number of molecules in the simulation box using the ``divisor`` input of the
+      |extract_average_statistic| protocol.
+
+    - **Components**: The molar volume of each of the components is estimated using the default :ref:`simulation workflow <properties/commonworkflows:|simulation_layer|>`,
+      divided by the molar number of molecules in the simulation box using the ``divisor`` input of the
+      |extract_average_statistic| protocol, and weighted by their mole fraction *in the mixture simulation box* using
+      the |weight_by_mole_fraction| protocol.
+
+The final excess molar volume is then computed by summing the component molar volumes (|add_values|) and subtracting these from
+the mixture molar volume (|subtract_values|).
+
+|reweighting_layer|
+*******************
+
+.. rst-class:: spaced-list
+
+    - **Mixture**: The enthalpy of the full mixture is estimated using the default :ref:`reweighting workflow <properties/commonworkflows:|reweighting_layer|>`
+      and divided by the molar number of molecules in the reweighting box using an extra |divide_value| protocol.
+
+    - **Components**: The enthalpy of each of the components is estimated using the default :ref:`reweighting workflow <properties/commonworkflows:|reweighting_layer|>`,
+      divided by the molar number of molecules in the reweighting box using an extra |divide_value| protocol, and weighted by
+      their mole fraction using the |weight_by_mole_fraction| protocol.
+
+The final enthalpy is then computed by summing the component enthalpies (|add_values|) and subtracting these from
+the mixture enthalpy (|subtract_values|).
+
+Solvation Free Energies
+"""""""""""""""""""""""
+
+Solvation free energies are currently computed using the `Yank <http://getyank.org/>`_ free energy package using direct
+molecular simulations. By default the calculations attempt to use 2000 solvent molecules, and the alchemical lambda
+spacings are selected using the built-in 'trailblazing' algorithm.
+
+See the Yank documentation for more details.
+
+References
+----------
+
+.. bibliography:: properties.bib
+    :cited:
+    :style: unsrt

--- a/docs/properties/properties.rst
+++ b/docs/properties/properties.rst
@@ -88,7 +88,9 @@ The estimation of liquid dielectric constants is assumed.
 
 The dielectric is estimated using the default :ref:`reweighting workflow <properties/commonworkflows:|reweighting_layer|>`
 which has been modified to use the specialized |reweight_dielectric_constant| protocol in place of the default |reweight_statistics|.
-The estimation of liquid dielectric constants is assumed.
+It should be noted that the |reweight_dielectric_constant| protocol employs bootstrapping to compute the uncertainty in
+the average dielectric constant, rather than attempting to propagate uncertainties in the average dipole moments and
+volumes. The estimation of liquid dielectric constants is assumed.
 
 Enthalpy of Vaporization
 """"""""""""""""""""""""
@@ -131,7 +133,8 @@ simplified expression is computed by default by this framework.
           available. This is fastest platform to use when simulating a single molecule in vacuum with OpenMM.
 
 The final enthalpy is then computed by subtracting the gas potential energy from the liquid potential energy
-(|subtract_values|) and adding the :math:`RT` term (|add_values|).
+(|subtract_values|) and adding the :math:`RT` term (|add_values|). Uncertainties are propagated through the subtraction
+by the normal means using the `uncertainties <https://pythonhosted.org/uncertainties/>`_ package.
 
 |reweighting_layer|
 *******************
@@ -145,8 +148,8 @@ The final enthalpy is then computed by subtracting the gas potential energy from
       which has been modified so that all periodic boundary conditions have been disabled.
 
 The final enthalpy is then computed by subtracting the gas potential energy from the liquid potential energy
-(|subtract_values|) and adding the :math:`RT` term (|add_values|).
-
+(|subtract_values|) and adding the :math:`RT` term (|add_values|). Uncertainties are propagated through the subtraction
+by the normal means using the `uncertainties <https://pythonhosted.org/uncertainties/>`_ package.
 
 Enthalpy of Mixing
 """"""""""""""""""
@@ -177,7 +180,8 @@ the full mixture simulations and the simulations of each individual component re
       the |weight_by_mole_fraction| protocol.
 
 The final enthalpy is then computed by summing the component enthalpies (|add_values|) and subtracting these from
-the mixture enthalpy (|subtract_values|).
+the mixture enthalpy (|subtract_values|). Uncertainties are propagated through the summation and subtraction by the
+normal means using the `uncertainties <https://pythonhosted.org/uncertainties/>`_ package.
 
 |reweighting_layer|
 *******************
@@ -192,7 +196,8 @@ the mixture enthalpy (|subtract_values|).
       their mole fraction using the |weight_by_mole_fraction| protocol.
 
 The final enthalpy is then computed by summing the component enthalpies (|add_values|) and subtracting these from
-the mixture enthalpy (|subtract_values|).
+the mixture enthalpy (|subtract_values|). Uncertainties are propagated through the summation and subtraction by the
+normal means using the `uncertainties <https://pythonhosted.org/uncertainties/>`_ package.
 
 Excess Molar Volume
 """""""""""""""""""
@@ -224,7 +229,8 @@ Avogadro constant.
       the |weight_by_mole_fraction| protocol.
 
 The final excess molar volume is then computed by summing the component molar volumes (|add_values|) and subtracting these from
-the mixture molar volume (|subtract_values|).
+the mixture molar volume (|subtract_values|). Uncertainties are propagated through the summation and subtraction by the
+normal means using the `uncertainties <https://pythonhosted.org/uncertainties/>`_ package.
 
 |reweighting_layer|
 *******************
@@ -239,7 +245,8 @@ the mixture molar volume (|subtract_values|).
       their mole fraction using the |weight_by_mole_fraction| protocol.
 
 The final enthalpy is then computed by summing the component enthalpies (|add_values|) and subtracting these from
-the mixture enthalpy (|subtract_values|).
+the mixture enthalpy (|subtract_values|). Uncertainties are propagated through the summation and subtraction by the
+normal means using the `uncertainties <https://pythonhosted.org/uncertainties/>`_ package.
 
 Solvation Free Energies
 """""""""""""""""""""""

--- a/openff/evaluator/protocols/openmm.py
+++ b/openff/evaluator/protocols/openmm.py
@@ -93,6 +93,17 @@ class OpenMMEnergyMinimisation(BaseEnergyMinimisation):
 class OpenMMSimulation(BaseSimulation):
     """Performs a molecular dynamics simulation in a given ensemble using
     an OpenMM backend.
+
+    This protocol employs the Langevin integrator implemented in the ``openmmtools``
+    package to propagate the state of the system using the default BAOAB splitting [1]_.
+    Further, simulations which are run in the NPT simulation will have a Monte Carlo
+    barostat (simtk.openmm.MonteCarloBarostat) applied every 25 steps (the OpenMM
+    default).
+
+    References
+    ----------
+    [1] Leimkuhler, Ben, and Charles Matthews. "Numerical methods for stochastic
+        molecular dynamics." Molecular Dynamics. Springer, Cham, 2015. 261-328.
     """
 
     class _Checkpoint:


### PR DESCRIPTION
## Description
This PR adds an initial set of documentation which outlines how each of the supported physical properties are estimated by the framework.

These changes have been [rendered on read the docs here](https://openff-evaluator.readthedocs.io/en/property-documentation/properties/properties.html).

This PR closes #16.

## Status
- [x] Ready to go