### PR TITLE
Refactor timeseries Module

### DIFF
--- a/openff/evaluator/tests/test_utils/test_timeseries.py
+++ b/openff/evaluator/tests/test_utils/test_timeseries.py
@@ -3,35 +3,42 @@ Units tests for openff.evaluator.utils.statistics
 """
 
 import numpy as np
-from pymbar import timeseries as pymbar_timeseries
+from pymbar.timeseries import statisticalInefficiency
 
-from openff.evaluator.utils import timeseries
+from openff.evaluator.utils.timeseries import (
+    analyze_time_series,
+    get_uncorrelated_indices,
+)
 
 
-def test_statistical_inefficiency():
-    """Test the statistical inefficiency calculation utility."""
+def test_analyze_time_series_std():
+    """Test the ``analyze_time_series`` utility with flat data."""
 
-    data_size = 200000
+    statistics = analyze_time_series(np.ones(10))
 
-    random_array = np.random.rand(data_size)
-    numpy_vector_array = []
+    assert statistics.n_total_points == 10
+    assert statistics.n_uncorrelated_points == 1
+    assert np.isclose(statistics.statistical_inefficiency, 10.0)
+    assert statistics.equilibration_index == 0
 
-    for i in range(data_size):
-        numpy_vector_array.append([random_array[i]])
 
-    a = np.array(numpy_vector_array)
+def test_analyze_time_series():
+    """Compare the output of the ``analyze_time_series`` utility with ``pymbar``."""
 
-    statistical_inefficiency = timeseries.calculate_statistical_inefficiency(
-        a, minimum_samples=3
+    random_array = np.random.rand(10)
+
+    statistics = analyze_time_series(random_array, minimum_samples=3)
+    pymbar_statistical_inefficiency = statisticalInefficiency(random_array, mintime=3)
+
+    assert np.isclose(
+        statistics.statistical_inefficiency, pymbar_statistical_inefficiency
     )
-    pymbar_statistical_inefficiency = pymbar_timeseries.statisticalInefficiency(
-        a, mintime=3
-    )
+    assert statistics.n_total_points == 10
+    assert 0 < statistics.n_uncorrelated_points <= 10
+    assert 0 <= statistics.equilibration_index < 10
 
-    print(
-        "utils: {}, pymbar: {}",
-        statistical_inefficiency,
-        pymbar_statistical_inefficiency,
-    )
 
-    assert abs(statistical_inefficiency - pymbar_statistical_inefficiency) < 0.00001
+def test_get_uncorrelated_indices():
+
+    uncorrelated_indices = get_uncorrelated_indices(4, 2.0)
+    assert uncorrelated_indices == [0, 2]


### PR DESCRIPTION
## Description
This PR replaces the `decorrelate_time_series` utility function of the `timeseries` module with the more general `analyze_time_series`. The new method returns a self contained `TimeSeriesStatistics` object which includes all of the information previously returned by `decorrelate_time_series` in a readily serialisable form.

Further, this PR removes the unused `calculate_autocorrelation_time` and unnecessary `get_uncorrelated_stride` functions.

## Status
- [X] Ready to go