### PR TITLE
Fix Merging of Nested Protocol Inputs

### DIFF
--- a/openff/evaluator/workflow/protocols.py
+++ b/openff/evaluator/workflow/protocols.py
@@ -393,7 +393,7 @@ class Protocol(AttributeClass, abc.ABC, metaclass=ProtocolMeta):
                 # We cannot safely choose which value to take when the
                 # values are not know ahead of time unless the two values
                 # come from the exact same source.
-                if self_value.protocol_path != other_value_post_merge.protocol_path:
+                if self_value.full_path != other_value_post_merge.full_path:
                     return False
 
             elif isinstance(self_value, PlaceholderValue) and isinstance(


### PR DESCRIPTION
## Description
This PR fixes a bug whereby only protocol id's were compared when considering whether two protocols could be merged based on a given attribute, rather than also including the exact protocol output attribute being taken as input. This lead to non-compatible protocols being merged when an input came from a nested output of a protocol (i.e. two protocols which used as input two different list items from a protocol output)

This bug does not appear to have affected any of the built-in estimation workflows.

## Status
- [X] Ready to go