### PR TITLE
[GRADIENTS] Update Default Protocol Utils

### DIFF
--- a/openff/evaluator/protocols/utils.py
+++ b/openff/evaluator/protocols/utils.py
@@ -1,11 +1,11 @@
 """
 A set of utilities for setting up property estimation workflows.
 """
-import copy
-from collections import namedtuple
+from dataclasses import astuple, dataclass
+from typing import Generic, Optional, Tuple, TypeVar
 
 from openff.evaluator import unit
-from openff.evaluator.attributes import UNDEFINED, PlaceholderValue
+from openff.evaluator.attributes import PlaceholderValue
 from openff.evaluator.datasets import PropertyPhase
 from openff.evaluator.protocols import (
     analysis,
@@ -17,84 +17,111 @@ from openff.evaluator.protocols import (
     reweighting,
     storage,
 )
+from openff.evaluator.protocols.groups import ConditionalGroup
 from openff.evaluator.storage.data import StoredSimulationData
 from openff.evaluator.thermodynamics import Ensemble
-from openff.evaluator.utils.statistics import ObservableType
-from openff.evaluator.workflow import registered_workflow_protocols
+from openff.evaluator.utils.observables import ObservableType
+from openff.evaluator.workflow import ProtocolGroup
 from openff.evaluator.workflow.schemas import ProtocolReplicator
 from openff.evaluator.workflow.utils import ProtocolPath, ReplicatorValue
 
-BaseReweightingProtocols = namedtuple(
-    "BaseReweightingProtocols",
-    "unpack_stored_data "
-    "analysis_protocol "
-    "decorrelate_statistics "
-    "decorrelate_trajectory "
-    "concatenate_trajectories "
-    "concatenate_statistics "
-    "build_reference_system "
-    "reduced_reference_potential "
-    "build_target_system "
-    "reduced_target_potential "
-    "mbar_protocol ",
-)
+S = TypeVar("S", bound=analysis.BaseAverageObservable)
+T = TypeVar("T", bound=reweighting.BaseMBARProtocol)
 
 
-BaseSimulationProtocols = namedtuple(
-    "BaseSimulationProtocols",
-    "build_coordinates "
-    "assign_parameters "
-    "energy_minimisation "
-    "equilibration_simulation "
-    "production_simulation "
-    "analysis_protocol "
-    "converge_uncertainty "
-    "extract_uncorrelated_trajectory "
-    "extract_uncorrelated_statistics ",
-)
+@dataclass
+class SimulationProtocols(Generic[S]):
+    """The common set of protocols which would be required to estimate an observable
+    by running a new molecule simulation."""
+
+    build_coordinates: coordinates.BuildCoordinatesPackmol
+    assign_parameters: forcefield.BaseBuildSystem
+    energy_minimisation: openmm.OpenMMEnergyMinimisation
+    equilibration_simulation: openmm.OpenMMSimulation
+    production_simulation: openmm.OpenMMSimulation
+    analysis_protocol: S
+    converge_uncertainty: ProtocolGroup
+    decorrelate_trajectory: analysis.DecorrelateTrajectory
+    decorrelate_observables: analysis.DecorrelateObservables
+
+    def __iter__(self):
+        yield from astuple(self)
+
+
+@dataclass
+class ReweightingProtocols(Generic[S, T]):
+    """The common set of protocols which would be required to re-weight an observable
+    from cached simulation data."""
+
+    unpack_stored_data: storage.UnpackStoredSimulationData
+
+    join_trajectories: reweighting.ConcatenateTrajectories
+    join_observables: reweighting.ConcatenateObservables
+
+    build_reference_system: forcefield.BaseBuildSystem
+    evaluate_reference_potential: reweighting.BaseEvaluateEnergies
+
+    build_target_system: forcefield.BaseBuildSystem
+    evaluate_target_potential: reweighting.BaseEvaluateEnergies
+
+    statistical_inefficiency: S
+
+    decorrelate_reference_potential: analysis.DecorrelateObservables
+    decorrelate_target_potential: analysis.DecorrelateObservables
+
+    decorrelate_observable: analysis.DecorrelateObservables
+    zero_gradients: Optional[gradients.ZeroGradients]
+
+    reweight_observable: T
+
+    def __iter__(self):
+        yield from astuple(self)
 
 
 def generate_base_reweighting_protocols(
-    analysis_protocol,
-    mbar_protocol,
-    replicator_id="data_repl",
-    id_suffix="",
-):
-    """Constructs a set of protocols which, when combined in a workflow schema,
-    may be executed to reweight a set of existing data to estimate a particular
-    property. The reweighted observable of interest will be calculated by
-    following the passed in `analysis_protocol`.
+    statistical_inefficiency: S,
+    reweight_observable: T,
+    replicator_id: str = "data_replicator",
+    id_suffix: str = "",
+) -> Tuple[ReweightingProtocols[S, T], ProtocolReplicator]:
+    """Constructs a set of protocols which, when combined in a workflow schema, may be
+    executed to reweight a set of cached simulation data to estimate the average
+    value of an observable.
 
     Parameters
     ----------
-    analysis_protocol: AveragePropertyProtocol
-        The protocol which will take input from the stored data,
-        and generate a set of observables to reweight.
-    mbar_protocol: BaseReweightingProtocol
-        A template mbar reweighting protocol, which has it's reference
-        observables already set. This method will automatically set the
-        reduced potentials on this object.
+    statistical_inefficiency
+        The protocol which will be used to compute the statistical inefficiency and
+        equilibration time of the observable of interest. This information will be
+        used to decorrelate the cached data prior to reweighting.
+    reweight_observable
+        The MBAR reweighting protocol to use to reweight the observable to the target
+        state. This method will automatically set the reduced potentials on the
+        object.
     replicator_id: str
-        The id to use for the data replicator.
+        The id to use for the cached data replicator.
     id_suffix: str
         A string suffix to append to each of the protocol ids.
 
     Returns
     -------
-    BaseReweightingProtocols:
-        A named tuple of the protocol which should form the bulk of
-        a property estimation workflow.
-    ProtocolReplicator:
-        A replicator which will clone the workflow for each piece of
-        stored data.
+        The protocols to add to the workflow, a reference to the average value of the
+        estimated observable (an ``Observable`` object), and the replicator which will
+        clone the workflow for each piece of cached simulation data.
     """
 
-    assert isinstance(analysis_protocol, analysis.AveragePropertyProtocol)
+    # Create the replicator which will apply these protocol once for each piece of
+    # cached simulation data.
+    data_replicator = ProtocolReplicator(replicator_id=replicator_id)
+    data_replicator.template_values = ProtocolPath("full_system_data", "global")
 
-    assert f"$({replicator_id})" in analysis_protocol.id
-    assert f"$({replicator_id})" not in mbar_protocol.id
+    # Validate the inputs.
+    assert isinstance(statistical_inefficiency, analysis.BaseAverageObservable)
 
-    replicator_suffix = "_$({}){}".format(replicator_id, id_suffix)
+    assert data_replicator.placeholder_id in statistical_inefficiency.id
+    assert data_replicator.placeholder_id not in reweight_observable.id
+
+    replicator_suffix = f"_{data_replicator.placeholder_id}{id_suffix}"
 
     # Unpack all the of the stored data.
     unpack_stored_data = storage.UnpackStoredSimulationData(
@@ -102,81 +129,37 @@ def generate_base_reweighting_protocols(
     )
     unpack_stored_data.simulation_data_path = ReplicatorValue(replicator_id)
 
-    # The autocorrelation time of each of the stored files will be calculated for this property
-    # using the passed in analysis protocol.
-    if isinstance(analysis_protocol, analysis.ExtractAverageStatistic):
-
-        analysis_protocol.statistics_path = ProtocolPath(
-            "statistics_file_path", unpack_stored_data.id
-        )
-
-    elif isinstance(analysis_protocol, analysis.AverageTrajectoryProperty):
-
-        analysis_protocol.input_coordinate_file = ProtocolPath(
-            "coordinate_file_path", unpack_stored_data.id
-        )
-        analysis_protocol.trajectory_path = ProtocolPath(
-            "trajectory_file_path", unpack_stored_data.id
-        )
-
-    # Decorrelate the frames of the stored trajectory and statistics arrays.
-    decorrelate_statistics = analysis.ExtractUncorrelatedStatisticsData(
-        "decorrelate_stats{}".format(replicator_suffix)
+    # Join the individual trajectories together.
+    join_trajectories = reweighting.ConcatenateTrajectories(
+        f"join_trajectories{id_suffix}"
     )
-    decorrelate_statistics.statistical_inefficiency = ProtocolPath(
-        "statistical_inefficiency", analysis_protocol.id
-    )
-    decorrelate_statistics.equilibration_index = ProtocolPath(
-        "equilibration_index", analysis_protocol.id
-    )
-    decorrelate_statistics.input_statistics_path = ProtocolPath(
-        "statistics_file_path", unpack_stored_data.id
-    )
-
-    decorrelate_trajectory = analysis.ExtractUncorrelatedTrajectoryData(
-        "decorrelate_traj{}".format(replicator_suffix)
-    )
-    decorrelate_trajectory.statistical_inefficiency = ProtocolPath(
-        "statistical_inefficiency", analysis_protocol.id
-    )
-    decorrelate_trajectory.equilibration_index = ProtocolPath(
-        "equilibration_index", analysis_protocol.id
-    )
-    decorrelate_trajectory.input_coordinate_file = ProtocolPath(
-        "coordinate_file_path", unpack_stored_data.id
-    )
-    decorrelate_trajectory.input_trajectory_path = ProtocolPath(
-        "trajectory_file_path", unpack_stored_data.id
-    )
-
-    # Stitch together all of the trajectories
-    join_trajectories = reweighting.ConcatenateTrajectories("concat_traj" + id_suffix)
     join_trajectories.input_coordinate_paths = ProtocolPath(
         "coordinate_file_path", unpack_stored_data.id
     )
     join_trajectories.input_trajectory_paths = ProtocolPath(
-        "output_trajectory_path", decorrelate_trajectory.id
+        "trajectory_file_path", unpack_stored_data.id
     )
-
-    join_statistics = reweighting.ConcatenateStatistics("concat_stats" + id_suffix)
-    join_statistics.input_statistics_paths = ProtocolPath(
-        "output_statistics_path", decorrelate_statistics.id
+    join_observables = reweighting.ConcatenateObservables(
+        f"join_observables{id_suffix}"
+    )
+    join_observables.input_observables = ProtocolPath(
+        "observables", unpack_stored_data.id
     )
 
     # Calculate the reduced potentials for each of the reference states.
     build_reference_system = forcefield.BaseBuildSystem(
-        "build_system{}".format(replicator_suffix)
+        f"build_system{replicator_suffix}"
     )
     build_reference_system.force_field_path = ProtocolPath(
         "force_field_path", unpack_stored_data.id
     )
-    build_reference_system.substance = ProtocolPath("substance", unpack_stored_data.id)
     build_reference_system.coordinate_file_path = ProtocolPath(
         "coordinate_file_path", unpack_stored_data.id
     )
+    build_reference_system.substance = ProtocolPath("substance", unpack_stored_data.id)
 
-    reduced_reference_potential = openmm.OpenMMReducedPotentials(
-        "reduced_potential{}".format(replicator_suffix)
+    reduced_reference_potential = openmm.OpenMMEvaluateEnergies(
+        f"reduced_potential{replicator_suffix}"
     )
     reduced_reference_potential.parameterized_system = ProtocolPath(
         "parameterized_system", build_reference_system.id
@@ -190,20 +173,17 @@ def generate_base_reweighting_protocols(
     reduced_reference_potential.trajectory_file_path = ProtocolPath(
         "output_trajectory_path", join_trajectories.id
     )
-    reduced_reference_potential.kinetic_energies_path = ProtocolPath(
-        "output_statistics_path", join_statistics.id
-    )
 
     # Calculate the reduced potential of the target state.
-    build_target_system = forcefield.BaseBuildSystem("build_system_target" + id_suffix)
+    build_target_system = forcefield.BaseBuildSystem(f"build_system_target{id_suffix}")
     build_target_system.force_field_path = ProtocolPath("force_field_path", "global")
     build_target_system.substance = ProtocolPath("substance", "global")
     build_target_system.coordinate_file_path = ProtocolPath(
         "output_coordinate_path", join_trajectories.id
     )
 
-    reduced_target_potential = openmm.OpenMMReducedPotentials(
-        "reduced_potential_target" + id_suffix
+    reduced_target_potential = openmm.OpenMMEvaluateEnergies(
+        f"reduced_potential_target{id_suffix}"
     )
     reduced_target_potential.thermodynamic_state = ProtocolPath(
         "thermodynamic_state", "global"
@@ -217,71 +197,151 @@ def generate_base_reweighting_protocols(
     reduced_target_potential.trajectory_file_path = ProtocolPath(
         "output_trajectory_path", join_trajectories.id
     )
-    reduced_target_potential.kinetic_energies_path = ProtocolPath(
-        "output_statistics_path", join_statistics.id
+    reduced_target_potential.gradient_parameters = ProtocolPath(
+        "parameter_gradient_keys", "global"
+    )
+
+    # Compute the observable gradients.
+    zero_gradients = gradients.ZeroGradients(f"zero_gradients{id_suffix}")
+    zero_gradients.force_field_path = ProtocolPath("force_field_path", "global")
+    zero_gradients.gradient_parameters = ProtocolPath(
+        "parameter_gradient_keys", "global"
+    )
+
+    # Decorrelate the reduced potentials and observables.
+    if not isinstance(statistical_inefficiency, analysis.BaseAverageObservable):
+        raise NotImplementedError()
+
+    decorrelate_reference_potential = analysis.DecorrelateObservables(
+        f"decorrelate_reference_potential{replicator_suffix}"
+    )
+    decorrelate_reference_potential.time_series_statistics = ProtocolPath(
+        "time_series_statistics", statistical_inefficiency.id
+    )
+    decorrelate_reference_potential.input_observables = ProtocolPath(
+        "output_observables", reduced_reference_potential.id
+    )
+
+    decorrelate_target_potential = analysis.DecorrelateObservables(
+        f"decorrelate_target_potential{id_suffix}"
+    )
+    decorrelate_target_potential.time_series_statistics = ProtocolPath(
+        "time_series_statistics", statistical_inefficiency.id
+    )
+    decorrelate_target_potential.input_observables = ProtocolPath(
+        "output_observables", reduced_target_potential.id
+    )
+
+    decorrelate_observable = analysis.DecorrelateObservables(
+        f"decorrelate_observable{id_suffix}"
+    )
+    decorrelate_observable.time_series_statistics = ProtocolPath(
+        "time_series_statistics", statistical_inefficiency.id
+    )
+    decorrelate_observable.input_observables = ProtocolPath(
+        "output_observables", zero_gradients.id
     )
 
     # Finally, apply MBAR to get the reweighted value.
-    mbar_protocol.reference_reduced_potentials = ProtocolPath(
-        "statistics_file_path", reduced_reference_potential.id
+    reweight_observable.reference_reduced_potentials = ProtocolPath(
+        "output_observables[ReducedPotential]", decorrelate_reference_potential.id
     )
-    mbar_protocol.target_reduced_potentials = ProtocolPath(
-        "statistics_file_path", reduced_target_potential.id
+    reweight_observable.target_reduced_potentials = ProtocolPath(
+        "output_observables[ReducedPotential]", decorrelate_target_potential.id
+    )
+    reweight_observable.observable = ProtocolPath(
+        "output_observables", decorrelate_observable.id
+    )
+    reweight_observable.frame_counts = ProtocolPath(
+        "time_series_statistics.n_uncorrelated_points", statistical_inefficiency.id
+    )
+
+    protocols = ReweightingProtocols(
+        unpack_stored_data,
+        #
+        join_trajectories,
+        join_observables,
+        #
+        build_reference_system,
+        reduced_reference_potential,
+        #
+        build_target_system,
+        reduced_target_potential,
+        #
+        statistical_inefficiency,
+        #
+        decorrelate_reference_potential,
+        decorrelate_target_potential,
+        #
+        decorrelate_observable,
+        zero_gradients,
+        #
+        reweight_observable,
+    )
+
+    return protocols, data_replicator
+
+
+def generate_reweighting_protocols(
+    observable_type: ObservableType,
+    replicator_id: str = "data_replicator",
+    id_suffix: str = "",
+) -> Tuple[
+    ReweightingProtocols[analysis.AverageObservable, reweighting.ReweightObservable],
+    ProtocolReplicator,
+]:
+
+    assert observable_type != ObservableType.KineticEnergy
+
+    statistical_inefficiency = analysis.AverageObservable(
+        f"observable_inefficiency_$({replicator_id}){id_suffix}"
+    )
+    statistical_inefficiency.bootstrap_iterations = 1
+
+    reweight_observable = reweighting.ReweightObservable(
+        f"reweight_observable{id_suffix}"
+    )
+
+    protocols, data_replicator = generate_base_reweighting_protocols(
+        statistical_inefficiency, reweight_observable, replicator_id, id_suffix
+    )
+    protocols.statistical_inefficiency.observable = ProtocolPath(
+        f"observables[{observable_type.value}]", protocols.unpack_stored_data.id
     )
 
     if (
-        isinstance(mbar_protocol, reweighting.ReweightStatistics)
-        and mbar_protocol.statistics_type != ObservableType.PotentialEnergy
-        and mbar_protocol.statistics_type != ObservableType.TotalEnergy
-        and mbar_protocol.statistics_type != ObservableType.Enthalpy
-        and mbar_protocol.statistics_type != ObservableType.ReducedPotential
+        observable_type != ObservableType.PotentialEnergy
+        and observable_type != ObservableType.TotalEnergy
+        and observable_type != ObservableType.Enthalpy
+        and observable_type != ObservableType.ReducedPotential
     ):
 
-        mbar_protocol.statistics_paths = ProtocolPath(
-            "output_statistics_path", decorrelate_statistics.id
+        protocols.zero_gradients.input_observables = ProtocolPath(
+            f"output_observables[{observable_type.value}]",
+            protocols.join_observables.id,
         )
 
-    elif isinstance(mbar_protocol, reweighting.ReweightStatistics):
+    else:
 
-        mbar_protocol.statistics_paths = [
-            ProtocolPath("statistics_file_path", reduced_target_potential.id)
-        ]
-        mbar_protocol.frame_counts = ProtocolPath(
-            "number_of_uncorrelated_samples", decorrelate_statistics.id
+        protocols.zero_gradients = None
+        protocols.decorrelate_observable = protocols.decorrelate_target_potential
+        protocols.reweight_observable.observable = ProtocolPath(
+            f"output_observables[{observable_type.value}]",
+            protocols.decorrelate_observable.id,
         )
 
-    base_protocols = BaseReweightingProtocols(
-        unpack_stored_data,
-        analysis_protocol,
-        decorrelate_statistics,
-        decorrelate_trajectory,
-        join_trajectories,
-        join_statistics,
-        build_reference_system,
-        reduced_reference_potential,
-        build_target_system,
-        reduced_target_potential,
-        mbar_protocol,
-    )
-
-    # Create the replicator object.
-    component_replicator = ProtocolReplicator(replicator_id=replicator_id)
-    component_replicator.template_values = ProtocolPath("full_system_data", "global")
-
-    return base_protocols, component_replicator
+    return protocols, data_replicator
 
 
-def generate_base_simulation_protocols(
-    analysis_protocol,
-    use_target_uncertainty,
-    id_suffix="",
-    conditional_group=None,
-    n_molecules=1000,
-):
-    """Constructs a set of protocols which, when combined in a workflow schema,
-    may be executed to run a single simulation to estimate a particular
-    property. The observable of interest to extract from the simulation is determined
-    by the passed in `analysis_protocol`.
+def generate_simulation_protocols(
+    analysis_protocol: S,
+    use_target_uncertainty: bool,
+    id_suffix: str = "",
+    conditional_group: Optional[ConditionalGroup] = None,
+    n_molecules: int = 1000,
+) -> Tuple[SimulationProtocols[S], ProtocolPath, StoredSimulationData]:
+    """Constructs a set of protocols which, when combined in a workflow schema, may be
+    executed to run a single simulation to estimate the average value of an observable.
 
     The protocols returned will:
 
@@ -298,12 +358,13 @@ def generate_base_simulation_protocols(
 
         5) Within a conditional group (up to a maximum of 100 times):
 
-            5a) Run a longer NPT production simulation for 1000000 steps using a timestep of 2fs
+            5a) Run a longer NPT production simulation for 1000000 steps using a
+                timestep of 2fs
 
             5b) Extract the average value of an observable and it's uncertainty.
 
-            5c) If a convergence mode is set by the options, check if the target uncertainty has been met.
-                If not, repeat steps 5a), 5b) and 5c).
+            5c) If a convergence mode is set by the options, check if the target
+                uncertainty has been met. If not, repeat steps 5a), 5b) and 5c).
 
         6) Extract uncorrelated configurations from a generated production
            simulation.
@@ -313,10 +374,10 @@ def generate_base_simulation_protocols(
 
     Parameters
     ----------
-    analysis_protocol: AveragePropertyProtocol
+    analysis_protocol
         The protocol which will extract the observable of
         interest from the generated simulation data.
-    use_target_uncertainty: bool
+    use_target_uncertainty
         Whether to run the simulation until the observable is
         estimated to within the target uncertainty.
     id_suffix: str
@@ -332,17 +393,11 @@ def generate_base_simulation_protocols(
 
     Returns
     -------
-    BaseSimulationProtocols
-        A named tuple of the generated protocols.
-    ProtocolPath
-        A reference to the final value of the estimated observable
-        and its uncertainty (a `pint.Measurement`).
-    StoredSimulationData
-        An object which describes the default data from a simulation to store,
-        such as the uncorrelated statistics and configurations.
+        The protocols to add to the workflow, a reference to the average value of the
+        estimated observable (an ``Observable`` object), and an object which describes
+        the default data from a simulation to store, such as the uncorrelated statistics
+        and configurations.
     """
-
-    assert isinstance(analysis_protocol, analysis.AveragePropertyProtocol)
 
     build_coordinates = coordinates.BuildCoordinatesPackmol(
         f"build_coordinates{id_suffix}"
@@ -428,33 +483,26 @@ def generate_base_simulation_protocols(
 
     conditional_group.add_protocols(production_simulation, analysis_protocol)
 
-    # Point the analyse protocol to the correct data source
-    if isinstance(analysis_protocol, analysis.AverageTrajectoryProperty):
-        analysis_protocol.input_coordinate_file = ProtocolPath(
-            "coordinate_file_path", build_coordinates.id
-        )
-        analysis_protocol.trajectory_path = ProtocolPath(
-            "trajectory_file_path", production_simulation.id
-        )
+    # Point the analyse protocol to the correct data sources
+    if not isinstance(analysis_protocol, analysis.BaseAverageObservable):
 
-    elif isinstance(analysis_protocol, analysis.ExtractAverageStatistic):
-        analysis_protocol.statistics_path = ProtocolPath(
-            "statistics_file_path", production_simulation.id
-        )
-
-    else:
         raise ValueError(
             "The analysis protocol must inherit from either the "
-            "AverageTrajectoryProperty or ExtractAverageStatistic "
+            "AverageTrajectoryObservable or BaseAverageObservable "
             "protocols."
         )
 
-    # Finally, extract uncorrelated data
-    statistical_inefficiency = ProtocolPath(
-        "statistical_inefficiency", conditional_group.id, analysis_protocol.id
+    analysis_protocol.thermodynamic_state = ProtocolPath(
+        "thermodynamic_state", "global"
     )
-    equilibration_index = ProtocolPath(
-        "equilibration_index", conditional_group.id, analysis_protocol.id
+    analysis_protocol.potential_energies = ProtocolPath(
+        f"observables[{ObservableType.PotentialEnergy.value}]",
+        production_simulation.id,
+    )
+
+    # Finally, extract uncorrelated data
+    time_series_statistics = ProtocolPath(
+        "time_series_statistics", conditional_group.id, analysis_protocol.id
     )
     coordinate_file = ProtocolPath(
         "output_coordinate_file", conditional_group.id, production_simulation.id
@@ -462,24 +510,22 @@ def generate_base_simulation_protocols(
     trajectory_path = ProtocolPath(
         "trajectory_file_path", conditional_group.id, production_simulation.id
     )
-    statistics_path = ProtocolPath(
-        "statistics_file_path", conditional_group.id, production_simulation.id
+    observables = ProtocolPath(
+        "observables", conditional_group.id, production_simulation.id
     )
 
-    extract_uncorrelated_trajectory = analysis.ExtractUncorrelatedTrajectoryData(
-        f"extract_traj{id_suffix}"
+    decorrelate_trajectory = analysis.DecorrelateTrajectory(
+        f"decorrelate_trajectory{id_suffix}"
     )
-    extract_uncorrelated_trajectory.statistical_inefficiency = statistical_inefficiency
-    extract_uncorrelated_trajectory.equilibration_index = equilibration_index
-    extract_uncorrelated_trajectory.input_coordinate_file = coordinate_file
-    extract_uncorrelated_trajectory.input_trajectory_path = trajectory_path
+    decorrelate_trajectory.time_series_statistics = time_series_statistics
+    decorrelate_trajectory.input_coordinate_file = coordinate_file
+    decorrelate_trajectory.input_trajectory_path = trajectory_path
 
-    extract_uncorrelated_statistics = analysis.ExtractUncorrelatedStatisticsData(
-        f"extract_stats{id_suffix}"
+    decorrelate_observables = analysis.DecorrelateObservables(
+        f"decorrelate_observables{id_suffix}"
     )
-    extract_uncorrelated_statistics.statistical_inefficiency = statistical_inefficiency
-    extract_uncorrelated_statistics.equilibration_index = equilibration_index
-    extract_uncorrelated_statistics.input_statistics_path = statistics_path
+    decorrelate_observables.time_series_statistics = time_series_statistics
+    decorrelate_observables.input_observables = observables
 
     # Build the object which defines which pieces of simulation data to store.
     output_to_store = StoredSimulationData()
@@ -493,12 +539,16 @@ def generate_base_simulation_protocols(
         "output_number_of_molecules", build_coordinates.id
     )
     output_to_store.substance = ProtocolPath("output_substance", build_coordinates.id)
-    output_to_store.statistical_inefficiency = statistical_inefficiency
-    output_to_store.statistics_file_name = ProtocolPath(
-        "output_statistics_path", extract_uncorrelated_statistics.id
+    output_to_store.statistical_inefficiency = ProtocolPath(
+        "time_series_statistics.statistical_inefficiency",
+        conditional_group.id,
+        analysis_protocol.id,
+    )
+    output_to_store.observables = ProtocolPath(
+        "output_observables", decorrelate_observables.id
     )
     output_to_store.trajectory_file_name = ProtocolPath(
-        "output_trajectory_path", extract_uncorrelated_trajectory.id
+        "output_trajectory_path", decorrelate_trajectory.id
     )
     output_to_store.coordinate_file_name = coordinate_file
 
@@ -509,7 +559,7 @@ def generate_base_simulation_protocols(
         "value", conditional_group.id, analysis_protocol.id
     )
 
-    base_protocols = BaseSimulationProtocols(
+    base_protocols = SimulationProtocols(
         build_coordinates,
         assign_parameters,
         energy_minimisation,
@@ -517,200 +567,8 @@ def generate_base_simulation_protocols(
         production_simulation,
         analysis_protocol,
         conditional_group,
-        extract_uncorrelated_trajectory,
-        extract_uncorrelated_statistics,
+        decorrelate_trajectory,
+        decorrelate_observables,
     )
 
     return base_protocols, final_value_source, output_to_store
-
-
-def generate_gradient_protocol_group(
-    template_reweighting_protocol,
-    force_field_path,
-    coordinate_file_path,
-    trajectory_file_path,
-    statistics_file_path,
-    replicator_id="repl",
-    substance_source=None,
-    id_suffix="",
-    enable_pbc=True,
-    effective_sample_indices=None,
-):
-    """Constructs a set of protocols which, when combined in a workflow schema,
-    may be executed to reweight a set of existing data to estimate a particular
-    property. The reweighted observable of interest will be calculated by
-    following the passed in `analysis_protocol`.
-
-    Parameters
-    ----------
-    template_reweighting_protocol: BaseMBARProtocol
-        A template protocol which will be used to reweight the observable of
-        interest to small perturbations to the parameter of interest. These
-        will then be used to calculate the finite difference gradient.
-
-        The template *must* have it's `reference_reduced_potentials` input set.
-        The `target_reduced_potentials` input will be set automatically by this
-        function.
-
-        In the case that the template is of type `ReweightStatistics` and the
-        observable is an energy, the statistics path will automatically be pointed
-        to the energies evaluated using the perturbed parameter as opposed to the
-        energy measured during the reference simulation.
-    force_field_path: ProtocolPath
-        The path to the force field parameters which the observables are being
-         estimated at.
-    coordinate_file_path: ProtocolPath
-        A path to the initial coordinates of the simulation trajectory which
-        was used to estimate the observable of interest.
-    trajectory_file_path: ProtocolPath
-        A path to the simulation trajectory which was used
-        to estimate the observable of interest.
-    statistics_file_path: ProtocolPath, optional
-        A path to the statistics which were generated alongside
-        the trajectory passed to the `trajectory_file_path`. These
-        should have been generated using the passed `force_field_path`.
-    replicator_id: str
-        A unique id which will be used for the protocol replicator which will
-        replicate this group for every parameter of interest.
-    substance_source: PlaceholderValue, optional
-        An optional protocol path to the substance whose gradient
-        is being estimated. If None, the global property substance
-        is used.
-    id_suffix: str
-        An optional string to append to the end of each of the
-        protocol ids.
-    enable_pbc: bool
-        If true, periodic boundary conditions are employed when recalculating
-        the reduced potentials.
-    effective_sample_indices: ProtocolPath, optional
-        A placeholder variable which in future will ensure that only samples
-        with a non-zero weight are included in the gradient calculation.
-
-    Returns
-    -------
-    ProtocolGroup
-        The protocol group which will estimate the gradient of
-        an observable with respect to one parameter.
-    ProtocolReplicator
-        The replicator which will copy the gradient group for
-        every parameter of interest.
-    ProtocolPath
-        A protocol path which points to the final gradient value.
-    """
-
-    assert isinstance(template_reweighting_protocol, reweighting.BaseMBARProtocol)
-    assert template_reweighting_protocol.reference_reduced_potentials is not None
-    assert template_reweighting_protocol.reference_reduced_potentials != UNDEFINED
-
-    id_suffix = f"_$({replicator_id}){id_suffix}"
-
-    # Set values of the optional parameters.
-    substance_source = (
-        ProtocolPath("substance", "global")
-        if substance_source is None
-        else substance_source
-    )
-    effective_sample_indices = (
-        effective_sample_indices if effective_sample_indices is not None else []
-    )
-
-    # Define the protocol which will evaluate the reduced potentials of the
-    # reference, forward and reverse states using only a subset of the full
-    # force field.
-    reduced_potentials = openmm.OpenMMGradientPotentials(
-        f"gradient_reduced_potentials{id_suffix}"
-    )
-    reduced_potentials.substance = substance_source
-    reduced_potentials.thermodynamic_state = ProtocolPath(
-        "thermodynamic_state", "global"
-    )
-    reduced_potentials.force_field_path = force_field_path
-    reduced_potentials.statistics_path = statistics_file_path
-    reduced_potentials.trajectory_file_path = trajectory_file_path
-    reduced_potentials.coordinate_file_path = coordinate_file_path
-    reduced_potentials.parameter_key = ReplicatorValue(replicator_id)
-    reduced_potentials.enable_pbc = enable_pbc
-    reduced_potentials.effective_sample_indices = effective_sample_indices
-
-    # Set up the protocols which will actually reweight the value of the
-    # observable to the forward and reverse states.
-    template_reweighting_protocol.bootstrap_iterations = 1
-    template_reweighting_protocol.required_effective_samples = 0
-
-    # We need to make sure we use the observable evaluated at the target state
-    # if the observable depends on the parameter being reweighted.
-    use_target_state_energies = isinstance(
-        template_reweighting_protocol, reweighting.ReweightStatistics
-    ) and (
-        template_reweighting_protocol.statistics_type == ObservableType.PotentialEnergy
-        or template_reweighting_protocol.statistics_type
-        == ObservableType.ReducedPotential
-        or template_reweighting_protocol.statistics_type == ObservableType.TotalEnergy
-        or template_reweighting_protocol.statistics_type == ObservableType.Enthalpy
-    )
-
-    template_reweighting_schema = template_reweighting_protocol.schema
-
-    # Create the reweighting protocols from the template schema.
-    reverse_mbar_schema = copy.deepcopy(template_reweighting_schema)
-    reverse_mbar_schema.id = f"reverse_reweight{id_suffix}"
-    reverse_mbar = registered_workflow_protocols[reverse_mbar_schema.type](
-        reverse_mbar_schema.id
-    )
-    reverse_mbar.schema = reverse_mbar_schema
-    reverse_mbar.target_reduced_potentials = ProtocolPath(
-        "reverse_potentials_path", reduced_potentials.id
-    )
-
-    forward_mbar_schema = copy.deepcopy(template_reweighting_schema)
-    forward_mbar_schema.id = f"forward_reweight{id_suffix}"
-    forward_mbar = registered_workflow_protocols[forward_mbar_schema.type](
-        forward_mbar_schema.id
-    )
-    forward_mbar.schema = forward_mbar_schema
-    forward_mbar.target_reduced_potentials = ProtocolPath(
-        "forward_potentials_path", reduced_potentials.id
-    )
-
-    if use_target_state_energies:
-
-        reverse_mbar.statistics_paths = [
-            ProtocolPath("reverse_potentials_path", reduced_potentials.id)
-        ]
-        forward_mbar.statistics_paths = [
-            ProtocolPath("forward_potentials_path", reduced_potentials.id)
-        ]
-
-    # Set up the protocol which will actually evaluate the parameter gradient
-    # using the central difference method.
-    central_difference = gradients.CentralDifferenceGradient(
-        f"central_difference{id_suffix}"
-    )
-    central_difference.parameter_key = ReplicatorValue(replicator_id)
-    central_difference.reverse_observable_value = ProtocolPath("value", reverse_mbar.id)
-    central_difference.forward_observable_value = ProtocolPath("value", forward_mbar.id)
-    central_difference.reverse_parameter_value = ProtocolPath(
-        "reverse_parameter_value", reduced_potentials.id
-    )
-    central_difference.forward_parameter_value = ProtocolPath(
-        "forward_parameter_value", reduced_potentials.id
-    )
-
-    # Assemble all of the protocols into a convenient group.
-    gradient_group = groups.ProtocolGroup(f"gradient_group{id_suffix}")
-    gradient_group.add_protocols(
-        reduced_potentials, reverse_mbar, forward_mbar, central_difference
-    )
-
-    # Create the replicator which will copy the group for each parameter gradient
-    # which will be calculated.
-    parameter_replicator = ProtocolReplicator(replicator_id=replicator_id)
-    parameter_replicator.template_values = ProtocolPath(
-        "parameter_gradient_keys", "global"
-    )
-
-    return (
-        gradient_group,
-        parameter_replicator,
-        ProtocolPath("gradient", gradient_group.id, central_difference.id),
-    )


### PR DESCRIPTION
## Description
This PR updates the `generate_base_reweighting_protocols`, `generate_reweighting_protocols` and `generate_simulation_protocols` to make use of the new `Observable` objects, removing all protocols which were previously required to compute finite difference gradients.

## Status
- [X] Ready to go