### PR TITLE
Use Merged Protocols in Workflow Provenance

### DIFF
--- a/openff/evaluator/layers/workflow.py
+++ b/openff/evaluator/layers/workflow.py
@@ -150,12 +150,14 @@ class WorkflowCalculationLayer(CalculationLayer, abc.ABC):
             workflow.schema = schema.workflow_schema
             workflows.append(workflow)
 
-            provenance[physical_property.id] = CalculationSource(
-                fidelity=cls.__name__, provenance=workflow.schema
-            )
-
         workflow_graph = WorkflowGraph()
         workflow_graph.add_workflows(*workflows)
+
+        for workflow in workflows:
+
+            provenance[workflow.uuid] = CalculationSource(
+                fidelity=cls.__name__, provenance=workflow.schema
+            )
 
         return workflow_graph, provenance
 


### PR DESCRIPTION
## Description
This PR fixes a bug introduced in a previous version whereby the workflow provenance included the original set of protocols and not protocols actually used in the computation (i.e. those present after merging all redundant calculations).

## Status
- [x] Ready to go