### PR TITLE
[GRADIENTS] Re-weighting Protocol Observables

### DIFF
--- a/openff/evaluator/protocols/reweighting.py
+++ b/openff/evaluator/protocols/reweighting.py
@@ -2,19 +2,26 @@
 A collection of protocols for reweighting cached simulation data.
 """
 import abc
+import copy
+import functools
 import typing
 from os import path
 
 import numpy as np
-import pint
 import pymbar
-from scipy.special import logsumexp
 
 from openff.evaluator import unit
 from openff.evaluator.attributes import UNDEFINED
+from openff.evaluator.forcefield import ParameterGradient
 from openff.evaluator.forcefield.system import ParameterizedSystem
+from openff.evaluator.protocols.analysis import compute_dielectric_constant
 from openff.evaluator.thermodynamics import ThermodynamicState
-from openff.evaluator.utils.statistics import ObservableType, StatisticsArray, bootstrap
+from openff.evaluator.utils.observables import (
+    Observable,
+    ObservableArray,
+    ObservableFrame,
+    bootstrap,
+)
 from openff.evaluator.workflow import Protocol, workflow_protocol
 from openff.evaluator.workflow.attributes import InputAttribute, OutputAttribute
 
@@ -26,7 +33,8 @@ class ConcatenateTrajectories(Protocol):
     """
 
     input_coordinate_paths = InputAttribute(
-        docstring="A list of paths to the starting PDB coordinates for each of the trajectories.",
+        docstring="A list of paths to the starting PDB coordinates for each of the "
+        "trajectories.",
         type_hint=list,
         default_value=UNDEFINED,
     )
@@ -82,44 +90,43 @@ class ConcatenateTrajectories(Protocol):
 
 
 @workflow_protocol()
-class ConcatenateStatistics(Protocol):
-    """A protocol which concatenates multiple trajectories into
-    a single one.
+class ConcatenateObservables(Protocol):
+    """A protocol which concatenates multiple ``ObservableFrame`` objects into
+    a single ``ObservableFrame`` object.
     """
 
-    input_statistics_paths = InputAttribute(
-        docstring="A list of paths to statistics arrays to concatenate.",
+    input_observables = InputAttribute(
+        docstring="A list of observable arrays to concatenate.",
         type_hint=list,
         default_value=UNDEFINED,
     )
-    output_statistics_path = OutputAttribute(
-        docstring="The path the csv file which contains the concatenated statistics.",
-        type_hint=str,
+    output_observables = OutputAttribute(
+        docstring="The concatenated observable array.",
+        type_hint=typing.Union[ObservableArray, ObservableFrame],
     )
 
     def _execute(self, directory, available_resources):
 
-        if len(self.input_statistics_paths) == 0:
-            raise ValueError("No statistics arrays were given to concatenate.")
+        if len(self.input_observables) == 0:
+            raise ValueError("No arrays were given to concatenate.")
 
-        arrays = [
-            StatisticsArray.from_pandas_csv(file_path)
-            for file_path in self.input_statistics_paths
-        ]
+        if not all(
+            isinstance(observables, type(self.input_observables[0]))
+            for observables in self.input_observables
+        ):
+            raise ValueError("The observables to concatenate must be the same type.")
 
-        if len(arrays) > 1:
-            output_array = StatisticsArray.join(*arrays)
+        object_type = type(self.input_observables[0])
+
+        if len(self.input_observables) > 1:
+            self.output_observables = object_type.join(*self.input_observables)
         else:
-            output_array = arrays[0]
-
-        self.output_statistics_path = path.join(directory, "output_statistics.csv")
-        output_array.to_pandas_csv(self.output_statistics_path)
+            self.output_observables = copy.deepcopy(self.input_observables[0])
 
 
-@workflow_protocol()
-class BaseReducedPotentials(Protocol, abc.ABC):
-    """A base class for protocols which will re-evaluate the reduced potential
-    of a series of configurations for a given set of force field parameters.
+class BaseEvaluateEnergies(Protocol, abc.ABC):
+    """A base class for protocols which will re-evaluate the energy of a series
+    of configurations for a given set of force field parameters.
     """
 
     thermodynamic_state = InputAttribute(
@@ -146,58 +153,53 @@ class BaseReducedPotentials(Protocol, abc.ABC):
         type_hint=str,
         default_value=UNDEFINED,
     )
-    kinetic_energies_path = InputAttribute(
-        docstring="The file path to a statistics array which contain the kinetic "
-        "energies of each frame in the trajectory.",
-        type_hint=str,
-        default_value=UNDEFINED,
+
+    gradient_parameters = InputAttribute(
+        docstring="An optional list of parameters to differentiate the evaluated "
+        "energies with respect to.",
+        type_hint=list,
+        default_value=lambda: list(),
     )
 
-    high_precision = InputAttribute(
-        docstring="If true, the reduced potentials will be calculated using double "
-        "precision operations.",
-        type_hint=bool,
-        default_value=False,
-    )
-
-    use_internal_energy = InputAttribute(
-        docstring="If true the internal energy, rather than the potential energy will "
-        "be used when calculating the reduced potential. This is required "
-        "when reweighting properties which depend on the total energy, such "
-        "as enthalpy.",
-        type_hint=bool,
-        default_value=False,
-    )
-
-    statistics_file_path = OutputAttribute(
-        docstring="A file path to the statistics file which contains the reduced "
-        "potentials, and the potential, kinetic and total energies and "
-        "enthalpies evaluated at the specified state and using the "
-        "specified system object.",
-        type_hint=str,
+    output_observables = OutputAttribute(
+        docstring="An observable array which stores the reduced potentials potential "
+        "energies evaluated at the specified state and using the specified system "
+        "object for each configuration in the trajectory.",
+        type_hint=ObservableFrame,
     )
 
 
 class BaseMBARProtocol(Protocol, abc.ABC):
-    """Reweights a set of observables using MBAR to calculate
+    """Re-weights a set of observables using MBAR to calculate
     the average value of the observables at a different state
     than they were originally measured.
     """
 
-    reference_reduced_potentials = InputAttribute(
-        docstring="A list of paths to the reduced potentials of each "
-        "reference state.",
-        type_hint=typing.Union[str, list],
+    reference_reduced_potentials: typing.List[ObservableArray] = InputAttribute(
+        docstring="The reduced potentials of each configuration evaluated at each of "
+        "the reference states.",
+        type_hint=list,
         default_value=UNDEFINED,
     )
     target_reduced_potentials = InputAttribute(
-        docstring="A list of paths to the reduced potentials of the target state.",
-        type_hint=typing.Union[str, list],
+        docstring="The reduced potentials of each configuration evaluated at the "
+        "target state.",
+        type_hint=ObservableArray,
+        default_value=UNDEFINED,
+    )
+
+    frame_counts = InputAttribute(
+        docstring="The number of configurations per reference state. The sum of these"
+        "should equal the length of the ``reference_reduced_potentials`` and "
+        "``target_reduced_potentials`` input arrays as well any input observable "
+        "arrays.",
+        type_hint=list,
         default_value=UNDEFINED,
     )
 
     bootstrap_uncertainties = InputAttribute(
-        docstring="If true, bootstrapping will be used to estimated the total uncertainty",
+        docstring="If true, bootstrapping will be used to estimated the total "
+        "uncertainty in the reweighted value.",
         type_hint=bool,
         default_value=False,
     )
@@ -205,513 +207,384 @@ class BaseMBARProtocol(Protocol, abc.ABC):
         docstring="The number of bootstrap iterations to perform if bootstraped "
         "uncertainties have been requested",
         type_hint=int,
-        default_value=1,
-    )
-    bootstrap_sample_size = InputAttribute(
-        docstring="The relative bootstrap sample size to use if bootstraped "
-        "uncertainties have been requested",
-        type_hint=float,
-        default_value=1.0,
+        default_value=250,
     )
 
     required_effective_samples = InputAttribute(
-        docstring="The minimum number of MBAR effective samples for the "
-        "reweighted value to be trusted. If this minimum is not met "
-        "then the uncertainty will be set to sys.float_info.max",
+        docstring="The minimum number of effective samples required to be able to "
+        "reweight the observable. If the effective samples is less than this minimum "
+        "an exception will be raised.",
         type_hint=int,
         default_value=50,
     )
 
     value = OutputAttribute(
-        docstring="The reweighted average value of the observable at the target state.",
-        type_hint=pint.Measurement,
+        docstring="The re-weighted average value of the observable at the target "
+        "state.",
+        type_hint=Observable,
     )
-
     effective_samples = OutputAttribute(
-        docstring="The number of effective samples which were reweighted.",
+        docstring="The number of effective samples which were re-weighted.",
         type_hint=float,
     )
-    effective_sample_indices = OutputAttribute(
-        docstring="The indices of those samples which have a non-zero weight.",
-        type_hint=list,
-    )
 
-    def __init__(self, protocol_id):
-        super().__init__(protocol_id)
-        self._reference_observables = []
-
-    def _execute(self, directory, available_resources):
-
-        if len(self._reference_observables) == 0:
-            raise ValueError("There were no observables to reweight.")
-
-        if not isinstance(self._reference_observables[0], pint.Quantity):
-
-            raise ValueError(
-                "The reference_observables input should be a list of pint.Quantity "
-                "wrapped ndarray's.",
-            )
-
-        observables = self._prepare_observables_array(self._reference_observables)
-        observable_unit = self._reference_observables[0].units
-
-        if self.bootstrap_uncertainties:
-            self._execute_with_bootstrapping(observable_unit, observables=observables)
-        else:
-            self._execute_without_bootstrapping(
-                observable_unit, observables=observables
-            )
-
-    def _load_reduced_potentials(self):
-        """Loads the target and reference reduced potentials
-        from the specified statistics files.
-
-        Returns
-        -------
-        numpy.ndarray
-            The reference reduced potentials array with dtype=double and
-            shape=(1,)
-        numpy.ndarray
-            The target reduced potentials array with dtype=double and
-            shape=(1,)
+    @abc.abstractmethod
+    def _observables(self) -> typing.Dict[str, ObservableArray]:
+        """The observables which will be re-weighted to yield the final average
+        observable of interest.
         """
-
-        if isinstance(self.reference_reduced_potentials, str):
-            self.reference_reduced_potentials = [self.reference_reduced_potentials]
-
-        if isinstance(self.target_reduced_potentials, str):
-            self.target_reduced_potentials = [self.target_reduced_potentials]
-
-        reference_reduced_potentials = []
-        target_reduced_potentials = []
-
-        # Load in the reference reduced potentials.
-        for file_path in self.reference_reduced_potentials:
-
-            statistics_array = StatisticsArray.from_pandas_csv(file_path)
-            reduced_potentials = statistics_array[ObservableType.ReducedPotential]
-
-            reference_reduced_potentials.append(
-                reduced_potentials.to(unit.dimensionless).magnitude
-            )
-
-        # Load in the target reduced potentials.
-        if len(target_reduced_potentials) > 1:
-
-            raise ValueError(
-                "This protocol currently only supports reweighting to "
-                "a single target state."
-            )
-
-        for file_path in self.target_reduced_potentials:
-
-            statistics_array = StatisticsArray.from_pandas_csv(file_path)
-            reduced_potentials = statistics_array[ObservableType.ReducedPotential]
-
-            target_reduced_potentials.append(
-                reduced_potentials.to(unit.dimensionless).magnitude
-            )
-
-        reference_reduced_potentials = np.array(reference_reduced_potentials)
-        target_reduced_potentials = np.array(target_reduced_potentials)
-
-        return reference_reduced_potentials, target_reduced_potentials
-
-    def _execute_with_bootstrapping(self, observable_unit, **observables):
-        """Calculates the average reweighted observables at the target state,
-        using bootstrapping to estimate uncertainties.
-
-        Parameters
-        ----------
-        observable_unit: pint.Unit:
-            The expected unit of the reweighted observable.
-        observables: dict of str and numpy.ndarray
-            The observables to reweight which have been stripped of their units.
-        """
-
-        (
-            reference_reduced_potentials,
-            target_reduced_potentials,
-        ) = self._load_reduced_potentials()
-
-        frame_counts = np.array(
-            [len(observable) for observable in self._reference_observables]
-        )
-
-        # Construct a dummy mbar object to get out the number of effective samples.
-        mbar = self._construct_mbar_object(reference_reduced_potentials)
-
-        (
-            self.effective_samples,
-            effective_sample_indices,
-        ) = self._compute_effective_samples(mbar, target_reduced_potentials)
-
-        if self.effective_samples < self.required_effective_samples:
-
-            raise ValueError(
-                f"There was not enough effective samples to reweight - "
-                f"{self.effective_samples} < {self.required_effective_samples}"
-            )
-
-        # Transpose the observables ready for bootstrapping.
-        reference_reduced_potentials = np.transpose(reference_reduced_potentials)
-        target_reduced_potentials = np.transpose(target_reduced_potentials)
-
-        transposed_observables = {}
-
-        for observable_key in observables:
-            transposed_observables[observable_key] = np.transpose(
-                observables[observable_key]
-            )
-
-        value, uncertainty = bootstrap(
-            self._bootstrap_function,
-            self.bootstrap_iterations,
-            self.bootstrap_sample_size,
-            frame_counts,
-            reference_reduced_potentials=reference_reduced_potentials,
-            target_reduced_potentials=target_reduced_potentials,
-            **transposed_observables,
-        )
-
-        self.effective_sample_indices = effective_sample_indices
-        self.value = (value * observable_unit).plus_minus(uncertainty * observable_unit)
-
-    def _execute_without_bootstrapping(self, observable_unit, **observables):
-        """Calculates the average reweighted observables at the target state,
-        using the built-in pymbar method to estimate uncertainties.
-
-        Parameters
-        ----------
-        observables: dict of str and numpy.ndarray
-            The observables to reweight which have been stripped of their units.
-        """
-
-        if len(observables) > 1:
-
-            raise ValueError(
-                "Currently only a single observable can be reweighted at"
-                "any one time."
-            )
-
-        (
-            reference_reduced_potentials,
-            target_reduced_potentials,
-        ) = self._load_reduced_potentials()
-
-        values, uncertainties, self.effective_samples = self._reweight_observables(
-            reference_reduced_potentials, target_reduced_potentials, **observables
-        )
-
-        observable_key = next(iter(observables))
-        uncertainty = uncertainties[observable_key]
-
-        if self.effective_samples < self.required_effective_samples:
-
-            raise ValueError(
-                f"There was not enough effective samples to reweight - "
-                f"{self.effective_samples} < {self.required_effective_samples}"
-            )
-
-        self.value = (values[observable_key] * observable_unit).plus_minus(
-            uncertainty * observable_unit
-        )
+        raise NotImplementedError()
 
     @staticmethod
-    def _prepare_observables_array(reference_observables):
-        """Takes a list of reference observables, and concatenates them
-        into a single `pint.Quantity` wrapped numpy array.
+    def _compute_weights(
+        mbar: pymbar.MBAR, target_reduced_potentials: ObservableArray
+    ) -> ObservableArray:
+        """Return the values that each sample at the target state should be weighted
+        by.
 
         Parameters
         ----------
-        reference_observables: List of pint.Quantity
-            A list of observables for each reference state,
-            which each observable is a `pint.Quantity` wrapped numpy
-            array.
+        mbar
+            A pre-computed MBAR object encoded information from the reference states.
+        target_reduced_potentials
+            The reduced potentials at the target state.
 
         Returns
         -------
-        np.ndarray
-            A unitless numpy array of all of the observables.
+            The values to weight each sample by.
         """
-        frame_counts = np.array(
-            [len(observable) for observable in reference_observables]
-        )
-        number_of_configurations = frame_counts.sum()
+        from scipy.special import logsumexp
 
-        observable_dimensions = (
-            1
-            if len(reference_observables[0].shape) == 1
-            else reference_observables[0].shape[1]
-        )
-        observable_unit = reference_observables[0].units
+        u_kn = target_reduced_potentials.value.to(unit.dimensionless).magnitude.T
 
-        observables = np.zeros((observable_dimensions, number_of_configurations))
+        log_ref_c_k = mbar.f_k - mbar.u_kn.T
+        log_denominator_n = logsumexp(log_ref_c_k, b=mbar.N_k, axis=1)
 
-        # Build up an array which contains the observables from all
-        # of the reference states.
-        for index_k, observables_k in enumerate(reference_observables):
+        f_hat = -logsumexp(-u_kn - log_denominator_n, axis=1)
 
-            start_index = np.array(frame_counts[0:index_k]).sum()
+        # Calculate the weights
+        weights = np.exp(f_hat - u_kn - log_denominator_n) * unit.dimensionless
 
-            for index in range(0, frame_counts[index_k]):
+        # Compute the gradients of the weights.
+        weight_gradients = []
 
-                value = observables_k[index].to(observable_unit).magnitude
+        for gradient in target_reduced_potentials.gradients:
 
-                if not isinstance(value, np.ndarray):
-                    observables[0][start_index + index] = value
-                    continue
+            gradient_value = gradient.value.magnitude.flatten()
 
-                for dimension in range(observable_dimensions):
-                    observables[dimension][start_index + index] = value[dimension]
+            # Compute the numerator of the gradient. We need to specifically ask for the
+            # sign of the exp sum as the numerator may be negative.
+            d_f_hat_numerator, d_f_hat_numerator_sign = logsumexp(
+                -u_kn - log_denominator_n, b=gradient_value, axis=1, return_sign=True
+            )
+            d_f_hat_numerator = d_f_hat_numerator_sign * np.exp(d_f_hat_numerator)
 
-        return observables
+            d_f_hat_d_theta = d_f_hat_numerator / np.exp(f_hat)
 
-    def _bootstrap_function(
-        self,
-        reference_reduced_potentials,
-        target_reduced_potentials,
-        **reference_observables,
-    ):
-        """The function which will be called after each bootstrap
-        iteration, if bootstrapping is being employed to estimated
-        the reweighting uncertainty.
+            d_weights_d_theta = (
+                (d_f_hat_d_theta - gradient_value) * weights * gradient.value.units
+            )
+
+            weight_gradients.append(
+                ParameterGradient(key=gradient.key, value=d_weights_d_theta.T)
+            )
+
+        return ObservableArray(value=weights.T, gradients=weight_gradients)
+
+    def _compute_effective_samples(
+        self, reference_reduced_potentials: ObservableArray
+    ) -> float:
+        """Compute the effective number of samples which contribute to the final
+        re-weighted estimate.
 
         Parameters
         ----------
         reference_reduced_potentials
-        target_reduced_potentials
-        reference_observables
+            An 2D array containing the reduced potentials of each configuration
+            evaluated at each reference state.
 
         Returns
         -------
-        float
-            The bootstrapped value,
-        """
-        assert len(reference_observables) == 1
-
-        transposed_observables = {}
-
-        for key in reference_observables:
-            transposed_observables[key] = np.transpose(reference_observables[key])
-
-        values, _, _ = self._reweight_observables(
-            np.transpose(reference_reduced_potentials),
-            np.transpose(target_reduced_potentials),
-            **transposed_observables,
-        )
-
-        return next(iter(values.values()))
-
-    def _construct_mbar_object(self, reference_reduced_potentials):
-        """Constructs a new `pymbar.MBAR` object for a given set of reference
-        and target reduced potentials
-
-        Parameters
-        -------
-        reference_reduced_potentials: numpy.ndarray
-            The reference reduced potentials.
-
-        Returns
-        -------
-        pymbar.MBAR
-            The constructed `MBAR` object.
+            The effective number of samples.
         """
 
-        frame_counts = np.array(
-            [len(observables) for observables in self._reference_observables]
-        )
-
-        # Construct the mbar object.
+        # Construct an MBAR object so that the number of effective samples can
+        # be computed.
         mbar = pymbar.MBAR(
-            reference_reduced_potentials,
-            frame_counts,
+            reference_reduced_potentials.value.to(unit.dimensionless).magnitude.T,
+            self.frame_counts,
             verbose=False,
             relative_tolerance=1e-12,
         )
 
-        return mbar
-
-    @staticmethod
-    def _compute_effective_samples(mbar, target_reduced_potentials):
-        """Compute the effective number of samples which contribute to the final
-        reweighted estimate.
-
-        Parameters
-        ----------
-        mbar: pymbar.MBAR
-            The MBAR object which contains the sample weights.
-        target_reduced_potentials: numpy.ndarray
-            The target reduced potentials.
-
-        Returns
-        -------
-        int
-            The effective number of samples.
-        list of int
-            The indices of samples which have non-zero weights.
-        """
-
-        states_with_samples = mbar.N_k > 0
-
-        log_ref_q_k = mbar.f_k[states_with_samples] - mbar.u_kn[states_with_samples].T
-        log_denominator_n = logsumexp(
-            log_ref_q_k, b=mbar.N_k[states_with_samples], axis=1
+        weights = (
+            self._compute_weights(mbar, self.target_reduced_potentials)
+            .value.to(unit.dimensionless)
+            .magnitude
         )
-
-        target_f_hat = -logsumexp(
-            -target_reduced_potentials[: len(target_reduced_potentials)]
-            - log_denominator_n,
-            axis=1,
-        )
-
-        log_tar_q_k = target_f_hat - target_reduced_potentials
-
-        # Calculate the weights
-        weights = np.exp(log_tar_q_k - log_denominator_n)
 
         effective_samples = 1.0 / np.sum(weights ** 2)
-
-        effective_sample_indices = [
-            index
-            for index in range(weights.shape[1])
-            if not np.isclose(weights[0][index], 0.0)
-        ]
-
-        return effective_samples, effective_sample_indices
-
-    def _reweight_observables(
-        self,
-        reference_reduced_potentials,
-        target_reduced_potentials,
-        **reference_observables,
-    ):
-        """Reweights a set of reference observables to
-        the target state.
-
-        Returns
-        -------
-        dict of str and float or list of float
-            The reweighted values.
-        dict of str and float or list of float
-            The MBAR calculated uncertainties in the reweighted values.
-        int
-            The number of effective samples.
-        """
-
-        # Construct the mbar object.
-        mbar = self._construct_mbar_object(reference_reduced_potentials)
-
-        (
-            effective_samples,
-            self.effective_sample_indices,
-        ) = self._compute_effective_samples(mbar, target_reduced_potentials)
-
-        values = {}
-        uncertainties = {}
-
-        for observable_key in reference_observables:
-
-            reference_observable = reference_observables[observable_key]
-            observable_dimensions = reference_observable.shape[0]
-
-            values[observable_key] = np.zeros((observable_dimensions, 1))
-            uncertainties[observable_key] = np.zeros((observable_dimensions, 1))
-
-            for dimension in range(observable_dimensions):
-
-                results = mbar.computeExpectations(
-                    reference_observable[dimension],
-                    target_reduced_potentials,
-                    state_dependent=True,
-                )
-
-                values[observable_key][dimension] = results[0][-1]
-                uncertainties[observable_key][dimension] = results[1][-1]
-
-            if observable_dimensions == 1:
-                values[observable_key] = values[observable_key][0][0].item()
-                uncertainties[observable_key] = uncertainties[observable_key][0][
-                    0
-                ].item()
-
-        return values, uncertainties, effective_samples
-
-
-@workflow_protocol()
-class ReweightStatistics(BaseMBARProtocol):
-    """Reweights a set of observables from a `StatisticsArray` using MBAR."""
-
-    statistics_paths = InputAttribute(
-        docstring="The file paths to the statistics array which contains the observables "
-        "of interest from each state. If the observable of interest is "
-        "dependant on the changing variable (e.g. the potential energy) then "
-        "this must be a path to the observable re-evaluated at the new state.",
-        type_hint=typing.Union[list, str],
-        default_value=UNDEFINED,
-    )
-    statistics_type = InputAttribute(
-        docstring="The type of observable to reweight.",
-        type_hint=ObservableType,
-        default_value=UNDEFINED,
-    )
-
-    frame_counts = InputAttribute(
-        docstring="A list which describes how many of the statistics in the array "
-        "belong to each reference state. If this input is used, only a single file "
-        "path should be passed to the `statistics_paths` input.",
-        type_hint=list,
-        default_value=[],
-        optional=True,
-    )
+        return float(effective_samples)
 
     def _execute(self, directory, available_resources):
 
-        if isinstance(self.statistics_paths, str):
-            self.statistics_paths = [self.statistics_paths]
+        # Retrieve the observables to reweight.
+        observables = self._observables()
 
-        if self.statistics_paths is None or len(self.statistics_paths) == 0:
-            return ValueError("No statistics paths were provided.")
+        if len(observables) == 0:
+            raise ValueError("There were no observables to reweight.")
 
-        if len(self.frame_counts) > 0 and len(self.statistics_paths) != 1:
+        if len(self.frame_counts) != len(self.reference_reduced_potentials):
+
+            raise ValueError("A frame count must be provided for each reference state.")
+
+        expected_frames = sum(self.frame_counts)
+
+        if any(
+            len(input_array) != expected_frames
+            for input_array in [
+                self.target_reduced_potentials,
+                *self.reference_reduced_potentials,
+                *observables.values(),
+            ]
+        ):
 
             raise ValueError(
-                "The frame counts input can only be used when only a single "
-                "path is passed to the `statistics_paths` input.",
+                f"The length of the input arrays do not match the expected length "
+                f"specified by the frame counts ({expected_frames})."
             )
 
-        if self.statistics_type == ObservableType.KineticEnergy:
-            raise ValueError("Kinetic energies cannot be reweighted.")
-
-        statistics_arrays = [
-            StatisticsArray.from_pandas_csv(file_path)
-            for file_path in self.statistics_paths
-        ]
-
-        self._reference_observables = []
-
-        if len(self.frame_counts) > 0:
-
-            statistics_array = statistics_arrays[0]
-            current_index = 0
-
-            for frame_count in self.frame_counts:
-
-                if frame_count <= 0:
-                    raise ValueError("The frame counts must be > 0.")
-
-                observables = statistics_array[self.statistics_type][
-                    current_index : current_index + frame_count
+        # Concatenate the reduced reference potentials into a single array.
+        # We ignore the gradients of the reference state potential as these
+        # should be all zero.
+        reference_reduced_potentials = ObservableArray(
+            value=np.hstack(
+                [
+                    reduced_potentials.value
+                    for reduced_potentials in self.reference_reduced_potentials
                 ]
-                self._reference_observables.append(observables)
+            )
+        )
 
-                current_index += frame_count
+        # Ensure that there is enough effective samples to re-weight.
+        self.effective_samples = self._compute_effective_samples(
+            reference_reduced_potentials
+        )
+
+        if self.effective_samples < self.required_effective_samples:
+
+            raise ValueError(
+                f"There was not enough effective samples to reweight - "
+                f"{self.effective_samples} < {self.required_effective_samples}"
+            )
+
+        if self.bootstrap_uncertainties:
+
+            self.value = bootstrap(
+                self._bootstrap_function,
+                self.bootstrap_iterations,
+                1.0,
+                self.frame_counts,
+                reference_reduced_potentials=reference_reduced_potentials,
+                target_reduced_potentials=self.target_reduced_potentials,
+                **observables,
+            )
 
         else:
 
-            for statistics_array in statistics_arrays:
+            self.value = self._bootstrap_function(
+                reference_reduced_potentials=reference_reduced_potentials,
+                target_reduced_potentials=self.target_reduced_potentials,
+                **observables,
+            )
 
-                observables = statistics_array[self.statistics_type]
-                self._reference_observables.append(observables)
+    def _bootstrap_function(self, **observables: ObservableArray) -> Observable:
+        """Re-weights a set of reference observables to the target state.
 
-        return super(ReweightStatistics, self)._execute(directory, available_resources)
+        Parameters
+        -------
+        observables
+            The observables to reweight, in addition to the reference and target
+            reduced potentials.
+        """
+
+        reference_reduced_potentials = observables.pop("reference_reduced_potentials")
+        target_reduced_potentials = observables.pop("target_reduced_potentials")
+
+        # Construct the mbar object using the specified reference reduced potentials.
+        # These may be the input values or values which have been sampled during
+        # bootstrapping, hence why it is not precomputed once.
+        mbar = pymbar.MBAR(
+            reference_reduced_potentials.value.to(unit.dimensionless).magnitude.T,
+            self.frame_counts,
+            verbose=False,
+            relative_tolerance=1e-12,
+        )
+
+        # Compute the MBAR weights.
+        weights = self._compute_weights(mbar, target_reduced_potentials)
+
+        return self._reweight_observables(
+            weights, mbar, target_reduced_potentials, **observables
+        )
+
+    def _reweight_observables(
+        self,
+        weights: ObservableArray,
+        mbar: pymbar.MBAR,
+        target_reduced_potentials: ObservableArray,
+        **observables: ObservableArray,
+    ) -> typing.Union[ObservableArray, Observable]:
+        """A function which computes the average value of an observable using
+        weights computed from MBAR and from a set of component observables.
+
+        Parameters
+        ----------
+        weights
+            The MBAR weights
+        observables
+            The component observables which may be combined to yield the final
+            average observable of interest.
+        mbar
+            A pre-computed MBAR object encoded information from the reference states.
+            This will be used to compute the std error when not bootstrapping.
+        target_reduced_potentials
+            The reduced potentials at the target state. This will be used to compute
+            the std error when not bootstrapping.
+
+        Returns
+        -------
+            The re-weighted average observable.
+        """
+
+        observable = observables.pop("observable")
+        assert len(observables) == 0
+
+        return_type = ObservableArray if observable.value.shape[1] > 1 else Observable
+
+        weighted_observable = weights * observable
+
+        average_value = weighted_observable.value.sum(axis=0)
+        average_gradients = [
+            ParameterGradient(key=gradient.key, value=gradient.value.sum(axis=0))
+            for gradient in weighted_observable.gradients
+        ]
+
+        if return_type == Observable:
+
+            average_value = average_value.item()
+            average_gradients = [
+                ParameterGradient(key=gradient.key, value=gradient.value.item())
+                for gradient in average_gradients
+            ]
+
+        else:
+
+            average_value = average_value.reshape(1, -1)
+            average_gradients = [
+                ParameterGradient(key=gradient.key, value=gradient.value.reshape(1, -1))
+                for gradient in average_gradients
+            ]
+
+        if self.bootstrap_uncertainties is False:
+
+            # Unfortunately we need to re-compute the average observable for now
+            # as pymbar does not expose an easier way to compute the average
+            # uncertainty.
+            observable_dimensions = observable.value.shape[1]
+            assert observable_dimensions == 1
+
+            results = mbar.computeExpectations(
+                observable.value.T.magnitude,
+                target_reduced_potentials.value.T.magnitude,
+                state_dependent=True,
+            )
+
+            uncertainty = results[1][-1] * observable.value.units
+            average_value = average_value.plus_minus(uncertainty)
+
+        return return_type(value=average_value, gradients=average_gradients)
+
+
+@workflow_protocol()
+class ReweightObservable(BaseMBARProtocol):
+    """Reweight an array of observables to a new state using MBAR."""
+
+    observable = InputAttribute(
+        docstring="The observables to reweight. The array should contain the values of "
+        "the observable evaluated for of each configuration at the target state.",
+        type_hint=ObservableArray,
+        default_value=UNDEFINED,
+    )
+
+    def _observables(self) -> typing.Dict[str, ObservableArray]:
+        return {"observable": self.observable}
+
+
+@workflow_protocol()
+class ReweightDielectricConstant(BaseMBARProtocol):
+    """Computes the avergage value of the dielectric constant be re-weighting a set
+    a set of dipole moments and volumes using MBAR.
+    """
+
+    dipole_moments = InputAttribute(
+        docstring="The dipole moments evaluated at reference state's configurations"
+        "using the force field of the target state.",
+        type_hint=typing.Union[ObservableArray, list],
+        default_value=UNDEFINED,
+    )
+    volumes = InputAttribute(
+        docstring="The dipole moments evaluated at reference state's configurations"
+        "using the force field of the target state.",
+        type_hint=typing.Union[ObservableArray, list],
+        default_value=UNDEFINED,
+    )
+
+    thermodynamic_state = InputAttribute(
+        docstring="The thermodynamic state to re-weight to.",
+        type_hint=ThermodynamicState,
+        default_value=UNDEFINED,
+    )
+
+    def __init__(self, protocol_id):
+        super().__init__(protocol_id)
+        self.bootstrap_uncertainties = True
+
+    def _observables(self) -> typing.Dict[str, ObservableArray]:
+        return {"volumes": self.volumes, "dipole_moments": self.dipole_moments}
+
+    def _reweight_observables(
+        self,
+        weights: ObservableArray,
+        mbar: pymbar.MBAR,
+        target_reduced_potentials: ObservableArray,
+        **observables: ObservableArray,
+    ) -> Observable:
+
+        volumes = observables.pop("volumes")
+        dipole_moments = observables.pop("dipole_moments")
+
+        dielectric_constant = compute_dielectric_constant(
+            dipole_moments,
+            volumes,
+            self.thermodynamic_state.temperature,
+            functools.partial(
+                super(ReweightDielectricConstant, self)._reweight_observables,
+                weights=weights,
+                mbar=mbar,
+                target_reduced_potentials=target_reduced_potentials,
+            ),
+        )
+
+        return dielectric_constant
+
+    def _execute(self, directory, available_resources):
+
+        if not self.bootstrap_uncertainties:
+
+            raise ValueError(
+                "The uncertainty in the average dielectric constant should only be "
+                "computed using bootstrapping."
+            )
+
+        super(ReweightDielectricConstant, self)._execute(directory, available_resources)


### PR DESCRIPTION
## Description

This PR refactors the re-weighting protocols to make use of the new `Observable` objects, allowing them to return the gradients of the computed observables with respect to any requested force field parameters.

The gradients are computed by propagating the gradients of the target reduced potentials through to the MBAR calculated weights, and then through to the ensemble average of the observable itself (making sure to include contributions from the gradients of the observables themselves).

This PR greatly simplifies the logic in the `BaseMBARProtocol` by making use of the same paths for bootstrapped and non-bootstrapped uncertainties, and by also abstracting the functions which return the observables to re-weight, and which re-weight the observables themselves.

This new abstraction is utilised to cleanly implement a new `ReweightDielectricConstant` protocol in the `reweighting` module. This will replace the `ReweightDielectricConstant` protocol in the `dielectric` properties module.

# API changes

`ConcatenateStatistics` -> `ConcatenateObservables`
`BaseReducedPotentials` -> `BaseEvaluateEnergies`
`ReweightStatistics` -> `ReweightObservable`

## Status
- [X] Ready to go