### PR TITLE
[GRADIENTS] Analysis Protocol Observables

### DIFF
--- a/openff/evaluator/protocols/analysis.py
+++ b/openff/evaluator/protocols/analysis.py
@@ -2,6 +2,7 @@
 A collection of protocols for running analysing the results of molecular simulations.
 """
 import abc
+import itertools
 import typing
 from os import path
 
@@ -10,9 +11,20 @@ import pint
 
 from openff.evaluator import unit
 from openff.evaluator.attributes import UNDEFINED
+from openff.evaluator.forcefield import ParameterGradient
 from openff.evaluator.thermodynamics import ThermodynamicState
-from openff.evaluator.utils import statistics, timeseries
-from openff.evaluator.utils.statistics import StatisticsArray, bootstrap
+from openff.evaluator.utils import timeseries
+from openff.evaluator.utils.observables import (
+    Observable,
+    ObservableArray,
+    ObservableFrame,
+    bootstrap,
+)
+from openff.evaluator.utils.timeseries import (
+    TimeSeriesStatistics,
+    analyze_time_series,
+    get_uncorrelated_indices,
+)
 from openff.evaluator.workflow import Protocol, workflow_protocol
 from openff.evaluator.workflow.attributes import (
     InequalityMergeBehaviour,
@@ -21,9 +33,9 @@ from openff.evaluator.workflow.attributes import (
 )
 
 
-class AveragePropertyProtocol(Protocol, abc.ABC):
+class BaseAverageObservable(Protocol, abc.ABC):
     """An abstract base class for protocols which will calculate the
-    average of a property and its uncertainty via bootstrapping.
+    average value of an observable and its uncertainty via bootstrapping.
     """
 
     bootstrap_iterations = InputAttribute(
@@ -39,163 +51,427 @@ class AveragePropertyProtocol(Protocol, abc.ABC):
         merge_behavior=InequalityMergeBehaviour.LargestValue,
     )
 
-    equilibration_index = OutputAttribute(
-        docstring="The index in the data set after which the data is stationary.",
-        type_hint=int,
+    thermodynamic_state = InputAttribute(
+        docstring="The state at which the observables were computed. This is required "
+        "to compute ensemble averages of the gradients of the observable with respect "
+        "to force field parameters.",
+        type_hint=ThermodynamicState,
+        default_value=UNDEFINED,
+        optional=True,
     )
-    statistical_inefficiency = OutputAttribute(
-        docstring="The statistical inefficiency in the data set.", type_hint=float
+    potential_energies = InputAttribute(
+        docstring="The potential energies which were evaluated at the same "
+        "configurations and using the same force field parameters as the observable to "
+        "average. This is required to compute ensemble averages of the gradients of "
+        "the observable with respect to force field parameters.",
+        type_hint=ObservableArray,
+        default_value=UNDEFINED,
+        optional=True,
     )
 
     value = OutputAttribute(
-        docstring="The average value and its uncertainty.", type_hint=pint.Measurement
-    )
-    uncorrelated_values = OutputAttribute(
-        docstring="The uncorrelated values which the average was calculated from.",
-        type_hint=pint.Quantity,
+        docstring="The average value of the observable.", type_hint=Observable
     )
 
-    def _bootstrap_function(self, **sample_kwargs):
+    time_series_statistics = OutputAttribute(
+        docstring="Statistics about the observables from which the average was computed."
+        "These include the statistical inefficiency and the index after which the "
+        "observables have become stationary (i.e. equilibrated).",
+        type_hint=TimeSeriesStatistics,
+    )
+
+    @abc.abstractmethod
+    def _observables(self) -> typing.Dict[str, ObservableArray]:
+        """A function which should return the observables to pass to the
+        ``_bootstrap_function`` function."""
+        raise NotImplementedError()
+
+    def _bootstrap_function(self, **kwargs: ObservableArray) -> Observable:
         """The function to perform on the data set being sampled by
         bootstrapping.
 
         Parameters
         ----------
-        sample_kwargs: dict of str and np.ndarray
-            A key words dictionary of the bootstrap sample data, where the
-            sample data is a numpy array of shape=(num_frames, num_dimensions)
-            with dtype=float.
+        observables
+            The bootstrap sample values.
 
         Returns
         -------
-        float
             The result of evaluating the data.
         """
 
-        assert len(sample_kwargs) == 1
-        sample_data = next(iter(sample_kwargs.values()))
+        # The simple base function only supports a single observable.
+        assert len(kwargs) == 1
 
-        return sample_data.mean()
+        # Compute the mean observable.
+        sample_observable = next(iter(kwargs.values()))
+        mean_observable = np.mean(sample_observable.value, axis=0)
 
+        if sample_observable.value.shape[1] > 1:
+            mean_observable = mean_observable.reshape(1, -1)
+        else:
+            mean_observable = mean_observable.item()
 
-class AverageTrajectoryProperty(AveragePropertyProtocol, abc.ABC):
-    """An abstract base class for protocols which will calculate the
-    average of a property from a simulation trajectory.
-    """
+        # Retrieve the potential gradients for easy access
+        potential_gradients = {
+            gradient.key: gradient.value
+            for gradient in (
+                []
+                if self.potential_energies == UNDEFINED
+                else self.potential_energies.gradients
+            )
+        }
+        observable_gradients = {
+            gradient.key: gradient for gradient in sample_observable.gradients
+        }
 
-    input_coordinate_file = InputAttribute(
-        docstring="The file path to the starting coordinates of a trajectory.",
-        type_hint=str,
-        default_value=UNDEFINED,
-    )
-    trajectory_path = InputAttribute(
-        docstring="The file path to the trajectory to average over.",
-        type_hint=str,
-        default_value=UNDEFINED,
-    )
+        # Compute the mean gradients.
+        gradients = []
+
+        for gradient_key in observable_gradients:
+
+            gradient = observable_gradients[gradient_key]
+
+            value = np.mean(gradient.value, axis=0) - self.thermodynamic_state.beta * (
+                np.mean(
+                    sample_observable.value * potential_gradients[gradient.key],
+                    axis=0,
+                )
+                - (
+                    np.mean(sample_observable.value, axis=0)
+                    * np.mean(potential_gradients[gradient.key], axis=0)
+                )
+            )
+
+            if sample_observable.value.shape[1] > 1:
+                value = value.reshape(1, -1)
+            else:
+                value = value.item()
+
+            gradients.append(ParameterGradient(key=gradient.key, value=value))
+
+        return_type = (
+            Observable if sample_observable.value.shape[1] == 1 else ObservableArray
+        )
+        return return_type(value=mean_observable, gradients=gradients)
+
+    def _execute(self, directory, available_resources):
+
+        # Retrieve the list of observables to compute the average using.
+        observables = self._observables()
+
+        if len(observables) == 0:
+            raise ValueError("There are no observables to average.")
+
+        expected_length = len(next(iter(observables.values())))
+
+        if not any(len(observable) != expected_length for observable in observables):
+            raise ValueError("The observables to average must have the same length.")
+
+        if (
+            self.potential_energies != UNDEFINED
+            and self.thermodynamic_state == UNDEFINED
+        ):
+            raise ValueError(
+                "The `thermodynamic_state` must be provided when the "
+                "`potential_energies` input is specified (i.e. when gradients should "
+                "be computed."
+            )
+
+        if self.potential_energies != UNDEFINED:
+
+            potential_gradients = {
+                gradient.key for gradient in self.potential_energies.gradients
+            }
+
+            if any(
+                {gradient.key for gradient in observable.gradients}
+                != potential_gradients
+                for observable in observables.values()
+            ):
+
+                raise ValueError(
+                    "The potential energies must have been differentiated with respect "
+                    "to the same force field parameters as the observables of interest."
+                )
+
+        # Find the largest equilibration time and statistical inefficiency for each of
+        # the observables.
+        equilibration_index = -1
+        statistical_inefficiency = 0.0
+
+        for observable in observables.values():
+
+            observable_statistics = analyze_time_series(observable.value.magnitude)
+
+            equilibration_index = max(
+                equilibration_index, observable_statistics.equilibration_index
+            )
+            statistical_inefficiency = max(
+                statistical_inefficiency, observable_statistics.statistical_inefficiency
+            )
+
+        equilibration_index = 0  # int(equilibration_index)
+        statistical_inefficiency = 1.0  # float(statistical_inefficiency)
+
+        uncorrelated_indices = get_uncorrelated_indices(
+            expected_length - equilibration_index, statistical_inefficiency
+        )
+
+        self.time_series_statistics = TimeSeriesStatistics(
+            n_total_points=expected_length,
+            n_uncorrelated_points=len(uncorrelated_indices),
+            statistical_inefficiency=statistical_inefficiency,
+            equilibration_index=equilibration_index,
+        )
+
+        # Decorrelate the observables.
+        uncorrelated_observables = {
+            key: observable.subset(
+                [index + equilibration_index for index in uncorrelated_indices]
+            )
+            for key, observable in observables.items()
+        }
+
+        if self.potential_energies != UNDEFINED:
+
+            self.potential_energies = self.potential_energies.subset(
+                [index + equilibration_index for index in uncorrelated_indices]
+            )
+
+        self.value = bootstrap(
+            self._bootstrap_function,
+            self.bootstrap_iterations,
+            self.bootstrap_sample_size,
+            **uncorrelated_observables,
+        )
 
 
 @workflow_protocol()
-class ExtractAverageStatistic(AveragePropertyProtocol):
-    """Extracts the average value from a statistics file which was generated
-    during a simulation.
+class AverageObservable(BaseAverageObservable):
+    """Computes the average value of an observable as well as bootstrapped
+    uncertainties for the average.
     """
 
-    statistics_path = InputAttribute(
-        docstring="The file path to the statistics to average over.",
-        type_hint=str,
+    observable = InputAttribute(
+        docstring="The file path to the observable which should be averaged.",
+        type_hint=ObservableArray,
         default_value=UNDEFINED,
     )
-    statistics_type = InputAttribute(
-        docstring="The type of statistic to average over.",
-        type_hint=statistics.ObservableType,
-        default_value=UNDEFINED,
-    )
-
     divisor = InputAttribute(
-        docstring="A value to divide the statistic by. This is useful if a statistic (such "
-        "as enthalpy) needs to be normalised by the number of molecules.",
+        docstring="A value to divide the statistic by. This is useful if a statistic "
+        "(such as enthalpy) needs to be normalised by the number of molecules.",
         type_hint=typing.Union[int, float, pint.Quantity],
         default_value=1.0,
     )
 
-    def __init__(self, protocol_id):
-
-        super().__init__(protocol_id)
-        self._statistics = None
-
-    def _execute(self, directory, available_resources):
-
-        self._statistics = statistics.StatisticsArray.from_pandas_csv(
-            self.statistics_path
-        )
-
-        if self.statistics_type not in self._statistics:
-
-            raise ValueError(
-                f"The {self.statistics_path} statistics file contains no "
-                f"data of type {self.statistics_type}."
-            )
-
-        values = self._statistics[self.statistics_type]
-
-        statistics_unit = values[0].units
-        unitless_values = values.to(statistics_unit).magnitude
-
-        divisor = self.divisor
-
-        if isinstance(self.divisor, pint.Quantity):
-            statistics_unit /= self.divisor.units
-            divisor = self.divisor.magnitude
-
-        unitless_values = np.array(unitless_values) / divisor
-
-        (
-            unitless_values,
-            self.equilibration_index,
-            self.statistical_inefficiency,
-        ) = timeseries.decorrelate_time_series(unitless_values)
-
-        final_value, final_uncertainty = bootstrap(
-            self._bootstrap_function,
-            self.bootstrap_iterations,
-            self.bootstrap_sample_size,
-            values=unitless_values,
-        )
-
-        self.uncorrelated_values = unitless_values * statistics_unit
-        self.value = (final_value * statistics_unit).plus_minus(
-            final_uncertainty * statistics_unit
-        )
-
-
-class ExtractUncorrelatedData(Protocol, abc.ABC):
-    """An abstract base class for protocols which will subsample
-    a data set, yielding only equilibrated, uncorrelated data.
-    """
-
-    equilibration_index = InputAttribute(
-        docstring="The index in the data set after which the data is stationary.",
-        type_hint=int,
-        default_value=UNDEFINED,
-        merge_behavior=InequalityMergeBehaviour.LargestValue,
-    )
-    statistical_inefficiency = InputAttribute(
-        docstring="The statistical inefficiency in the data set.",
-        type_hint=float,
-        default_value=UNDEFINED,
-        merge_behavior=InequalityMergeBehaviour.LargestValue,
-    )
-
-    number_of_uncorrelated_samples = OutputAttribute(
-        docstring="The number of uncorrelated samples.", type_hint=int
-    )
+    def _observables(self) -> typing.Dict[str, ObservableArray]:
+        return {"observable": self.observable / self.divisor}
 
 
 @workflow_protocol()
-class ExtractUncorrelatedTrajectoryData(ExtractUncorrelatedData):
-    """A protocol which will subsample frames from a trajectory, yielding only uncorrelated
-    frames as determined from a provided statistical inefficiency and equilibration time.
+class AverageFreeEnergies(Protocol):
+    """A protocol which computes the Boltzmann weighted average
+    (ΔG° = -RT × Log[ Σ_{n} exp(-βΔG°_{n}) ]) of a set of free
+    energies which were measured at the same thermodynamic state.
+    Confidence intervals are computed by bootstrapping with replacement.
+    """
+
+    values: typing.List[Observable] = InputAttribute(
+        docstring="The values to add together.", type_hint=list, default_value=UNDEFINED
+    )
+    thermodynamic_state = InputAttribute(
+        docstring="The thermodynamic state at which the free energies were measured.",
+        type_hint=ThermodynamicState,
+        default_value=UNDEFINED,
+    )
+
+    bootstrap_cycles = InputAttribute(
+        docstring="The number of bootstrap cycles to perform when estimating "
+        "the uncertainty in the combined free energies.",
+        type_hint=int,
+        default_value=2000,
+    )
+
+    result = OutputAttribute(docstring="The sum of the values.", type_hint=Observable)
+    confidence_intervals = OutputAttribute(
+        docstring="The 95% confidence intervals on the average free energy.",
+        type_hint=pint.Quantity,
+    )
+
+    def _execute(self, directory, available_resources):
+
+        from scipy.special import logsumexp
+
+        default_unit = unit.kilocalorie / unit.mole
+
+        boltzmann_factor = (
+            self.thermodynamic_state.temperature * unit.molar_gas_constant
+        )
+        boltzmann_factor.ito(default_unit)
+
+        beta = 1.0 / boltzmann_factor
+
+        values = [
+            (-beta * value.value.to(default_unit)).to(unit.dimensionless).magnitude
+            for value in self.values
+        ]
+
+        # Compute the mean.
+        mean = logsumexp(values)
+
+        # Compute the gradients of the mean.
+        value_gradients = [
+            {gradient.key: -beta * gradient.value for gradient in value.gradients}
+            for value in self.values
+        ]
+        value_gradients_by_key = {
+            gradient_key: [
+                gradients_by_key[gradient_key] for gradients_by_key in value_gradients
+            ]
+            for gradient_key in value_gradients[0]
+        }
+
+        mean_gradients = []
+
+        for gradient_key, gradient_values in value_gradients_by_key.items():
+
+            expected_unit = value_gradients[0][gradient_key].units
+
+            d_log_mean_numerator, d_mean_numerator_sign = logsumexp(
+                values,
+                b=[x.to(expected_unit).magnitude for x in gradient_values],
+                return_sign=True,
+            )
+            d_mean_numerator = d_mean_numerator_sign * np.exp(d_log_mean_numerator)
+
+            d_mean_d_theta = d_mean_numerator / np.exp(mean)
+
+            mean_gradients.append(
+                ParameterGradient(
+                    key=gradient_key,
+                    value=-boltzmann_factor * d_mean_d_theta * expected_unit,
+                )
+            )
+
+        # Compute the standard error and 95% CI
+        cycle_result = np.empty(self.bootstrap_cycles)
+
+        for cycle_index, cycle in enumerate(range(self.bootstrap_cycles)):
+
+            cycle_values = np.empty(len(self.values))
+
+            for value_index, value in enumerate(self.values):
+
+                cycle_mean = value.value.to(default_unit).magnitude
+                cycle_sem = value.error.to(default_unit).magnitude
+
+                sampled_value = np.random.normal(cycle_mean, cycle_sem) * default_unit
+                cycle_values[value_index] = (
+                    (-beta * sampled_value).to(unit.dimensionless).magnitude
+                )
+
+            # ΔG° = -RT × Log[ Σ_{n} exp(-βΔG°_{n}) ]
+            cycle_result[cycle_index] = logsumexp(cycle_values)
+
+        mean = -boltzmann_factor * mean
+        sem = np.std(-boltzmann_factor * cycle_result)
+
+        confidence_intervals = np.empty(2)
+        sorted_statistics = np.sort(cycle_result)
+
+        confidence_intervals[0] = sorted_statistics[int(0.025 * self.bootstrap_cycles)]
+        confidence_intervals[1] = sorted_statistics[int(0.975 * self.bootstrap_cycles)]
+
+        confidence_intervals = -boltzmann_factor * confidence_intervals
+
+        self.result = Observable(value=mean.plus_minus(sem), gradients=mean_gradients)
+        self.confidence_intervals = confidence_intervals
+
+    def validate(self, attribute_type=None):
+        super(AverageFreeEnergies, self).validate(attribute_type)
+        assert all(isinstance(x, Observable) for x in self.values)
+
+        if len(self.values) == 0:
+            return
+
+        expected_gradients = {gradient.key for gradient in self.values[0].gradients}
+
+        if not all(
+            expected_gradients == {gradient.key for gradient in value.gradients}
+            for value in self.values
+        ):
+
+            raise ValueError(
+                "The values must contain gradient information for the same set of "
+                "force field parameters."
+            )
+
+
+class BaseDecorrelateProtocol(Protocol, abc.ABC):
+    """An abstract base class for protocols which will subsample
+    a set of data, yielding only equilibrated, uncorrelated data.
+    """
+
+    time_series_statistics: typing.Union[
+        TimeSeriesStatistics, typing.List[TimeSeriesStatistics]
+    ] = InputAttribute(
+        docstring="Statistics about the data to decorrelate. This should include the "
+        "statistical inefficiency and the index after which the observables have "
+        "become stationary (i.e. equilibrated). If a list of such statistics are "
+        "provided it will be assumed that multiple time series which have been "
+        "joined together are being decorrelated and hence will each be decorrelated "
+        "separately.",
+        type_hint=typing.Union[list, TimeSeriesStatistics],
+        default_value=UNDEFINED,
+    )
+
+    def _n_expected(self) -> int:
+        """Returns the expected number of samples to decorrelate."""
+
+        time_series_statistics = self.time_series_statistics
+
+        if isinstance(time_series_statistics, TimeSeriesStatistics):
+            time_series_statistics = [time_series_statistics]
+
+        return sum(statistics.n_total_points for statistics in time_series_statistics)
+
+    def _uncorrelated_indices(self) -> typing.List[int]:
+        """Returns the indices of the time series being decorrelated to retain."""
+
+        time_series_statistics = self.time_series_statistics
+
+        if isinstance(time_series_statistics, TimeSeriesStatistics):
+            time_series_statistics = [time_series_statistics]
+
+        n_cumulative = [
+            0,
+            *itertools.accumulate(
+                [statistics.n_total_points for statistics in time_series_statistics]
+            ),
+        ]
+
+        uncorrelated_indices = [
+            n_cumulative[statistics_index] + index + statistics.equilibration_index
+            for statistics_index, statistics in enumerate(time_series_statistics)
+            for index in timeseries.get_uncorrelated_indices(
+                statistics.n_total_points - statistics.equilibration_index,
+                statistics.statistical_inefficiency,
+            )
+        ]
+
+        assert len(uncorrelated_indices) == sum(
+            statistics.n_uncorrelated_points for statistics in time_series_statistics
+        )
+
+        return uncorrelated_indices
+
+
+@workflow_protocol()
+class DecorrelateTrajectory(BaseDecorrelateProtocol):
+    """A protocol which will subsample frames from a trajectory, yielding only
+    uncorrelated frames as determined from a provided statistical inefficiency and
+    equilibration time.
     """
 
     input_coordinate_file = InputAttribute(
@@ -260,155 +536,58 @@ class ExtractUncorrelatedTrajectoryData(ExtractUncorrelatedData):
         # noinspection PyProtectedMember
         base_distance_unit = mdtraj.Trajectory._distance_unit
 
-        # Determine the stride that needs to be taken to yield uncorrelated frames.
-        stride = timeseries.get_uncorrelated_stride(self.statistical_inefficiency)
+        # Determine the frames to retrain
+        uncorrelated_indices = {*self._uncorrelated_indices()}
+
         frame_count = 0
 
         with DCDTrajectoryFile(self.input_trajectory_path, "r") as input_file:
-
-            # Skip the equilibration configurations.
-            if self.equilibration_index > 0:
-                input_file.seek(self.equilibration_index)
-
             with DCDTrajectoryFile(self.output_trajectory_path, "w") as output_file:
 
-                for frame in self._yield_frame(input_file, topology, stride):
+                for frame in self._yield_frame(input_file, topology, 1):
 
-                    output_file.write(
-                        xyz=in_units_of(
-                            frame.xyz, base_distance_unit, output_file.distance_unit
-                        ),
-                        cell_lengths=in_units_of(
-                            frame.unitcell_lengths,
-                            base_distance_unit,
-                            output_file.distance_unit,
-                        ),
-                        cell_angles=frame.unitcell_angles[0],
-                    )
+                    if frame_count in uncorrelated_indices:
+
+                        output_file.write(
+                            xyz=in_units_of(
+                                frame.xyz, base_distance_unit, output_file.distance_unit
+                            ),
+                            cell_lengths=in_units_of(
+                                frame.unitcell_lengths,
+                                base_distance_unit,
+                                output_file.distance_unit,
+                            ),
+                            cell_angles=frame.unitcell_angles[0],
+                        )
 
                     frame_count += 1
 
-        self.number_of_uncorrelated_samples = frame_count
+        assert frame_count == self._n_expected()
 
 
 @workflow_protocol()
-class ExtractUncorrelatedStatisticsData(ExtractUncorrelatedData):
-    """A protocol which will subsample entries from a statistics array, yielding only uncorrelated
-    entries as determined from a provided statistical inefficiency and equilibration time.
+class DecorrelateObservables(BaseDecorrelateProtocol):
+    """A protocol which will subsample a trajectory of observables, yielding only
+    uncorrelated entries as determined from a provided statistical inefficiency and
+    equilibration time.
     """
 
-    input_statistics_path = InputAttribute(
-        docstring="The file path to the statistics to subsample.",
-        type_hint=str,
+    input_observables = InputAttribute(
+        docstring="The observables to decorrelate.",
+        type_hint=typing.Union[ObservableArray, ObservableFrame],
         default_value=UNDEFINED,
     )
 
-    output_statistics_path = OutputAttribute(
-        docstring="The file path to the subsampled statistics.", type_hint=str
+    output_observables = OutputAttribute(
+        docstring="The decorrelated observables.",
+        type_hint=typing.Union[ObservableArray, ObservableFrame],
     )
 
     def _execute(self, directory, available_resources):
 
-        statistics_array = StatisticsArray.from_pandas_csv(self.input_statistics_path)
+        assert len(self.input_observables) == self._n_expected()
 
-        uncorrelated_indices = timeseries.get_uncorrelated_indices(
-            len(statistics_array) - self.equilibration_index,
-            self.statistical_inefficiency,
-        )
+        uncorrelated_indices = self._uncorrelated_indices()
+        uncorrelated_observable = self.input_observables.subset(uncorrelated_indices)
 
-        uncorrelated_indices = [
-            index + self.equilibration_index for index in uncorrelated_indices
-        ]
-        uncorrelated_statistics = StatisticsArray.from_existing(
-            statistics_array, uncorrelated_indices
-        )
-
-        self.output_statistics_path = path.join(
-            directory, "uncorrelated_statistics.csv"
-        )
-        uncorrelated_statistics.to_pandas_csv(self.output_statistics_path)
-
-        self.number_of_uncorrelated_samples = len(uncorrelated_statistics)
-
-
-@workflow_protocol()
-class AverageFreeEnergies(Protocol):
-    """A protocol which computes the Boltzmann weighted average
-    (ΔG° = -RT × Log[ Σ_{n} exp(-βΔG°_{n}) ]) of a set of free
-    energies which were measured at the same thermodynamic state.
-    Confidence intervals are computed by bootstrapping with replacement.
-    """
-
-    values = InputAttribute(
-        docstring="The values to add together.", type_hint=list, default_value=UNDEFINED
-    )
-    thermodynamic_state = InputAttribute(
-        docstring="The thermodynamic state at which the free energies were measured.",
-        type_hint=ThermodynamicState,
-        default_value=UNDEFINED,
-    )
-
-    bootstrap_cycles = InputAttribute(
-        docstring="The number of bootstrap cycles to perform when estimating "
-        "the uncertainty in the combined free energies.",
-        type_hint=int,
-        default_value=2000,
-    )
-
-    result = OutputAttribute(
-        docstring="The sum of the values.", type_hint=pint.Measurement
-    )
-    confidence_intervals = OutputAttribute(
-        docstring="The 95% confidence intervals on the average free energy.",
-        type_hint=pint.Quantity,
-    )
-
-    def _execute(self, directory, available_resources):
-
-        default_unit = unit.kilocalorie / unit.mole
-
-        boltzmann_factor = (
-            self.thermodynamic_state.temperature * unit.molar_gas_constant
-        )
-        boltzmann_factor.ito(default_unit)
-
-        beta = 1.0 / boltzmann_factor
-
-        cycle_result = np.empty(self.bootstrap_cycles)
-
-        for cycle_index, cycle in enumerate(range(self.bootstrap_cycles)):
-
-            cycle_values = np.empty(len(self.values))
-
-            for value_index, value in enumerate(self.values):
-
-                mean = value.value.to(default_unit).magnitude
-                sem = value.error.to(default_unit).magnitude
-
-                sampled_value = np.random.normal(mean, sem) * default_unit
-                cycle_values[value_index] = (
-                    (-beta * sampled_value).to(unit.dimensionless).magnitude
-                )
-
-            # ΔG° = -RT × Log[ Σ_{n} exp(-βΔG°_{n}) ]
-            cycle_result[cycle_index] = np.log(np.sum(np.exp(cycle_values)))
-
-        mean = np.mean(-boltzmann_factor * cycle_result)
-        sem = np.std(-boltzmann_factor * cycle_result)
-
-        confidence_intervals = np.empty(2)
-        sorted_statistics = np.sort(cycle_result)
-        confidence_intervals[0] = sorted_statistics[int(0.025 * self.bootstrap_cycles)]
-        confidence_intervals[1] = sorted_statistics[int(0.975 * self.bootstrap_cycles)]
-
-        confidence_intervals = -boltzmann_factor * confidence_intervals
-
-        self.result = mean.plus_minus(sem)
-        self.confidence_intervals = confidence_intervals
-
-    def validate(self, attribute_type=None):
-
-        super(AverageFreeEnergies, self).validate(attribute_type)
-        assert all(
-            isinstance(x, (unit.Measurement, pint.Measurement)) for x in self.values
-        )
+        self.output_observables = uncorrelated_observable

--- a/openff/evaluator/tests/test_protocols/test_analysis.py
+++ b/openff/evaluator/tests/test_protocols/test_analysis.py
@@ -1,107 +1,126 @@
 import tempfile
 
+import numpy as np
 import pytest
 
 from openff.evaluator import unit
-from openff.evaluator.backends import ComputeResources
+from openff.evaluator.forcefield import ParameterGradient, ParameterGradientKey
 from openff.evaluator.protocols.analysis import (
     AverageFreeEnergies,
-    ExtractAverageStatistic,
-    ExtractUncorrelatedStatisticsData,
-    ExtractUncorrelatedTrajectoryData,
+    AverageObservable,
+    DecorrelateObservables,
+    DecorrelateTrajectory,
 )
 from openff.evaluator.thermodynamics import ThermodynamicState
 from openff.evaluator.utils import get_data_filename
-from openff.evaluator.utils.statistics import ObservableType, StatisticsArray
+from openff.evaluator.utils.observables import Observable, ObservableArray
+from openff.evaluator.utils.timeseries import TimeSeriesStatistics
 
 
-def test_extract_average_statistic():
-
-    statistics_path = get_data_filename("test/statistics/stats_pandas.csv")
+def test_average_observable():
 
     with tempfile.TemporaryDirectory() as temporary_directory:
 
-        extract_protocol = ExtractAverageStatistic("extract_protocol")
-        extract_protocol.statistics_path = statistics_path
-        extract_protocol.statistics_type = ObservableType.PotentialEnergy
-        extract_protocol.execute(temporary_directory, ComputeResources())
+        average_observable = AverageObservable("")
+        average_observable.observable = ObservableArray(1.0 * unit.kelvin)
+        average_observable.bootstrap_iterations = 1
+        average_observable.execute(temporary_directory)
+
+        assert np.isclose(average_observable.value.value, 1.0 * unit.kelvin)
 
 
-def test_extract_uncorrelated_trajectory_data():
+def test_average_free_energies_protocol():
+    """Tests adding together two free energies."""
+
+    delta_g_one = Observable(
+        value=(-10.0 * unit.kilocalorie / unit.mole).plus_minus(
+            1.0 * unit.kilocalorie / unit.mole
+        ),
+        gradients=[
+            ParameterGradient(
+                key=ParameterGradientKey("vdW", "[#6:1]", "sigma"),
+                value=0.1 * unit.kilocalorie / unit.mole / unit.angstrom,
+            )
+        ],
+    )
+    delta_g_two = Observable(
+        value=(-20.0 * unit.kilocalorie / unit.mole).plus_minus(
+            2.0 * unit.kilocalorie / unit.mole
+        ),
+        gradients=[
+            ParameterGradient(
+                key=ParameterGradientKey("vdW", "[#6:1]", "sigma"),
+                value=0.2 * unit.kilocalorie / unit.mole / unit.angstrom,
+            )
+        ],
+    )
+
+    thermodynamic_state = ThermodynamicState(298 * unit.kelvin, 1 * unit.atmosphere)
+
+    sum_protocol = AverageFreeEnergies("")
+
+    sum_protocol.values = [delta_g_one, delta_g_two]
+    sum_protocol.thermodynamic_state = thermodynamic_state
+
+    sum_protocol.execute()
+
+    result_value = sum_protocol.result.value.to(unit.kilocalorie / unit.mole)
+    result_uncertainty = sum_protocol.result.error.to(unit.kilocalorie / unit.mole)
+
+    assert isinstance(sum_protocol.result, Observable)
+    assert result_value.magnitude == pytest.approx(-20.0, abs=0.2)
+    assert result_uncertainty.magnitude == pytest.approx(2.0, abs=0.2)
+
+    assert (
+        sum_protocol.confidence_intervals[0]
+        > result_value
+        > sum_protocol.confidence_intervals[1]
+    )
+
+    gradient_value = sum_protocol.result.gradients[0].value.to(
+        unit.kilocalorie / unit.mole / unit.angstrom
+    )
+    beta = 1.0 / (298.0 * unit.kelvin * unit.molar_gas_constant).to(
+        unit.kilocalorie / unit.mole
+    )
+
+    assert np.isclose(
+        gradient_value.magnitude,
+        (0.1 * np.exp(-beta.magnitude * -10.0) + 0.2 * np.exp(-beta.magnitude * -20.0))
+        / (np.exp(-beta.magnitude * -10.0) + np.exp(-beta.magnitude * -20.0)),
+    )
+
+
+def test_decorrelate_trajectory():
 
     import mdtraj
 
     coordinate_path = get_data_filename("test/trajectories/water.pdb")
     trajectory_path = get_data_filename("test/trajectories/water.dcd")
 
-    original_trajectory = mdtraj.load(trajectory_path, top=coordinate_path)
-
     with tempfile.TemporaryDirectory() as temporary_directory:
 
-        extract_protocol = ExtractUncorrelatedTrajectoryData("extract_protocol")
-        extract_protocol.input_coordinate_file = coordinate_path
-        extract_protocol.input_trajectory_path = trajectory_path
-        extract_protocol.equilibration_index = 2
-        extract_protocol.statistical_inefficiency = 2.0
-        extract_protocol.execute(temporary_directory, ComputeResources())
+        protocol = DecorrelateTrajectory("")
+        protocol.input_coordinate_file = coordinate_path
+        protocol.input_trajectory_path = trajectory_path
+        protocol.time_series_statistics = TimeSeriesStatistics(10, 4, 2.0, 2)
+        protocol.execute(temporary_directory)
 
         final_trajectory = mdtraj.load(
-            extract_protocol.output_trajectory_path, top=coordinate_path
+            protocol.output_trajectory_path, top=coordinate_path
         )
-        assert len(final_trajectory) == (len(original_trajectory) - 2) / 2
-        assert (
-            extract_protocol.number_of_uncorrelated_samples
-            == (len(original_trajectory) - 2) / 2
-        )
+        assert len(final_trajectory) == 4
 
 
-def test_extract_uncorrelated_statistics_data():
-
-    statistics_path = get_data_filename("test/statistics/stats_pandas.csv")
-    original_array = StatisticsArray.from_pandas_csv(statistics_path)
+def test_decorrelate_observables():
 
     with tempfile.TemporaryDirectory() as temporary_directory:
 
-        extract_protocol = ExtractUncorrelatedStatisticsData("extract_protocol")
-        extract_protocol.input_statistics_path = statistics_path
-        extract_protocol.equilibration_index = 2
-        extract_protocol.statistical_inefficiency = 2.0
-        extract_protocol.execute(temporary_directory, ComputeResources())
-
-        final_array = StatisticsArray.from_pandas_csv(
-            extract_protocol.output_statistics_path
+        protocol = DecorrelateObservables("")
+        protocol.input_observables = ObservableArray(
+            np.ones((10, 1)) * unit.nanometer ** 3
         )
-        assert len(final_array) == (len(original_array) - 2) / 2
-        assert (
-            extract_protocol.number_of_uncorrelated_samples
-            == (len(original_array) - 2) / 2
-        )
+        protocol.time_series_statistics = TimeSeriesStatistics(10, 4, 2.0, 2)
+        protocol.execute(temporary_directory)
 
-
-def test_average_free_energies_protocol():
-    """Tests adding together two free energies."""
-
-    compute_resources = ComputeResources(number_of_threads=1)
-
-    delta_g_one = (-10.0 * unit.kilocalorie / unit.mole).plus_minus(
-        1.0 * unit.kilocalorie / unit.mole
-    )
-    delta_g_two = (-20.0 * unit.kilocalorie / unit.mole).plus_minus(
-        2.0 * unit.kilocalorie / unit.mole
-    )
-
-    thermodynamic_state = ThermodynamicState(298 * unit.kelvin, 1 * unit.atmosphere)
-
-    sum_protocol = AverageFreeEnergies("average_free_energies")
-
-    sum_protocol.values = [delta_g_one, delta_g_two]
-    sum_protocol.thermodynamic_state = thermodynamic_state
-
-    sum_protocol.execute("", compute_resources)
-
-    result_value = sum_protocol.result.value.to(unit.kilocalorie / unit.mole)
-    result_uncertainty = sum_protocol.result.error.to(unit.kilocalorie / unit.mole)
-
-    assert isinstance(sum_protocol.result, unit.Measurement)
-    assert result_value.magnitude == pytest.approx(-20.0, abs=0.2)
-    assert result_uncertainty.magnitude == pytest.approx(2.0, abs=0.2)
+        assert len(protocol.output_observables) == 4


### PR DESCRIPTION
## Description
This PR refactors the Analysis protocols to make use of the new Observable objects, allowing them to return the gradients of the computed observables with respect to any requested force field parameters.

The gradients of ensemble averaged observables are computed here using the fluctuation formula described in [1].

## API changes

- `AveragePropertyProtocol` -> `BaseAverageObservable`
- `ExtractAverageStatistic` -> `AverageObservable`
- `ExtractUncorrelatedData` -> `BaseDecorrelateProtocol`
- `ExtractUncorrelatedTrajectoryData` -> `DecorrelateTrajectory`
- `ExtractUncorrelatedStatisticsData` -> `DecorrelateObservables`


## References
- [1] Wang, Lee-Ping, et al. "Systematic improvement of a classical molecular model of water." The Journal of Physical Chemistry B 117.34 (2013): 9956-9972.

## Status
- [X] Ready to go