### PR TITLE
[GRADIENTS] Add Parameterised System Placeholder

### DIFF
--- a/openff/evaluator/forcefield/system.py
+++ b/openff/evaluator/forcefield/system.py
@@ -1,0 +1,89 @@
+from typing import TYPE_CHECKING
+
+from openff.evaluator.forcefield import ForceFieldSource
+from openff.evaluator.substances import Substance
+from openff.evaluator.utils.serialization import TypedBaseModel
+
+if TYPE_CHECKING:
+
+    from openforcefield.topology import Topology
+    from simtk.openmm import System
+
+
+class ParameterizedSystem(TypedBaseModel):
+    """An object model which stores information about a parameterized system,
+    including the composition of the system, the original force field source, a
+    path to the topology and a path to the parameterized system object."""
+
+    @property
+    def substance(self) -> Substance:
+        return self._substance
+
+    @property
+    def force_field(self) -> ForceFieldSource:
+        return self._force_field
+
+    @property
+    def topology_path(self) -> str:
+        return self._topology_path
+
+    @property
+    def topology(self) -> "Topology":
+
+        from openforcefield.topology import Molecule, Topology
+        from simtk.openmm import app
+
+        pdb_file = app.PDBFile(self._topology_path)
+
+        topology = Topology.from_openmm(
+            pdb_file.topology,
+            unique_molecules=[
+                Molecule.from_smiles(smiles=component.smiles)
+                for component in self._substance.components
+            ],
+        )
+
+        return topology
+
+    @property
+    def system_path(self) -> str:
+        return self._system_path
+
+    @property
+    def system(self) -> "System":
+        from simtk import openmm
+
+        with open(self._system_path) as file:
+            system = openmm.XmlSerializer.deserialize(file.read())
+
+        return system
+
+    def __init__(
+        self,
+        substance: Substance = None,
+        force_field: ForceFieldSource = None,
+        topology_path: str = None,
+        system_path: str = None,
+    ):
+
+        self._substance = substance
+        self._force_field = force_field
+
+        self._topology_path = topology_path
+        self._system_path = system_path
+
+    def __getstate__(self):
+
+        return {
+            "substance": self._substance,
+            "force_field": self._force_field,
+            "topology_path": self._topology_path,
+            "system_path": self._system_path,
+        }
+
+    def __setstate__(self, state):
+
+        self._substance = state["substance"]
+        self._force_field = state["force_field"]
+        self._topology_path = state["topology_path"]
+        self._system_path = state["system_path"]

--- a/openff/evaluator/protocols/openmm.py
+++ b/openff/evaluator/protocols/openmm.py
@@ -46,9 +46,7 @@ class OpenMMEnergyMinimisation(BaseEnergyMinimisation):
         platform = setup_platform_with_resources(available_resources)
 
         input_pdb_file = app.PDBFile(self.input_coordinate_file)
-
-        with open(self.system_path, "rb") as file:
-            system = openmm.XmlSerializer.deserialize(file.read().decode())
+        system = self.parameterized_system.system
 
         if not self.enable_pbc:
 
@@ -253,9 +251,8 @@ class OpenMMSimulation(BaseSimulation):
             available_resources, self.high_precision
         )
 
-        # Load in the system object from the provided xml file.
-        with open(self.system_path, "r") as file:
-            system = XmlSerializer.deserialize(file.read())
+        # Load in the system object.
+        system = self.parameterized_system.system
 
         # Disable the periodic boundary conditions if requested.
         if not self.enable_pbc:
@@ -623,10 +620,7 @@ class OpenMMSimulation(BaseSimulation):
         # Create the object which will transfer simulation output to the
         # reporters.
         topology = app.PDBFile(self.input_coordinate_file).topology
-
-        with open(self.system_path, "r") as file:
-            system = openmm.XmlSerializer.deserialize(file.read())
-
+        system = self.parameterized_system.system
         simulation = self._Simulation(integrator, topology, system, current_step)
 
         # Perform the simulation.
@@ -688,6 +682,7 @@ class OpenMMReducedPotentials(BaseReducedPotentials):
         import mdtraj
         import openmmtools
 
+        # Load in the inputs.
         trajectory = mdtraj.load_dcd(
             self.trajectory_file_path, self.coordinate_file_path
         )

--- a/openff/evaluator/protocols/reweighting.py
+++ b/openff/evaluator/protocols/reweighting.py
@@ -12,6 +12,7 @@ from scipy.special import logsumexp
 
 from openff.evaluator import unit
 from openff.evaluator.attributes import UNDEFINED
+from openff.evaluator.forcefield.system import ParameterizedSystem
 from openff.evaluator.thermodynamics import ThermodynamicState
 from openff.evaluator.utils.statistics import ObservableType, StatisticsArray, bootstrap
 from openff.evaluator.workflow import Protocol, workflow_protocol
@@ -127,10 +128,10 @@ class BaseReducedPotentials(Protocol, abc.ABC):
         default_value=UNDEFINED,
     )
 
-    system_path = InputAttribute(
-        docstring="The path to the system object which describes the systems "
-        "potential energy function.",
-        type_hint=str,
+    parameterized_system = InputAttribute(
+        docstring="The parameterized system object which encodes the systems potential "
+        "energy function.",
+        type_hint=ParameterizedSystem,
         default_value=UNDEFINED,
     )
     enable_pbc = InputAttribute(
@@ -139,12 +140,6 @@ class BaseReducedPotentials(Protocol, abc.ABC):
         default_value=True,
     )
 
-    coordinate_file_path = InputAttribute(
-        docstring="The path to the coordinate file which contains topology "
-        "information about the system.",
-        type_hint=str,
-        default_value=UNDEFINED,
-    )
     trajectory_file_path = InputAttribute(
         docstring="The path to the trajectory file which contains the "
         "configurations to calculate the energies of.",

--- a/openff/evaluator/protocols/simulation.py
+++ b/openff/evaluator/protocols/simulation.py
@@ -9,6 +9,7 @@ import pint
 
 from openff.evaluator import unit
 from openff.evaluator.attributes import UNDEFINED
+from openff.evaluator.forcefield.system import ParameterizedSystem
 from openff.evaluator.thermodynamics import Ensemble, ThermodynamicState
 from openff.evaluator.workflow import Protocol, workflow_protocol
 from openff.evaluator.workflow.attributes import (
@@ -27,10 +28,10 @@ class BaseEnergyMinimisation(Protocol, abc.ABC):
     input_coordinate_file = InputAttribute(
         docstring="The coordinates to minimise.", type_hint=str, default_value=UNDEFINED
     )
-    system_path = InputAttribute(
-        docstring="The path to the XML system object which defines the forces present "
-        "in the system.",
-        type_hint=str,
+    parameterized_system = InputAttribute(
+        docstring="The parameterized system object which encodes the systems potential "
+        "energy function.",
+        type_hint=ParameterizedSystem,
         default_value=UNDEFINED,
     )
 
@@ -131,10 +132,10 @@ class BaseSimulation(Protocol, abc.ABC):
         type_hint=str,
         default_value=UNDEFINED,
     )
-    system_path = InputAttribute(
-        docstring="A path to the XML system object which defines the forces present "
-        "in the system.",
-        type_hint=str,
+    parameterized_system = InputAttribute(
+        docstring="The parameterized system object which encodes the systems potential "
+        "energy function.",
+        type_hint=ParameterizedSystem,
         default_value=UNDEFINED,
     )
 

--- a/openff/evaluator/protocols/utils.py
+++ b/openff/evaluator/protocols/utils.py
@@ -178,8 +178,8 @@ def generate_base_reweighting_protocols(
     reduced_reference_potential = openmm.OpenMMReducedPotentials(
         "reduced_potential{}".format(replicator_suffix)
     )
-    reduced_reference_potential.system_path = ProtocolPath(
-        "system_path", build_reference_system.id
+    reduced_reference_potential.parameterized_system = ProtocolPath(
+        "parameterized_system", build_reference_system.id
     )
     reduced_reference_potential.thermodynamic_state = ProtocolPath(
         "thermodynamic_state", unpack_stored_data.id
@@ -208,8 +208,8 @@ def generate_base_reweighting_protocols(
     reduced_target_potential.thermodynamic_state = ProtocolPath(
         "thermodynamic_state", "global"
     )
-    reduced_target_potential.system_path = ProtocolPath(
-        "system_path", build_target_system.id
+    reduced_target_potential.parameterized_system = ProtocolPath(
+        "parameterized_system", build_target_system.id
     )
     reduced_target_potential.coordinate_file_path = ProtocolPath(
         "output_coordinate_path", join_trajectories.id
@@ -364,7 +364,9 @@ def generate_base_simulation_protocols(
     energy_minimisation.input_coordinate_file = ProtocolPath(
         "coordinate_file_path", build_coordinates.id
     )
-    energy_minimisation.system_path = ProtocolPath("system_path", assign_parameters.id)
+    energy_minimisation.parameterized_system = ProtocolPath(
+        "parameterized_system", assign_parameters.id
+    )
 
     equilibration_simulation = openmm.OpenMMSimulation(
         f"equilibration_simulation{id_suffix}"
@@ -379,8 +381,8 @@ def generate_base_simulation_protocols(
     equilibration_simulation.input_coordinate_file = ProtocolPath(
         "output_coordinate_file", energy_minimisation.id
     )
-    equilibration_simulation.system_path = ProtocolPath(
-        "system_path", assign_parameters.id
+    equilibration_simulation.parameterized_system = ProtocolPath(
+        "parameterized_system", assign_parameters.id
     )
 
     # Production
@@ -395,8 +397,11 @@ def generate_base_simulation_protocols(
     production_simulation.input_coordinate_file = ProtocolPath(
         "output_coordinate_file", equilibration_simulation.id
     )
-    production_simulation.system_path = ProtocolPath(
-        "system_path", assign_parameters.id
+    production_simulation.parameterized_system = ProtocolPath(
+        "parameterized_system", assign_parameters.id
+    )
+    production_simulation.gradient_parameters = ProtocolPath(
+        "parameter_gradient_keys", "global"
     )
 
     # Set up a conditional group to ensure convergence of uncertainty

--- a/openff/evaluator/protocols/yank.py
+++ b/openff/evaluator/protocols/yank.py
@@ -15,6 +15,7 @@ import yaml
 from openff.evaluator import unit
 from openff.evaluator.attributes import UNDEFINED
 from openff.evaluator.forcefield import SmirnoffForceFieldSource
+from openff.evaluator.forcefield.system import ParameterizedSystem
 from openff.evaluator.substances import Component, Substance
 from openff.evaluator.thermodynamics import ThermodynamicState
 from openff.evaluator.utils.openmm import (
@@ -526,8 +527,8 @@ class LigandReceptorYankProtocol(BaseYankProtocol):
         default_value=UNDEFINED,
     )
     solvated_ligand_system = InputAttribute(
-        docstring="The file path to the solvated ligand system object.",
-        type_hint=str,
+        docstring="The parameterized solvated ligand system object.",
+        type_hint=ParameterizedSystem,
         default_value=UNDEFINED,
     )
 
@@ -537,8 +538,8 @@ class LigandReceptorYankProtocol(BaseYankProtocol):
         default_value=UNDEFINED,
     )
     solvated_complex_system = InputAttribute(
-        docstring="The file path to the solvated complex system object.",
-        type_hint=str,
+        docstring="The parameterized solvated complex system object.",
+        type_hint=ParameterizedSystem,
         default_value=UNDEFINED,
     )
 
@@ -752,7 +753,7 @@ class LigandReceptorYankProtocol(BaseYankProtocol):
             os.path.join(directory, self._local_ligand_coordinates),
         )
         shutil.copyfile(
-            self.solvated_ligand_system,
+            self.solvated_ligand_system.system_path,
             os.path.join(directory, self._local_ligand_system),
         )
 
@@ -761,7 +762,7 @@ class LigandReceptorYankProtocol(BaseYankProtocol):
             os.path.join(directory, self._local_complex_coordinates),
         )
         shutil.copyfile(
-            self.solvated_complex_system,
+            self.solvated_complex_system.system_path,
             os.path.join(directory, self._local_complex_system),
         )
 
@@ -819,9 +820,9 @@ class SolvationYankProtocol(BaseYankProtocol):
         default_value=UNDEFINED,
     )
     solvent_1_system = InputAttribute(
-        docstring="The file path to the system object of the solute embedded in the "
+        docstring="The parameterized system object of the solute embedded in the "
         "first solvent.",
-        type_hint=str,
+        type_hint=ParameterizedSystem,
         default_value=UNDEFINED,
     )
 
@@ -832,9 +833,9 @@ class SolvationYankProtocol(BaseYankProtocol):
         default_value=UNDEFINED,
     )
     solvent_2_system = InputAttribute(
-        docstring="The file path to the system object of the solute embedded in the "
+        docstring="The parameterized system object of the solute embedded in the "
         "second solvent.",
-        type_hint=str,
+        type_hint=ParameterizedSystem,
         default_value=UNDEFINED,
     )
 
@@ -1028,7 +1029,8 @@ class SolvationYankProtocol(BaseYankProtocol):
             os.path.join(directory, self._local_solvent_1_coordinates),
         )
         shutil.copyfile(
-            self.solvent_1_system, os.path.join(directory, self._local_solvent_1_system)
+            self.solvent_1_system.system_path,
+            os.path.join(directory, self._local_solvent_1_system),
         )
 
         shutil.copyfile(
@@ -1036,7 +1038,8 @@ class SolvationYankProtocol(BaseYankProtocol):
             os.path.join(directory, self._local_solvent_2_coordinates),
         )
         shutil.copyfile(
-            self.solvent_2_system, os.path.join(directory, self._local_solvent_2_system)
+            self.solvent_2_system.system_path,
+            os.path.join(directory, self._local_solvent_2_system),
         )
 
         # Disable the pbc of the any solvents which should be treated

--- a/openff/evaluator/tests/test_protocols/test_forcefield.py
+++ b/openff/evaluator/tests/test_protocols/test_forcefield.py
@@ -38,8 +38,8 @@ def test_build_smirnoff_system():
         assign_parameters.force_field_path = force_field_path
         assign_parameters.coordinate_file_path = build_coordinates.coordinate_file_path
         assign_parameters.substance = substance
-        assign_parameters.execute(directory, None)
-        assert path.isfile(assign_parameters.system_path)
+        assign_parameters.execute(directory)
+        assert path.isfile(assign_parameters.parameterized_system.system_path)
 
 
 def test_build_tleap_system():
@@ -56,14 +56,14 @@ def test_build_tleap_system():
         build_coordinates = BuildCoordinatesPackmol("build_coordinates")
         build_coordinates.max_molecules = 9
         build_coordinates.substance = substance
-        build_coordinates.execute(directory, None)
+        build_coordinates.execute(directory)
 
         assign_parameters = BuildTLeapSystem("assign_parameters")
         assign_parameters.force_field_path = force_field_path
         assign_parameters.coordinate_file_path = build_coordinates.coordinate_file_path
         assign_parameters.substance = substance
-        assign_parameters.execute(directory, None)
-        assert path.isfile(assign_parameters.system_path)
+        assign_parameters.execute(directory)
+        assert path.isfile(assign_parameters.parameterized_system.system_path)
 
 
 def test_build_ligpargen_system(requests_mock):
@@ -156,11 +156,11 @@ phase2="3.141592653589793" phase3="0.00" phase4="3.141592653589793"/>
         build_coordinates = BuildCoordinatesPackmol("build_coordinates")
         build_coordinates.max_molecules = 8
         build_coordinates.substance = substance
-        build_coordinates.execute(directory, None)
+        build_coordinates.execute(directory)
 
         assign_parameters = BuildLigParGenSystem("assign_parameters")
         assign_parameters.force_field_path = force_field_path
         assign_parameters.coordinate_file_path = build_coordinates.coordinate_file_path
         assign_parameters.substance = substance
-        assign_parameters.execute(directory, None)
-        assert path.isfile(assign_parameters.system_path)
+        assign_parameters.execute(directory)
+        assert path.isfile(assign_parameters.parameterized_system.system_path)

--- a/openff/evaluator/tests/test_protocols/test_openmm.py
+++ b/openff/evaluator/tests/test_protocols/test_openmm.py
@@ -36,29 +36,32 @@ def _setup_dummy_system(directory):
     substance = Substance.from_components("C")
 
     build_coordinates = BuildCoordinatesPackmol("build_coordinates")
-    build_coordinates.max_molecules = 1
-    build_coordinates.mass_density = 0.001 * unit.grams / unit.milliliters
+    build_coordinates.max_molecules = 10
+    build_coordinates.mass_density = 0.05 * unit.grams / unit.milliliters
     build_coordinates.substance = substance
-    build_coordinates.execute(directory, None)
+    build_coordinates.execute(directory)
 
     assign_parameters = BuildSmirnoffSystem("assign_parameters")
     assign_parameters.force_field_path = force_field_path
     assign_parameters.coordinate_file_path = build_coordinates.coordinate_file_path
     assign_parameters.substance = substance
-    assign_parameters.execute(directory, None)
+    assign_parameters.execute(directory)
 
-    return build_coordinates.coordinate_file_path, assign_parameters.system_path
+    return (
+        build_coordinates.coordinate_file_path,
+        assign_parameters.parameterized_system,
+    )
 
 
 def test_run_energy_minimisation():
 
     with tempfile.TemporaryDirectory() as directory:
 
-        coordinate_path, system_path = _setup_dummy_system(directory)
+        coordinate_path, parameterized_system = _setup_dummy_system(directory)
 
         energy_minimisation = OpenMMEnergyMinimisation("energy_minimisation")
         energy_minimisation.input_coordinate_file = coordinate_path
-        energy_minimisation.system_path = system_path
+        energy_minimisation.parameterized_system = parameterized_system
         energy_minimisation.execute(directory, ComputeResources())
         assert path.isfile(energy_minimisation.output_coordinate_file)
 
@@ -69,14 +72,14 @@ def test_run_openmm_simulation():
 
     with tempfile.TemporaryDirectory() as directory:
 
-        coordinate_path, system_path = _setup_dummy_system(directory)
+        coordinate_path, parameterized_system = _setup_dummy_system(directory)
 
         npt_equilibration = OpenMMSimulation("npt_equilibration")
         npt_equilibration.steps_per_iteration = 2
         npt_equilibration.output_frequency = 1
         npt_equilibration.thermodynamic_state = thermodynamic_state
         npt_equilibration.input_coordinate_file = coordinate_path
-        npt_equilibration.system_path = system_path
+        npt_equilibration.parameterized_system = parameterized_system
         npt_equilibration.execute(directory, ComputeResources())
 
         assert path.isfile(npt_equilibration.output_coordinate_file)
@@ -92,7 +95,7 @@ def test_run_openmm_simulation_checkpoints():
 
     with tempfile.TemporaryDirectory() as directory:
 
-        coordinate_path, system_path = _setup_dummy_system(directory)
+        coordinate_path, parameterized_system = _setup_dummy_system(directory)
 
         # Check that executing twice doesn't run the simulation twice
         npt_equilibration = OpenMMSimulation("npt_equilibration")
@@ -101,7 +104,7 @@ def test_run_openmm_simulation_checkpoints():
         npt_equilibration.output_frequency = 1
         npt_equilibration.thermodynamic_state = thermodynamic_state
         npt_equilibration.input_coordinate_file = coordinate_path
-        npt_equilibration.system_path = system_path
+        npt_equilibration.parameterized_system = parameterized_system
 
         npt_equilibration.execute(directory, ComputeResources())
         assert os.path.isfile(npt_equilibration._checkpoint_path)
@@ -154,7 +157,7 @@ def test_gradient_reduced_potentials(use_subset):
 
     with tempfile.TemporaryDirectory() as directory:
 
-        force_field_path = path.join(directory, "ff.json")
+        coordinate_path, parameterized_system = _setup_dummy_system(directory)
 
         with open(force_field_path, "w") as file:
             file.write(build_tip3p_smirnoff_force_field().json())


### PR DESCRIPTION
## Description
This PR adds a new `ParameterizedSystem` object which encodes both a parameterized openmm `System` object, a the `ForceFieldSource` used to create it, the `Substance` which is parameterised and the path to a topology for the system.

This object reduces the amount of information which needs to be passed between objects by storing commonly accessed information in a single object.

This object is expected to be a placeholder until the OpenFF `System` object is ready for production use.

## Notes

- This PR will cause test failures for dielectric and solvation free energy workflows. This will be resolved in a separate PR.

## Status
- [X] Ready to go