### PR TITLE
[GRADIENTS] Remove Defunct Gradient Protocols

### DIFF
--- a/openff/evaluator/tests/test_protocols/test_gradient_protocols.py
+++ b/openff/evaluator/tests/test_protocols/test_gradient_protocols.py
@@ -1,34 +1,32 @@
-import random
+import os
 import tempfile
 
+import numpy as np
+
 from openff.evaluator import unit
-from openff.evaluator.backends import ComputeResources
 from openff.evaluator.forcefield import ParameterGradientKey
-from openff.evaluator.protocols.gradients import CentralDifferenceGradient
+from openff.evaluator.protocols.gradients import ZeroGradients
+from openff.evaluator.tests.utils import build_tip3p_smirnoff_force_field
+from openff.evaluator.utils.observables import ObservableArray
 
 
-def test_central_difference_gradient():
+def test_zero_gradient():
 
     with tempfile.TemporaryDirectory() as directory:
 
+        force_field_path = os.path.join(directory, "ff.json")
+
+        with open(force_field_path, "w") as file:
+            file.write(build_tip3p_smirnoff_force_field().json())
+
         gradient_key = ParameterGradientKey("vdW", "[#1]-[#8X2H2+0:1]-[#1]", "epsilon")
 
-        reverse_parameter = -random.random() * unit.kelvin
-        reverse_observable = -random.random() * unit.kelvin
+        zero_gradients = ZeroGradients("")
+        zero_gradients.input_observables = ObservableArray(value=0.0 * unit.kelvin)
+        zero_gradients.gradient_parameters = [gradient_key]
+        zero_gradients.force_field_path = force_field_path
+        zero_gradients.execute()
 
-        forward_parameter = random.random() * unit.kelvin
-        forward_observable = random.random() * unit.kelvin
-
-        central_difference = CentralDifferenceGradient("central_difference")
-        central_difference.parameter_key = gradient_key
-        central_difference.reverse_observable_value = reverse_observable
-        central_difference.reverse_parameter_value = reverse_parameter
-        central_difference.forward_observable_value = forward_observable
-        central_difference.forward_parameter_value = forward_parameter
-
-        central_difference.execute(directory, ComputeResources())
-
-        assert central_difference.gradient.value == (
-            (forward_observable - reverse_observable)
-            / (forward_parameter - reverse_parameter)
-        )
+        assert len(zero_gradients.output_observables.gradients) == 1
+        assert zero_gradients.output_observables.gradients[0].key == gradient_key
+        assert np.allclose(zero_gradients.output_observables.gradients[0].value, 0.0)


### PR DESCRIPTION
## Description
This PR removes the now defunct `BaseGradientPotentials` and `CentralDifferenceGradient` which were previously used to compute finite difference gradients. 

Further, this PR adds a new `ZeroGradients` utility protocol to zero out gradient information for a specified observable and for a specified set of force field parameters.

## Status
- [X] Ready to go