### PR TITLE
[GRADIENTS] Update Physical Property Workflows

### DIFF
--- a/openff/evaluator/properties/density.py
+++ b/openff/evaluator/properties/density.py
@@ -1,25 +1,23 @@
 """
 A collection of density physical property definitions.
 """
-import copy
 
 from openff.evaluator import unit
-from openff.evaluator.attributes import UNDEFINED, PlaceholderValue
+from openff.evaluator.attributes import UNDEFINED
 from openff.evaluator.datasets import PhysicalProperty, PropertyPhase
 from openff.evaluator.datasets.thermoml import thermoml_property
 from openff.evaluator.layers import register_calculation_schema
 from openff.evaluator.layers.reweighting import ReweightingLayer, ReweightingSchema
 from openff.evaluator.layers.simulation import SimulationLayer, SimulationSchema
-from openff.evaluator.protocols import analysis, miscellaneous, reweighting
+from openff.evaluator.properties.properties import EstimableExcessProperty
+from openff.evaluator.protocols import analysis
 from openff.evaluator.protocols.utils import (
-    generate_base_reweighting_protocols,
-    generate_base_simulation_protocols,
-    generate_gradient_protocol_group,
+    generate_reweighting_protocols,
+    generate_simulation_protocols,
 )
-from openff.evaluator.storage.query import SimulationDataQuery, SubstanceQuery
-from openff.evaluator.utils.statistics import ObservableType
-from openff.evaluator.workflow.schemas import ProtocolReplicator, WorkflowSchema
-from openff.evaluator.workflow.utils import ProtocolPath, ReplicatorValue
+from openff.evaluator.utils.observables import ObservableType
+from openff.evaluator.workflow.schemas import WorkflowSchema
+from openff.evaluator.workflow.utils import ProtocolPath
 
 
 @thermoml_property("Mass density, kg/m3", supported_phases=PropertyPhase.Liquid)
@@ -33,7 +31,7 @@ class Density(PhysicalProperty):
     @staticmethod
     def default_simulation_schema(
         absolute_tolerance=UNDEFINED, relative_tolerance=UNDEFINED, n_molecules=1000
-    ):
+    ) -> SimulationSchema:
         """Returns the default calculation schema to use when estimating
         this class of property from direct simulations.
 
@@ -62,48 +60,16 @@ class Density(PhysicalProperty):
             absolute_tolerance != UNDEFINED or relative_tolerance != UNDEFINED
         )
 
-        # Define the protocol which will extract the average density from
-        # the results of a simulation.
-        extract_density = analysis.ExtractAverageStatistic("extract_density")
-        extract_density.statistics_type = ObservableType.Density
-
         # Define the protocols which will run the simulation itself.
-        protocols, value_source, output_to_store = generate_base_simulation_protocols(
-            extract_density,
+        protocols, value_source, output_to_store = generate_simulation_protocols(
+            analysis.AverageObservable("average_density"),
             use_target_uncertainty,
             n_molecules=n_molecules,
         )
-
-        # Set up the gradient calculations
-        coordinate_source = ProtocolPath(
-            "output_coordinate_file", protocols.equilibration_simulation.id
-        )
-        trajectory_source = ProtocolPath(
-            "trajectory_file_path",
-            protocols.converge_uncertainty.id,
+        # Specify that the average density should be estimated.
+        protocols.analysis_protocol.observable = ProtocolPath(
+            f"observables[{ObservableType.Density.value}]",
             protocols.production_simulation.id,
-        )
-        statistics_source = ProtocolPath(
-            "statistics_file_path",
-            protocols.converge_uncertainty.id,
-            protocols.production_simulation.id,
-        )
-
-        reweight_density_template = reweighting.ReweightStatistics("")
-        reweight_density_template.statistics_type = ObservableType.Density
-        reweight_density_template.statistics_paths = statistics_source
-        reweight_density_template.reference_reduced_potentials = statistics_source
-
-        (
-            gradient_group,
-            gradient_replicator,
-            gradient_source,
-        ) = generate_gradient_protocol_group(
-            reweight_density_template,
-            ProtocolPath("force_field_path", "global"),
-            coordinate_source,
-            trajectory_source,
-            statistics_source,
         )
 
         # Build the workflow schema.
@@ -115,16 +81,11 @@ class Density(PhysicalProperty):
             protocols.energy_minimisation.schema,
             protocols.equilibration_simulation.schema,
             protocols.converge_uncertainty.schema,
-            protocols.extract_uncorrelated_trajectory.schema,
-            protocols.extract_uncorrelated_statistics.schema,
-            gradient_group.schema,
+            protocols.decorrelate_trajectory.schema,
+            protocols.decorrelate_observables.schema,
         ]
 
-        schema.protocol_replicators = [gradient_replicator]
-
         schema.outputs_to_store = {"full_system": output_to_store}
-
-        schema.gradients_sources = [gradient_source]
         schema.final_value_source = value_source
 
         calculation_schema.workflow_schema = schema
@@ -135,7 +96,7 @@ class Density(PhysicalProperty):
         absolute_tolerance=UNDEFINED,
         relative_tolerance=UNDEFINED,
         n_effective_samples=50,
-    ):
+    ) -> ReweightingSchema:
         """Returns the default calculation schema to use when estimating
         this property by reweighting existing data.
 
@@ -161,810 +122,34 @@ class Density(PhysicalProperty):
         calculation_schema.absolute_tolerance = absolute_tolerance
         calculation_schema.relative_tolerance = relative_tolerance
 
-        data_replicator_id = "data_replicator"
-
-        # The protocol which will be used to calculate the densities from
-        # the existing data.
-        density_calculation = analysis.ExtractAverageStatistic(
-            f"calc_density_$({data_replicator_id})"
+        protocols, data_replicator = generate_reweighting_protocols(
+            ObservableType.Density
         )
-        density_calculation.statistics_type = ObservableType.Density
-
-        reweight_density = reweighting.ReweightStatistics("reweight_density")
-        reweight_density.statistics_type = ObservableType.Density
-        reweight_density.required_effective_samples = n_effective_samples
-
-        protocols, data_replicator = generate_base_reweighting_protocols(
-            density_calculation, reweight_density, data_replicator_id
-        )
-
-        # Set up the gradient calculations
-        coordinate_path = ProtocolPath(
-            "output_coordinate_path", protocols.concatenate_trajectories.id
-        )
-        trajectory_path = ProtocolPath(
-            "output_trajectory_path", protocols.concatenate_trajectories.id
-        )
-        statistics_path = ProtocolPath(
-            "statistics_file_path", protocols.reduced_target_potential.id
-        )
-
-        reweight_density_template = copy.deepcopy(reweight_density)
-
-        (
-            gradient_group,
-            gradient_replicator,
-            gradient_source,
-        ) = generate_gradient_protocol_group(
-            reweight_density_template,
-            ProtocolPath("force_field_path", "global"),
-            coordinate_path,
-            trajectory_path,
-            statistics_path,
-            replicator_id="grad",
-            effective_sample_indices=ProtocolPath(
-                "effective_sample_indices", protocols.mbar_protocol.id
-            ),
-        )
+        protocols.reweight_observable.required_effective_samples = n_effective_samples
 
         schema = WorkflowSchema()
-        schema.protocol_schemas = [
-            *(x.schema for x in protocols),
-            gradient_group.schema,
-        ]
-        schema.protocol_replicators = [data_replicator, gradient_replicator]
-        schema.gradients_sources = [gradient_source]
-        schema.final_value_source = ProtocolPath("value", protocols.mbar_protocol.id)
+        schema.protocol_schemas = [x.schema for x in protocols]
+        schema.protocol_replicators = [data_replicator]
+
+        schema.final_value_source = ProtocolPath(
+            "value", protocols.reweight_observable.id
+        )
 
         calculation_schema.workflow_schema = schema
         return calculation_schema
 
 
 @thermoml_property("Excess molar volume, m3/mol", supported_phases=PropertyPhase.Liquid)
-class ExcessMolarVolume(PhysicalProperty):
+class ExcessMolarVolume(EstimableExcessProperty):
     """A class representation of an excess molar volume property"""
 
     @classmethod
     def default_unit(cls):
         return unit.centimeter ** 3 / unit.mole
 
-    @staticmethod
-    def _get_simulation_protocols(
-        id_suffix,
-        gradient_replicator_id,
-        replicator_id=None,
-        weight_by_mole_fraction=False,
-        component_substance_reference=None,
-        full_substance_reference=None,
-        use_target_uncertainty=False,
-        n_molecules=1000,
-    ):
-
-        """Returns the set of protocols which when combined in a workflow
-        will yield the molar volume of a substance.
-
-        Parameters
-        ----------
-        id_suffix: str
-            A suffix to append to the id of each of the returned protocols.
-        gradient_replicator_id: str
-            The id of the replicator which will clone those protocols which will
-            estimate the gradient of the molar volume with respect to a given parameter.
-        replicator_id: str, optional
-            The id of the replicator which will be used to clone these protocols.
-            This will be appended to the id of each of the returned protocols if
-            set.
-        weight_by_mole_fraction: bool
-            If true, an extra protocol will be added to weight the calculated
-            molar volume by the mole fraction of the component.
-        component_substance_reference: ProtocolPath or PlaceholderValue, optional
-            An optional protocol path (or replicator reference) to the component substance
-            whose enthalpy is being estimated.
-        full_substance_reference: ProtocolPath or PlaceholderValue, optional
-            An optional protocol path (or replicator reference) to the full substance
-            whose enthalpy of mixing is being estimated. This cannot be `None` if
-            `weight_by_mole_fraction` is `True`.
-        use_target_uncertainty: bool
-            Whether to calculate the observable to within the target
-            uncertainty.
-        n_molecules: int
-            The number of molecules to use in the simulation.
-
-        Returns
-        -------
-        BaseSimulationProtocols
-            The protocols used to estimate the molar volume of a substance.
-        DivideValue
-            The protocol used to calculate the number of molar molecules in
-            the system.
-        ProtocolPath
-            A reference to the estimated molar volume.
-        WorkflowSimulationDataToStore
-            An object which describes the default data from a simulation to store,
-            such as the uncorrelated statistics and configurations.
-        ProtocolGroup
-            The group of protocols which will calculate the gradient of the reduced potential
-            with respect to a given property.
-        ProtocolReplicator
-            The protocol which will replicate the gradient group for every gradient to
-            estimate.
-        ProtocolPath
-            A reference to the value of the gradient.
-        """
-
-        if replicator_id is not None:
-            id_suffix = f"{id_suffix}_$({replicator_id})"
-
-        if component_substance_reference is None:
-            component_substance_reference = ProtocolPath("substance", "global")
-
-        if weight_by_mole_fraction is True and full_substance_reference is None:
-
-            raise ValueError(
-                "The full substance reference must be set when weighting by"
-                "the mole fraction"
-            )
-
-        # Define the protocol which will extract the average molar volume from
-        # the results of a simulation.
-        extract_volume = analysis.ExtractAverageStatistic(f"extract_volume{id_suffix}")
-        extract_volume.statistics_type = ObservableType.Volume
-
-        # Define the protocols which will run the simulation itself.
-        (
-            simulation_protocols,
-            value_source,
-            output_to_store,
-        ) = generate_base_simulation_protocols(
-            extract_volume, use_target_uncertainty, id_suffix, n_molecules=n_molecules
-        )
-
-        # Divide the volume by the number of molecules in the system
-        number_of_molecules = ProtocolPath(
-            "output_number_of_molecules", simulation_protocols.build_coordinates.id
-        )
-        built_substance = ProtocolPath(
-            "output_substance", simulation_protocols.build_coordinates.id
-        )
-
-        number_of_molar_molecules = miscellaneous.DivideValue(
-            f"number_of_molar_molecules{id_suffix}"
-        )
-        number_of_molar_molecules.value = number_of_molecules
-        number_of_molar_molecules.divisor = (1.0 * unit.avogadro_constant).to(
-            "mole**-1"
-        )
-
-        extract_volume.divisor = ProtocolPath("result", number_of_molar_molecules.id)
-
-        # Use the correct substance.
-        simulation_protocols.build_coordinates.substance = component_substance_reference
-        simulation_protocols.assign_parameters.substance = built_substance
-        output_to_store.substance = built_substance
-
-        conditional_group = simulation_protocols.converge_uncertainty
-
-        if weight_by_mole_fraction:
-            # The component workflows need an extra step to multiply their molar volumes by their
-            # relative mole fraction.
-            weight_by_mole_fraction = miscellaneous.WeightByMoleFraction(
-                f"weight_by_mole_fraction{id_suffix}"
-            )
-            weight_by_mole_fraction.value = ProtocolPath("value", extract_volume.id)
-            weight_by_mole_fraction.full_substance = full_substance_reference
-            weight_by_mole_fraction.component = component_substance_reference
-
-            conditional_group.add_protocols(weight_by_mole_fraction)
-
-            value_source = ProtocolPath(
-                "weighted_value", conditional_group.id, weight_by_mole_fraction.id
-            )
-
-        if use_target_uncertainty:
-
-            # Make sure the convergence criteria is set to use the per component
-            # uncertainty target.
-            conditional_group.conditions[0].right_hand_value = ProtocolPath(
-                "per_component_uncertainty", "global"
-            )
-
-            if weight_by_mole_fraction:
-                # Make sure the weighted uncertainty is being used in the conditional comparison.
-                conditional_group.conditions[0].left_hand_value = ProtocolPath(
-                    "weighted_value.error",
-                    conditional_group.id,
-                    weight_by_mole_fraction.id,
-                )
-
-        # Set up the gradient calculations
-        coordinate_source = ProtocolPath(
-            "output_coordinate_file", simulation_protocols.equilibration_simulation.id
-        )
-        trajectory_source = ProtocolPath(
-            "trajectory_file_path",
-            simulation_protocols.converge_uncertainty.id,
-            simulation_protocols.production_simulation.id,
-        )
-        statistics_source = ProtocolPath(
-            "statistics_file_path",
-            simulation_protocols.converge_uncertainty.id,
-            simulation_protocols.production_simulation.id,
-        )
-
-        reweight_molar_volume_template = reweighting.ReweightStatistics("")
-        reweight_molar_volume_template.statistics_type = ObservableType.Volume
-        reweight_molar_volume_template.statistics_paths = statistics_source
-        reweight_molar_volume_template.reference_reduced_potentials = statistics_source
-
-        (
-            gradient_group,
-            gradient_replicator,
-            gradient_source,
-        ) = generate_gradient_protocol_group(
-            reweight_molar_volume_template,
-            ProtocolPath("force_field_path", "global"),
-            coordinate_source,
-            trajectory_source,
-            statistics_source,
-            replicator_id=gradient_replicator_id,
-            substance_source=built_substance,
-            id_suffix=id_suffix,
-        )
-
-        # Remove the group id from the path.
-        gradient_source.pop_next_in_path()
-
-        if weight_by_mole_fraction:
-            # The component workflows need an extra step to multiply their gradients by their
-            # relative mole fraction.
-            weight_gradient = miscellaneous.WeightByMoleFraction(
-                f"weight_gradient_by_mole_fraction{id_suffix}"
-            )
-            weight_gradient.value = gradient_source
-            weight_gradient.full_substance = full_substance_reference
-            weight_gradient.component = component_substance_reference
-
-            gradient_group.add_protocols(weight_gradient)
-            gradient_source = ProtocolPath("weighted_value", weight_gradient.id)
-
-        scale_gradient = miscellaneous.DivideValue(f"scale_gradient{id_suffix}")
-        scale_gradient.value = gradient_source
-        scale_gradient.divisor = ProtocolPath("result", number_of_molar_molecules.id)
-
-        gradient_group.add_protocols(scale_gradient)
-        gradient_source = ProtocolPath("result", gradient_group.id, scale_gradient.id)
-
-        return (
-            simulation_protocols,
-            number_of_molar_molecules,
-            value_source,
-            output_to_store,
-            gradient_group,
-            gradient_replicator,
-            gradient_source,
-        )
-
-    @staticmethod
-    def _get_reweighting_protocols(
-        id_suffix,
-        gradient_replicator_id,
-        data_replicator_id,
-        replicator_id=None,
-        weight_by_mole_fraction=False,
-        substance_reference=None,
-        n_effective_samples=50,
-    ):
-
-        """Returns the set of protocols which when combined in a workflow
-        will yield the molar volume of a substance by reweighting cached data.
-
-        Parameters
-        ----------
-        id_suffix: str
-            A suffix to append to the id of each of the returned protocols.
-        gradient_replicator_id: str
-            The id of the replicator which will clone those protocols which will
-            estimate the gradient of the molar volume with respect to a given parameter.
-        data_replicator_id: str
-            The id of the replicator which will be used to clone these protocols
-            for each cached simulation data.
-        replicator_id: str, optional
-            The optional id of the replicator which will be used to clone these
-            protocols, e.g. for each component in the system.
-        weight_by_mole_fraction: bool
-            If true, an extra protocol will be added to weight the calculated
-            molar volume by the mole fraction of the component.
-        substance_reference: ProtocolPath or PlaceholderValue, optional
-            An optional protocol path (or replicator reference) to the substance
-            whose molar volume is being estimated.
-        n_effective_samples: int
-            The minimum number of effective samples to require when
-            reweighting the cached simulation data.
-
-        Returns
-        -------
-        BaseReweightingProtocols
-            The protocols used to estimate the molar volume of a substance.
-        ProtocolPath
-            A reference to the estimated molar volume.
-        ProtocolReplicator
-            The replicator which will replicate each protocol for each
-            cached simulation datum.
-        ProtocolGroup
-            The group of protocols which will calculate the gradient of the reduced potential
-            with respect to a given property.
-        ProtocolPath
-            A reference to the value of the gradient.
-        """
-
-        if replicator_id is not None:
-            id_suffix = f"{id_suffix}_$({replicator_id})"
-
-        full_id_suffix = id_suffix
-
-        if data_replicator_id is not None:
-            full_id_suffix = f"{id_suffix}_$({data_replicator_id})"
-
-        if substance_reference is None:
-            substance_reference = ProtocolPath("substance", "global")
-
-        extract_volume = analysis.ExtractAverageStatistic(
-            f"extract_volume{full_id_suffix}"
-        )
-        extract_volume.statistics_type = ObservableType.Volume
-        reweight_volume = reweighting.ReweightStatistics(f"reweight_volume{id_suffix}")
-        reweight_volume.statistics_type = ObservableType.Volume
-        reweight_volume.required_effective_samples = n_effective_samples
-
-        (protocols, data_replicator) = generate_base_reweighting_protocols(
-            analysis_protocol=extract_volume,
-            mbar_protocol=reweight_volume,
-            replicator_id=data_replicator_id,
-            id_suffix=id_suffix,
-        )
-
-        # Make sure to use the correct substance.
-        protocols.build_target_system.substance = substance_reference
-
-        value_source = ProtocolPath("value", protocols.mbar_protocol.id)
-
-        # Set up the protocols which will be responsible for adding together
-        # the component molar volumes, and subtracting these from the full system volume.
-        weight_volume = None
-
-        if weight_by_mole_fraction is True:
-            weight_volume = miscellaneous.WeightByMoleFraction(
-                f"weight_volume{id_suffix}"
-            )
-            weight_volume.value = ProtocolPath("value", protocols.mbar_protocol.id)
-            weight_volume.full_substance = ProtocolPath("substance", "global")
-            weight_volume.component = substance_reference
-
-            value_source = ProtocolPath("weighted_value", weight_volume.id)
-
-        # Divide by the component molar volumes by the number of molecules in the system
-        number_of_molecules = ProtocolPath(
-            "total_number_of_molecules",
-            protocols.unpack_stored_data.id.replace(f"$({data_replicator_id})", "0"),
-        )
-
-        number_of_molar_molecules = miscellaneous.MultiplyValue(
-            f"number_of_molar_molecules{id_suffix}"
-        )
-        number_of_molar_molecules.value = (1.0 / unit.avogadro_constant).to(unit.mole)
-        number_of_molar_molecules.multiplier = number_of_molecules
-
-        divide_by_molecules = miscellaneous.DivideValue(
-            f"divide_by_molecules{id_suffix}"
-        )
-        divide_by_molecules.value = value_source
-        divide_by_molecules.divisor = ProtocolPath(
-            "result", number_of_molar_molecules.id
-        )
-
-        value_source = ProtocolPath("result", divide_by_molecules.id)
-
-        # Set up the gradient calculations.
-        reweight_volume_template = copy.deepcopy(reweight_volume)
-
-        coordinate_path = ProtocolPath(
-            "output_coordinate_path", protocols.concatenate_trajectories.id
-        )
-        trajectory_path = ProtocolPath(
-            "output_trajectory_path", protocols.concatenate_trajectories.id
-        )
-        statistics_path = ProtocolPath(
-            "statistics_file_path", protocols.reduced_target_potential.id
-        )
-
-        gradient_group, _, gradient_source = generate_gradient_protocol_group(
-            reweight_volume_template,
-            ProtocolPath("force_field_path", "global"),
-            coordinate_path,
-            trajectory_path,
-            statistics_path,
-            replicator_id=gradient_replicator_id,
-            id_suffix=id_suffix,
-            substance_source=substance_reference,
-            effective_sample_indices=ProtocolPath(
-                "effective_sample_indices", protocols.mbar_protocol.id
-            ),
-        )
-
-        # Remove the group id from the path.
-        gradient_source.pop_next_in_path()
-
-        if weight_by_mole_fraction is True:
-            # The component workflows need an extra step to multiply their gradients by their
-            # relative mole fraction.
-            weight_gradient = miscellaneous.WeightByMoleFraction(
-                f"weight_gradient_$({gradient_replicator_id})_"
-                f"by_mole_fraction{id_suffix}"
-            )
-            weight_gradient.value = gradient_source
-            weight_gradient.full_substance = ProtocolPath("substance", "global")
-            weight_gradient.component = substance_reference
-
-            gradient_group.add_protocols(weight_gradient)
-            gradient_source = ProtocolPath("weighted_value", weight_gradient.id)
-
-        scale_gradient = miscellaneous.DivideValue(
-            f"scale_gradient_$({gradient_replicator_id}){id_suffix}"
-        )
-        scale_gradient.value = gradient_source
-        scale_gradient.divisor = ProtocolPath("result", number_of_molar_molecules.id)
-
-        gradient_group.add_protocols(scale_gradient)
-        gradient_source = ProtocolPath("result", gradient_group.id, scale_gradient.id)
-
-        all_protocols = (*protocols, number_of_molar_molecules, divide_by_molecules)
-
-        if weight_volume is not None:
-            all_protocols = (*all_protocols, weight_volume)
-
-        return (
-            all_protocols,
-            value_source,
-            data_replicator,
-            gradient_group,
-            gradient_source,
-        )
-
-    @staticmethod
-    def _default_reweighting_storage_query():
-        """Returns the default storage queries to use when
-        retrieving cached simulation data to reweight.
-
-        This will include one query (with the key `"full_system_data"`)
-        to return data for the full mixture system, and another query
-        (with the key `"component_data"`) which will include data for
-        each pure component in the system.
-
-        Returns
-        -------
-        dict of str and SimulationDataQuery
-            The dictionary of queries.
-        """
-
-        mixture_data_query = SimulationDataQuery()
-        mixture_data_query.substance = PlaceholderValue()
-        mixture_data_query.property_phase = PropertyPhase.Liquid
-
-        # Set up a query which will return the data of each
-        # individual component in the system.
-        component_query = SubstanceQuery()
-        component_query.components_only = True
-
-        component_data_query = SimulationDataQuery()
-        component_data_query.property_phase = PropertyPhase.Liquid
-        component_data_query.substance = PlaceholderValue()
-        component_data_query.substance_query = component_query
-
-        return {
-            "full_system_data": mixture_data_query,
-            "component_data": component_data_query,
-        }
-
-    @staticmethod
-    def default_simulation_schema(
-        absolute_tolerance=UNDEFINED, relative_tolerance=UNDEFINED, n_molecules=1000
-    ):
-        """Returns the default calculation schema to use when estimating
-        this class of property from direct simulations.
-
-        Parameters
-        ----------
-        absolute_tolerance: pint.Quantity, optional
-            The absolute tolerance to estimate the property to within.
-        relative_tolerance: float
-            The tolerance (as a fraction of the properties reported
-            uncertainty) to estimate the property to within.
-        n_molecules: int
-            The number of molecules to use in the simulation.
-
-        Returns
-        -------
-        SimulationSchema
-            The schema to follow when estimating this property.
-        """
-        assert absolute_tolerance == UNDEFINED or relative_tolerance == UNDEFINED
-
-        calculation_schema = SimulationSchema()
-        calculation_schema.absolute_tolerance = absolute_tolerance
-        calculation_schema.relative_tolerance = relative_tolerance
-
-        use_target_uncertainty = (
-            absolute_tolerance != UNDEFINED or relative_tolerance != UNDEFINED
-        )
-
-        # Define the id of the replicator which will clone the gradient protocols
-        # for each gradient key to be estimated.
-        gradient_replicator_id = "gradient_replicator"
-
-        # Set up a workflow to calculate the molar volume of the full, mixed system.
-        (
-            full_system_protocols,
-            full_system_molar_molecules,
-            full_system_volume,
-            full_output,
-            full_system_gradient_group,
-            full_system_gradient_replicator,
-            full_system_gradient,
-        ) = ExcessMolarVolume._get_simulation_protocols(
-            "_full",
-            gradient_replicator_id,
-            use_target_uncertainty=use_target_uncertainty,
-            n_molecules=n_molecules,
-        )
-
-        # Set up a general workflow for calculating the molar volume of one of the system components.
-        component_replicator_id = "component_replicator"
-        component_substance = ReplicatorValue(component_replicator_id)
-
-        # Make sure to weight by the mole fractions of the actual full system as these may be slightly
-        # different to the mole fractions of the measure property due to rounding.
-        full_substance = ProtocolPath(
-            "output_substance", full_system_protocols.build_coordinates.id
-        )
-
-        (
-            component_protocols,
-            component_molar_molecules,
-            component_volumes,
-            component_output,
-            component_gradient_group,
-            component_gradient_replicator,
-            component_gradient,
-        ) = ExcessMolarVolume._get_simulation_protocols(
-            "_component",
-            gradient_replicator_id,
-            replicator_id=component_replicator_id,
-            weight_by_mole_fraction=True,
-            component_substance_reference=component_substance,
-            full_substance_reference=full_substance,
-            use_target_uncertainty=use_target_uncertainty,
-            n_molecules=n_molecules,
-        )
-
-        # Finally, set up the protocols which will be responsible for adding together
-        # the component molar volumes, and subtracting these from the mixed system molar volume.
-        add_component_molar_volumes = miscellaneous.AddValues(
-            "add_component_molar_volumes"
-        )
-        add_component_molar_volumes.values = component_volumes
-
-        calculate_excess_volume = miscellaneous.SubtractValues(
-            "calculate_excess_volume"
-        )
-        calculate_excess_volume.value_b = full_system_volume
-        calculate_excess_volume.value_a = ProtocolPath(
-            "result", add_component_molar_volumes.id
-        )
-
-        # Create the replicator object which defines how the pure component
-        # molar volume estimation protocols will be replicated for each component.
-        component_replicator = ProtocolReplicator(replicator_id=component_replicator_id)
-        component_replicator.template_values = ProtocolPath("components", "global")
-
-        # Combine the gradients.
-        add_component_gradients = miscellaneous.AddValues(
-            f"add_component_gradients" f"_$({gradient_replicator_id})"
-        )
-        add_component_gradients.values = component_gradient
-
-        combine_gradients = miscellaneous.SubtractValues(
-            f"combine_gradients_$({gradient_replicator_id})"
-        )
-        combine_gradients.value_b = full_system_gradient
-        combine_gradients.value_a = ProtocolPath("result", add_component_gradients.id)
-
-        # Combine the gradient replicators.
-        gradient_replicator = ProtocolReplicator(replicator_id=gradient_replicator_id)
-        gradient_replicator.template_values = ProtocolPath(
-            "parameter_gradient_keys", "global"
-        )
-
-        # Build the final workflow schema
-        schema = WorkflowSchema()
-
-        schema.protocol_schemas = [
-            component_protocols.build_coordinates.schema,
-            component_protocols.assign_parameters.schema,
-            component_protocols.energy_minimisation.schema,
-            component_protocols.equilibration_simulation.schema,
-            component_protocols.converge_uncertainty.schema,
-            component_molar_molecules.schema,
-            full_system_protocols.build_coordinates.schema,
-            full_system_protocols.assign_parameters.schema,
-            full_system_protocols.energy_minimisation.schema,
-            full_system_protocols.equilibration_simulation.schema,
-            full_system_protocols.converge_uncertainty.schema,
-            full_system_molar_molecules.schema,
-            component_protocols.extract_uncorrelated_trajectory.schema,
-            component_protocols.extract_uncorrelated_statistics.schema,
-            full_system_protocols.extract_uncorrelated_trajectory.schema,
-            full_system_protocols.extract_uncorrelated_statistics.schema,
-            add_component_molar_volumes.schema,
-            calculate_excess_volume.schema,
-            component_gradient_group.schema,
-            full_system_gradient_group.schema,
-            add_component_gradients.schema,
-            combine_gradients.schema,
-        ]
-
-        schema.protocol_replicators = [gradient_replicator, component_replicator]
-
-        # Finally, tell the schemas where to look for its final values.
-        schema.gradients_sources = [ProtocolPath("result", combine_gradients.id)]
-        schema.final_value_source = ProtocolPath("result", calculate_excess_volume.id)
-
-        schema.outputs_to_store = {
-            "full_system": full_output,
-            f"component_$({component_replicator_id})": component_output,
-        }
-
-        calculation_schema.workflow_schema = schema
-        return calculation_schema
-
-    @staticmethod
-    def default_reweighting_schema(
-        absolute_tolerance=UNDEFINED,
-        relative_tolerance=UNDEFINED,
-        n_effective_samples=50,
-    ):
-        """Returns the default calculation schema to use when estimating
-        this property by reweighting existing data.
-
-        Parameters
-        ----------
-        absolute_tolerance: pint.Quantity, optional
-            The absolute tolerance to estimate the property to within.
-        relative_tolerance: float
-            The tolerance (as a fraction of the properties reported
-            uncertainty) to estimate the property to within.
-        n_effective_samples: int
-            The minimum number of effective samples to require when
-            reweighting the cached simulation data.
-
-        Returns
-        -------
-        ReweightingSchema
-            The schema to follow when estimating this property.
-        """
-        assert absolute_tolerance == UNDEFINED or relative_tolerance == UNDEFINED
-
-        calculation_schema = ReweightingSchema()
-        calculation_schema.absolute_tolerance = absolute_tolerance
-        calculation_schema.relative_tolerance = relative_tolerance
-
-        # Set up the storage queries
-        calculation_schema.storage_queries = (
-            ExcessMolarVolume._default_reweighting_storage_query()
-        )
-
-        # Set up a replicator that will re-run the component reweighting workflow for each
-        # component in the system.
-        component_replicator = ProtocolReplicator(replicator_id="component_replicator")
-        component_replicator.template_values = ProtocolPath("components", "global")
-
-        gradient_replicator = ProtocolReplicator("gradient")
-        gradient_replicator.template_values = ProtocolPath(
-            "parameter_gradient_keys", "global"
-        )
-
-        # Set up the protocols which will reweight data for the full system.
-        full_data_replicator_id = "full_data_replicator"
-
-        (
-            full_protocols,
-            full_volume,
-            full_data_replicator,
-            full_gradient_group,
-            full_gradient_source,
-        ) = ExcessMolarVolume._get_reweighting_protocols(
-            "_full",
-            gradient_replicator.id,
-            full_data_replicator_id,
-            n_effective_samples=n_effective_samples,
-        )
-
-        # Set up the protocols which will reweight data for each component.
-        component_data_replicator_id = (
-            f"component_{component_replicator.placeholder_id}_data_replicator"
-        )
-
-        (
-            component_protocols,
-            component_volumes,
-            component_data_replicator,
-            component_gradient_group,
-            component_gradient_source,
-        ) = ExcessMolarVolume._get_reweighting_protocols(
-            "_component",
-            gradient_replicator.id,
-            component_data_replicator_id,
-            replicator_id=component_replicator.id,
-            weight_by_mole_fraction=True,
-            substance_reference=ReplicatorValue(component_replicator.id),
-            n_effective_samples=n_effective_samples,
-        )
-
-        # Make sure the replicator is only replicating over component data.
-        component_data_replicator.template_values = ProtocolPath(
-            f"component_data[$({component_replicator.id})]", "global"
-        )
-
-        add_component_molar_volumes = miscellaneous.AddValues(
-            "add_component_molar_volumes"
-        )
-        add_component_molar_volumes.values = component_volumes
-
-        calculate_excess_volume = miscellaneous.SubtractValues(
-            "calculate_excess_potential"
-        )
-        calculate_excess_volume.value_b = full_volume
-        calculate_excess_volume.value_a = ProtocolPath(
-            "result", add_component_molar_volumes.id
-        )
-
-        # Combine the gradients.
-        add_component_gradients = miscellaneous.AddValues(
-            f"add_component_gradients" f"_{gradient_replicator.placeholder_id}"
-        )
-        add_component_gradients.values = component_gradient_source
-
-        combine_gradients = miscellaneous.SubtractValues(
-            f"combine_gradients_{gradient_replicator.placeholder_id}"
-        )
-        combine_gradients.value_b = full_gradient_source
-        combine_gradients.value_a = ProtocolPath("result", add_component_gradients.id)
-
-        # Build the final workflow schema.
-        schema = WorkflowSchema()
-
-        schema.protocol_schemas = [
-            *(x.schema for x in full_protocols),
-            *(x.schema for x in component_protocols),
-            add_component_molar_volumes.schema,
-            calculate_excess_volume.schema,
-            full_gradient_group.schema,
-            component_gradient_group.schema,
-            add_component_gradients.schema,
-            combine_gradients.schema,
-        ]
-
-        schema.protocol_replicators = [
-            full_data_replicator,
-            component_replicator,
-            component_data_replicator,
-            gradient_replicator,
-        ]
-
-        schema.gradients_sources = [ProtocolPath("result", combine_gradients.id)]
-        schema.final_value_source = ProtocolPath("result", calculate_excess_volume.id)
-
-        calculation_schema.workflow_schema = schema
-        return calculation_schema
+    @classmethod
+    def _observable_type(cls) -> ObservableType:
+        return ObservableType.Volume
 
 
 # Register the properties via the plugin system.

--- a/openff/evaluator/properties/dielectric.py
+++ b/openff/evaluator/properties/dielectric.py
@@ -1,13 +1,6 @@
 """
 A collection of dielectric physical property definitions.
 """
-import copy
-
-import numpy as np
-import pint
-from simtk import openmm
-from simtk.openmm import XmlSerializer
-
 from openff.evaluator import unit
 from openff.evaluator.attributes import UNDEFINED
 from openff.evaluator.datasets import PhysicalProperty, PropertyPhase
@@ -15,328 +8,22 @@ from openff.evaluator.datasets.thermoml import thermoml_property
 from openff.evaluator.layers import register_calculation_schema
 from openff.evaluator.layers.reweighting import ReweightingLayer, ReweightingSchema
 from openff.evaluator.layers.simulation import SimulationLayer, SimulationSchema
-from openff.evaluator.protocols import analysis, reweighting
+from openff.evaluator.protocols.analysis import (
+    AverageDielectricConstant,
+    ComputeDipoleMoments,
+    DecorrelateObservables,
+)
+from openff.evaluator.protocols.reweighting import (
+    ConcatenateObservables,
+    ReweightDielectricConstant,
+)
 from openff.evaluator.protocols.utils import (
     generate_base_reweighting_protocols,
-    generate_base_simulation_protocols,
-    generate_gradient_protocol_group,
+    generate_simulation_protocols,
 )
-from openff.evaluator.thermodynamics import ThermodynamicState
-from openff.evaluator.utils import timeseries
-from openff.evaluator.utils.statistics import bootstrap
-from openff.evaluator.workflow import WorkflowSchema, workflow_protocol
-from openff.evaluator.workflow.attributes import InputAttribute, OutputAttribute
+from openff.evaluator.utils.observables import ObservableType
+from openff.evaluator.workflow import WorkflowSchema
 from openff.evaluator.workflow.utils import ProtocolPath
-
-
-@workflow_protocol()
-class ExtractAverageDielectric(analysis.AverageTrajectoryProperty):
-    """Extracts the average dielectric constant from a simulation trajectory."""
-
-    system_path = InputAttribute(
-        docstring="The path to the XML system object which defines the forces present in the system.",
-        type_hint=str,
-        default_value=UNDEFINED,
-    )
-    thermodynamic_state = InputAttribute(
-        docstring="The thermodynamic state at which the trajectory was generated.",
-        type_hint=ThermodynamicState,
-        default_value=UNDEFINED,
-    )
-
-    dipole_moments = OutputAttribute(
-        docstring="The raw (possibly correlated) dipole moments which were used in "
-        "the dielectric calculation.",
-        type_hint=pint.Quantity,
-    )
-    volumes = OutputAttribute(
-        docstring="The raw (possibly correlated) which were used in the dielectric calculation.",
-        type_hint=pint.Quantity,
-    )
-
-    uncorrelated_volumes = OutputAttribute(
-        docstring="The uncorrelated volumes which were used in the dielectric "
-        "calculation.",
-        type_hint=pint.Quantity,
-    )
-
-    def _bootstrap_function(self, **sample_kwargs):
-        """Calculates the static dielectric constant from an
-        array of dipoles and volumes.
-
-        Notes
-        -----
-        The static dielectric constant is taken from for Equation 7 of [1]
-
-        References
-        ----------
-        [1] A. Glattli, X. Daura and W. F. van Gunsteren. Derivation of an improved simple point charge
-            model for liquid water: SPC/A and SPC/L. J. Chem. Phys. 116(22):9811-9828, 2002
-
-        Parameters
-        ----------
-        sample_kwargs: dict of str and np.ndarray
-            A key words dictionary of the bootstrap sample data, where the
-            sample data is a numpy array of shape=(num_frames, num_dimensions)
-            with dtype=float. The kwargs should include the dipole moment and
-            the system volume
-
-        Returns
-        -------
-        float
-            The unitless static dielectric constant
-        """
-
-        dipole_moments = sample_kwargs["dipoles"]
-        volumes = sample_kwargs["volumes"]
-
-        temperature = self.thermodynamic_state.temperature
-
-        dipole_mu = dipole_moments.mean(0)
-        shifted_dipoles = dipole_moments - dipole_mu
-
-        dipole_variance = (shifted_dipoles * shifted_dipoles).sum(-1).mean(0) * (
-            unit.elementary_charge * unit.nanometers
-        ) ** 2
-
-        volume = volumes.mean() * unit.nanometer ** 3
-
-        e0 = 8.854187817e-12 * unit.farad / unit.meter  # Taken from QCElemental
-
-        dielectric_constant = 1.0 + dipole_variance / (
-            3 * unit.boltzmann_constant * temperature * volume * e0
-        )
-
-        return dielectric_constant
-
-    def _extract_charges(self):
-        """Extracts all of the charges from a system object.
-
-        Returns
-        -------
-        list of float
-        """
-        from simtk import unit as simtk_unit
-
-        charge_list = []
-
-        with open(self._system_path, "r") as file:
-            system = XmlSerializer.deserialize(file.read())
-
-        for force_index in range(system.getNumForces()):
-
-            force = system.getForce(force_index)
-
-            if not isinstance(force, openmm.NonbondedForce):
-                continue
-
-            for atom_index in range(force.getNumParticles()):
-                charge = force.getParticleParameters(atom_index)[0]
-                charge = charge.value_in_unit(simtk_unit.elementary_charge)
-
-                charge_list.append(charge)
-
-        return charge_list
-
-    def _extract_dipoles_and_volumes(self):
-        """Extract the systems dipole moments and volumes.
-
-        Returns
-        -------
-        numpy.ndarray
-            The dipole moments of the trajectory (shape=(n_frames, 3), dtype=float)
-        numpy.ndarray
-            The volumes of the trajectory (shape=(n_frames, 1), dtype=float)
-        """
-        import mdtraj
-
-        dipole_moments = []
-        volumes = []
-        charge_list = self._extract_charges()
-
-        for chunk in mdtraj.iterload(
-            self.trajectory_path, top=self.input_coordinate_file, chunk=50
-        ):
-
-            dipole_moments.extend(mdtraj.geometry.dipole_moments(chunk, charge_list))
-            volumes.extend(chunk.unitcell_volumes)
-
-        dipole_moments = np.array(dipole_moments)
-        volumes = np.array(volumes)
-
-        return dipole_moments, volumes
-
-    def _execute(self, directory, available_resources):
-
-        super(ExtractAverageDielectric, self)._execute(directory, available_resources)
-
-        # Extract the dipoles
-        dipole_moments, volumes = self._extract_dipoles_and_volumes()
-        self.dipole_moments = dipole_moments * unit.dimensionless
-
-        (
-            dipole_moments,
-            self.equilibration_index,
-            self.statistical_inefficiency,
-        ) = timeseries.decorrelate_time_series(dipole_moments)
-
-        uncorrelated_length = len(volumes) - self.equilibration_index
-
-        sample_indices = timeseries.get_uncorrelated_indices(
-            uncorrelated_length, self.statistical_inefficiency
-        )
-        sample_indices = [index + self.equilibration_index for index in sample_indices]
-
-        self.volumes = volumes * unit.nanometer ** 3
-        uncorrelated_volumes = volumes[sample_indices]
-
-        self.uncorrelated_values = dipole_moments * unit.dimensionless
-        self.uncorrelated_volumes = uncorrelated_volumes * unit.nanometer ** 3
-
-        value, uncertainty = bootstrap(
-            self._bootstrap_function,
-            self.bootstrap_iterations,
-            self.bootstrap_sample_size,
-            dipoles=dipole_moments,
-            volumes=uncorrelated_volumes,
-        )
-
-        self.value = (value * unit.dimensionless).plus_minus(
-            uncertainty * unit.dimensionless
-        )
-
-
-@workflow_protocol()
-class ReweightDielectricConstant(reweighting.BaseMBARProtocol):
-    """Reweights a set of dipole moments (`reference_observables`) and volumes
-    (`reference_volumes`) using MBAR, and then combines these to yeild the reweighted
-    dielectric constant. Uncertainties in the dielectric constant are determined
-    by bootstrapping.
-    """
-
-    reference_dipole_moments = InputAttribute(
-        docstring="A Quantity wrapped np.ndarray of the dipole moments of each "
-        "of the reference states.",
-        type_hint=list,
-        default_value=UNDEFINED,
-    )
-    reference_volumes = InputAttribute(
-        docstring="A Quantity wrapped np.ndarray of the volumes of each of the "
-        "reference states.",
-        type_hint=list,
-        default_value=UNDEFINED,
-    )
-
-    thermodynamic_state = InputAttribute(
-        docstring="The thermodynamic state at which the trajectory was generated.",
-        type_hint=ThermodynamicState,
-        default_value=UNDEFINED,
-    )
-
-    def __init__(self, protocol_id):
-        super().__init__(protocol_id)
-        self.bootstrap_uncertainties = True
-
-    def _bootstrap_function(
-        self,
-        reference_reduced_potentials,
-        target_reduced_potentials,
-        **reference_observables,
-    ):
-
-        assert len(reference_observables) == 3
-
-        transposed_observables = {}
-
-        for key in reference_observables:
-            transposed_observables[key] = np.transpose(reference_observables[key])
-
-        values, _, _ = self._reweight_observables(
-            np.transpose(reference_reduced_potentials),
-            np.transpose(target_reduced_potentials),
-            **transposed_observables,
-        )
-
-        average_squared_dipole = values["dipoles_sqr"]
-        average_dipole_squared = np.linalg.norm(values["dipoles"])
-
-        dipole_variance = (average_squared_dipole - average_dipole_squared) * (
-            unit.elementary_charge * unit.nanometers
-        ) ** 2
-
-        volume = values["volumes"] * unit.nanometer ** 3
-
-        e0 = 8.854187817e-12 * unit.farad / unit.meter  # Taken from QCElemental
-
-        dielectric_constant = 1.0 + dipole_variance / (
-            3
-            * unit.boltzmann_constant
-            * self.thermodynamic_state.temperature
-            * volume
-            * e0
-        )
-
-        return dielectric_constant
-
-    def _execute(self, directory, available_resources):
-
-        if len(self.reference_dipole_moments) == 0:
-            raise ValueError("There were no dipole moments to reweight.")
-
-        if len(self.reference_volumes) == 0:
-            raise ValueError("There were no volumes to reweight.")
-
-        if not isinstance(
-            self.reference_dipole_moments[0], pint.Quantity
-        ) or not isinstance(self.reference_volumes[0], pint.Quantity):
-
-            raise ValueError(
-                "The reference observables should be a list of "
-                "pint.Quantity wrapped ndarray's.",
-            )
-
-        if len(self.reference_dipole_moments) != len(self.reference_volumes):
-
-            raise ValueError(
-                "The number of reference dipoles does not match the "
-                "number of reference volumes.",
-            )
-
-        for reference_dipoles, reference_volumes in zip(
-            self.reference_dipole_moments, self.reference_volumes
-        ):
-
-            if len(reference_dipoles) == len(reference_volumes):
-                continue
-
-            raise ValueError(
-                "The number of reference dipoles does not match the "
-                "number of reference volumes.",
-            )
-
-        self._reference_observables = self.reference_dipole_moments
-
-        dipole_moments = self._prepare_observables_array(self.reference_dipole_moments)
-        dipole_moments_sqr = np.array(
-            [[np.dot(dipole, dipole) for dipole in np.transpose(dipole_moments)]]
-        )
-
-        volumes = self._prepare_observables_array(self.reference_volumes)
-
-        if self.bootstrap_uncertainties:
-
-            self._execute_with_bootstrapping(
-                unit.dimensionless,
-                dipoles=dipole_moments,
-                dipoles_sqr=dipole_moments_sqr,
-                volumes=volumes,
-            )
-        else:
-
-            raise ValueError(
-                "Dielectric constant can only be reweighted in conjunction "
-                "with bootstrapped uncertainties.",
-            )
 
 
 @thermoml_property(
@@ -378,77 +65,38 @@ class DielectricConstant(PhysicalProperty):
         calculation_schema.absolute_tolerance = absolute_tolerance
         calculation_schema.relative_tolerance = relative_tolerance
 
-        # Define the protocol which will extract the average dielectric constant
-        # from the results of a simulation.
-        extract_dielectric = ExtractAverageDielectric("extract_dielectric")
-        extract_dielectric.thermodynamic_state = ProtocolPath(
-            "thermodynamic_state", "global"
-        )
-
-        # Define the protocols which will run the simulation itself.
         use_target_uncertainty = (
             absolute_tolerance != UNDEFINED or relative_tolerance != UNDEFINED
         )
 
-        protocols, value_source, output_to_store = generate_base_simulation_protocols(
-            extract_dielectric,
+        # Define the protocols which will run the simulation itself.
+        protocols, value_source, output_to_store = generate_simulation_protocols(
+            AverageDielectricConstant("average_dielectric"),
             use_target_uncertainty,
             n_molecules=n_molecules,
         )
 
-        # Make sure the input of the analysis protcol is properly hooked up.
-        extract_dielectric.system_path = ProtocolPath(
-            "system_path", protocols.assign_parameters.id
+        # Add a protocol to compute the dipole moments and pass these to
+        # the analysis protocol.
+        compute_dipoles = ComputeDipoleMoments("compute_dipoles")
+        compute_dipoles.parameterized_system = ProtocolPath(
+            "parameterized_system", protocols.assign_parameters.id
         )
-
-        # Dielectric constants typically take longer to converge, so we need to
-        # reflect this in the maximum number of convergence iterations.
-        protocols.converge_uncertainty.max_iterations = 400
-
-        # Set up the gradient calculations. For dielectric constants, we need to use
-        # a slightly specialised reweighting protocol which we set up here.
-        coordinate_source = ProtocolPath(
-            "output_coordinate_file", protocols.equilibration_simulation.id
+        compute_dipoles.trajectory_path = ProtocolPath(
+            "trajectory_file_path", protocols.production_simulation.id
         )
-        trajectory_source = ProtocolPath(
-            "trajectory_file_path",
-            protocols.converge_uncertainty.id,
+        compute_dipoles.gradient_parameters = ProtocolPath(
+            "parameter_gradient_keys", "global"
+        )
+        protocols.converge_uncertainty.add_protocols(compute_dipoles)
+
+        protocols.analysis_protocol.volumes = ProtocolPath(
+            f"observables[{ObservableType.Volume.value}]",
             protocols.production_simulation.id,
         )
-        statistics_source = ProtocolPath(
-            "statistics_file_path",
-            protocols.converge_uncertainty.id,
-            protocols.production_simulation.id,
-        )
-
-        gradient_mbar_protocol = ReweightDielectricConstant("gradient_mbar")
-        gradient_mbar_protocol.reference_dipole_moments = [
-            ProtocolPath(
-                "dipole_moments",
-                protocols.converge_uncertainty.id,
-                extract_dielectric.id,
-            )
-        ]
-        gradient_mbar_protocol.reference_volumes = [
-            ProtocolPath(
-                "volumes", protocols.converge_uncertainty.id, extract_dielectric.id
-            )
-        ]
-        gradient_mbar_protocol.thermodynamic_state = ProtocolPath(
-            "thermodynamic_state", "global"
-        )
-        gradient_mbar_protocol.reference_reduced_potentials = statistics_source
-
-        (
-            gradient_group,
-            gradient_replicator,
-            gradient_source,
-        ) = generate_gradient_protocol_group(
-            gradient_mbar_protocol,
-            ProtocolPath("force_field_path", "global"),
-            coordinate_source,
-            trajectory_source,
-            statistics_source,
+        protocols.analysis_protocol.dipole_moments = ProtocolPath(
+            "dipole_moments",
+            compute_dipoles.id,
         )
 
         # Build the workflow schema.
@@ -460,16 +108,11 @@ class DielectricConstant(PhysicalProperty):
             protocols.energy_minimisation.schema,
             protocols.equilibration_simulation.schema,
             protocols.converge_uncertainty.schema,
-            protocols.extract_uncorrelated_trajectory.schema,
-            protocols.extract_uncorrelated_statistics.schema,
-            gradient_group.schema,
+            protocols.decorrelate_trajectory.schema,
+            protocols.decorrelate_observables.schema,
         ]
 
-        schema.protocol_replicators = [gradient_replicator]
-
         schema.outputs_to_store = {"full_system": output_to_store}
-
-        schema.gradients_sources = [gradient_source]
         schema.final_value_source = value_source
 
         calculation_schema.workflow_schema = schema
@@ -506,78 +149,82 @@ class DielectricConstant(PhysicalProperty):
         calculation_schema.absolute_tolerance = absolute_tolerance
         calculation_schema.relative_tolerance = relative_tolerance
 
-        data_replicator_id = "data_replicator"
-
-        # Set up a protocol to extract the dielectric constant from the stored data.
-        extract_dielectric = ExtractAverageDielectric(
-            f"calc_dielectric_$({data_replicator_id})"
+        protocols, data_replicator = generate_base_reweighting_protocols(
+            statistical_inefficiency=AverageDielectricConstant(
+                "average_dielectric_$(data_replicator)"
+            ),
+            reweight_observable=ReweightDielectricConstant("reweight_dielectric"),
         )
-
-        # For the dielectric constant, we employ a slightly more advanced reweighting
-        # protocol set up for calculating fluctuation properties.
-        reweight_dielectric = ReweightDielectricConstant("reweight_dielectric")
-        reweight_dielectric.reference_dipole_moments = ProtocolPath(
-            "uncorrelated_values", extract_dielectric.id
+        protocols.zero_gradients.input_observables = ProtocolPath(
+            "output_observables[Volume]",
+            protocols.join_observables.id,
         )
-        reweight_dielectric.reference_volumes = ProtocolPath(
-            "uncorrelated_volumes", extract_dielectric.id
-        )
-        reweight_dielectric.thermodynamic_state = ProtocolPath(
+        protocols.statistical_inefficiency.thermodynamic_state = ProtocolPath(
             "thermodynamic_state", "global"
         )
-        reweight_dielectric.bootstrap_uncertainties = True
-        reweight_dielectric.bootstrap_iterations = 200
-        reweight_dielectric.required_effective_samples = n_effective_samples
+        protocols.reweight_observable.required_effective_samples = n_effective_samples
 
-        protocols, data_replicator = generate_base_reweighting_protocols(
-            extract_dielectric, reweight_dielectric, data_replicator_id
-        )
+        # We don't need to perform bootstrapping as this protocol is only used to
+        # calculate the statistical inefficiency and equilibration time. The
+        # re-weighting protocol will instead compute the bootstrapped uncertainties.
+        protocols.statistical_inefficiency.bootstrap_iterations = 1
 
-        # Make sure input is taken from the correct protocol outputs.
-        extract_dielectric.system_path = ProtocolPath(
-            "system_path", protocols.build_reference_system.id
+        # Set up a protocol to re-evaluate the dipole moments at the target state
+        # and concatenate the into a single array.
+        compute_dipoles = ComputeDipoleMoments("compute_dipoles_$(data_replicator)")
+        compute_dipoles.parameterized_system = ProtocolPath(
+            "parameterized_system", protocols.build_target_system.id
         )
-        extract_dielectric.thermodynamic_state = ProtocolPath(
-            "thermodynamic_state", protocols.unpack_stored_data.id
+        compute_dipoles.trajectory_path = ProtocolPath(
+            "trajectory_file_path", protocols.unpack_stored_data.id
         )
-
-        # Set up the gradient calculations
-        coordinate_path = ProtocolPath(
-            "output_coordinate_path", protocols.concatenate_trajectories.id
+        compute_dipoles.gradient_parameters = ProtocolPath(
+            "parameter_gradient_keys", "global"
         )
-        trajectory_path = ProtocolPath(
-            "output_trajectory_path", protocols.concatenate_trajectories.id
-        )
-        statistics_path = ProtocolPath(
-            "statistics_file_path", protocols.reduced_target_potential.id
+        join_dipoles = ConcatenateObservables("join_dipoles")
+        join_dipoles.input_observables = ProtocolPath(
+            "dipole_moments",
+            compute_dipoles.id,
         )
 
-        reweight_dielectric_template = copy.deepcopy(reweight_dielectric)
+        # Point the dielectric protocols to the volumes and dipole moments.
+        protocols.statistical_inefficiency.volumes = ProtocolPath(
+            "observables[Volume]", protocols.unpack_stored_data.id
+        )
+        protocols.statistical_inefficiency.dipole_moments = ProtocolPath(
+            "dipole_moments", compute_dipoles.id
+        )
 
-        (
-            gradient_group,
-            gradient_replicator,
-            gradient_source,
-        ) = generate_gradient_protocol_group(
-            reweight_dielectric_template,
-            ProtocolPath("force_field_path", "global"),
-            coordinate_path,
-            trajectory_path,
-            statistics_path,
-            replicator_id="grad",
-            effective_sample_indices=ProtocolPath(
-                "effective_sample_indices", reweight_dielectric.id
-            ),
+        # Make sure to decorrelate the dipole moments.
+        decorrelate_dipoles = DecorrelateObservables("decorrelate_dipoles")
+        decorrelate_dipoles.time_series_statistics = ProtocolPath(
+            "time_series_statistics", protocols.statistical_inefficiency.id
+        )
+        decorrelate_dipoles.input_observables = ProtocolPath(
+            "output_observables", join_dipoles.id
+        )
+
+        protocols.reweight_observable.dipole_moments = ProtocolPath(
+            "output_observables", decorrelate_dipoles.id
+        )
+        protocols.reweight_observable.volumes = ProtocolPath(
+            "output_observables", protocols.decorrelate_observable.id
+        )
+        protocols.reweight_observable.thermodynamic_state = ProtocolPath(
+            "thermodynamic_state", "global"
         )
 
         schema = WorkflowSchema()
         schema.protocol_schemas = [
             *(x.schema for x in protocols),
-            gradient_group.schema,
+            compute_dipoles.schema,
+            join_dipoles.schema,
+            decorrelate_dipoles.schema,
         ]
-        schema.protocol_replicators = [data_replicator, gradient_replicator]
-        schema.gradients_sources = [gradient_source]
-        schema.final_value_source = ProtocolPath("value", protocols.mbar_protocol.id)
+        schema.protocol_replicators = [data_replicator]
+        schema.final_value_source = ProtocolPath(
+            "value", protocols.reweight_observable.id
+        )
 
         calculation_schema.workflow_schema = schema
         return calculation_schema

--- a/openff/evaluator/properties/enthalpy.py
+++ b/openff/evaluator/properties/enthalpy.py
@@ -1,8 +1,6 @@
 """
 A collection of enthalpy physical property definitions.
 """
-import copy
-from collections import namedtuple
 
 from openff.evaluator import unit
 from openff.evaluator.attributes import UNDEFINED, PlaceholderValue
@@ -11,765 +9,42 @@ from openff.evaluator.datasets.thermoml import thermoml_property
 from openff.evaluator.layers import register_calculation_schema
 from openff.evaluator.layers.reweighting import ReweightingLayer, ReweightingSchema
 from openff.evaluator.layers.simulation import SimulationLayer, SimulationSchema
-from openff.evaluator.protocols import analysis, groups, miscellaneous, reweighting
+from openff.evaluator.properties.properties import EstimableExcessProperty
+from openff.evaluator.protocols import analysis, groups, miscellaneous
 from openff.evaluator.protocols.utils import (
-    generate_base_reweighting_protocols,
-    generate_base_simulation_protocols,
-    generate_gradient_protocol_group,
+    generate_reweighting_protocols,
+    generate_simulation_protocols,
 )
-from openff.evaluator.storage.query import SimulationDataQuery, SubstanceQuery
+from openff.evaluator.storage.query import SimulationDataQuery
 from openff.evaluator.thermodynamics import Ensemble
-from openff.evaluator.utils.statistics import ObservableType
-from openff.evaluator.workflow.schemas import ProtocolReplicator, WorkflowSchema
-from openff.evaluator.workflow.utils import ProtocolPath, ReplicatorValue
+from openff.evaluator.utils.observables import ObservableType
+from openff.evaluator.workflow.schemas import WorkflowSchema
+from openff.evaluator.workflow.utils import ProtocolPath
 
 
 @thermoml_property(
     "Excess molar enthalpy (molar enthalpy of mixing), kJ/mol",
     supported_phases=PropertyPhase.Liquid,
 )
-class EnthalpyOfMixing(PhysicalProperty):
+class EnthalpyOfMixing(EstimableExcessProperty):
     """A class representation of an enthalpy of mixing property"""
 
     @classmethod
     def default_unit(cls):
         return unit.kilojoule / unit.mole
 
-    EnthalpyWorkflow = namedtuple(
-        "EnthalpySchema",
-        "build_coordinates "
-        "assign_topology "
-        "energy_minimisation "
-        "npt_equilibration "
-        "converge_uncertainty "
-        "subsample_trajectory "
-        "subsample_statistics ",
-    )
-
-    @staticmethod
-    def _get_simulation_protocols(
-        id_suffix,
-        gradient_replicator_id,
-        replicator_id=None,
-        weight_by_mole_fraction=False,
-        component_substance_reference=None,
-        full_substance_reference=None,
-        use_target_uncertainty=False,
-        n_molecules=1000,
-    ):
-
-        """Returns the set of protocols which when combined in a workflow
-        will yield the enthalpy of a substance.
-
-        Parameters
-        ----------
-        id_suffix: str
-            A suffix to append to the id of each of the returned protocols.
-        gradient_replicator_id: str
-            The id of the replicator which will clone those protocols which will
-            estimate the gradient of the enthalpy with respect to a given parameter.
-        replicator_id: str, optional
-            The id of the replicator which will be used to clone these protocols.
-            This will be appended to the id of each of the returned protocols if
-            set.
-        weight_by_mole_fraction: bool
-            If true, an extra protocol will be added to weight the calculated
-            enthalpy by the mole fraction of the component.
-        component_substance_reference: ProtocolPath or PlaceholderValue, optional
-            An optional protocol path (or replicator reference) to the component substance
-            whose enthalpy is being estimated.
-        full_substance_reference: ProtocolPath or PlaceholderValue, optional
-            An optional protocol path (or replicator reference) to the full substance
-            whose enthalpy of mixing is being estimated. This cannot be `None` if
-            `weight_by_mole_fraction` is `True`.
-        use_target_uncertainty: bool
-            Whether to calculate the observable to within the target
-            uncertainty.
-        n_molecules: int
-            The number of molecules to use in the simulation.
-
-        Returns
-        -------
-        BaseSimulationProtocols
-            The protocols used to estimate the enthalpy of a substance.
-        ProtocolPath
-            A reference to the estimated enthalpy.
-        WorkflowSimulationDataToStore
-            An object which describes the default data from a simulation to store,
-            such as the uncorrelated statistics and configurations.
-        ProtocolGroup
-            The group of protocols which will calculate the gradient of the reduced potential
-            with respect to a given property.
-        ProtocolReplicator
-            The protocol which will replicate the gradient group for every gradient to
-            estimate.
-        ProtocolPath
-            A reference to the value of the gradient.
-        """
-
-        if replicator_id is not None:
-            id_suffix = f"{id_suffix}_$({replicator_id})"
-
-        if component_substance_reference is None:
-            component_substance_reference = ProtocolPath("substance", "global")
-
-        if weight_by_mole_fraction is True and full_substance_reference is None:
-
-            raise ValueError(
-                "The full substance reference must be set when weighting by"
-                "the mole fraction"
-            )
-
-        # Define the protocol which will extract the average enthalpy from
-        # the results of a simulation.
-        extract_enthalpy = analysis.ExtractAverageStatistic(
-            f"extract_enthalpy{id_suffix}"
-        )
-        extract_enthalpy.statistics_type = ObservableType.Enthalpy
-
-        # Define the protocols which will run the simulation itself.
-        (
-            simulation_protocols,
-            value_source,
-            output_to_store,
-        ) = generate_base_simulation_protocols(
-            extract_enthalpy, use_target_uncertainty, id_suffix, n_molecules=n_molecules
-        )
-
-        number_of_molecules = ProtocolPath(
-            "output_number_of_molecules", simulation_protocols.build_coordinates.id
-        )
-        built_substance = ProtocolPath(
-            "output_substance", simulation_protocols.build_coordinates.id
-        )
-
-        # Divide the enthalpy by the number of molecules in the system
-        extract_enthalpy.divisor = number_of_molecules
-
-        # Use the correct substance.
-        simulation_protocols.build_coordinates.substance = component_substance_reference
-        simulation_protocols.assign_parameters.substance = built_substance
-        output_to_store.substance = built_substance
-
-        conditional_group = simulation_protocols.converge_uncertainty
-
-        if weight_by_mole_fraction:
-
-            # The component workflows need an extra step to multiply their enthalpies by their
-            # relative mole fraction.
-            weight_by_mole_fraction = miscellaneous.WeightByMoleFraction(
-                f"weight_by_mole_fraction{id_suffix}"
-            )
-            weight_by_mole_fraction.value = ProtocolPath("value", extract_enthalpy.id)
-            weight_by_mole_fraction.full_substance = full_substance_reference
-            weight_by_mole_fraction.component = component_substance_reference
-
-            conditional_group.add_protocols(weight_by_mole_fraction)
-
-            value_source = ProtocolPath(
-                "weighted_value", conditional_group.id, weight_by_mole_fraction.id
-            )
-
-        if use_target_uncertainty:
-
-            # Make sure the convergence criteria is set to use the per component
-            # uncertainty target.
-            conditional_group.conditions[0].right_hand_value = ProtocolPath(
-                "per_component_uncertainty", "global"
-            )
-
-            if weight_by_mole_fraction:
-                # Make sure the weighted uncertainty is being used in the conditional comparison.
-                conditional_group.conditions[0].left_hand_value = ProtocolPath(
-                    "weighted_value.error",
-                    conditional_group.id,
-                    weight_by_mole_fraction.id,
-                )
-
-        # Set up the gradient calculations
-        coordinate_source = ProtocolPath(
-            "output_coordinate_file", simulation_protocols.equilibration_simulation.id
-        )
-        trajectory_source = ProtocolPath(
-            "trajectory_file_path",
-            simulation_protocols.converge_uncertainty.id,
-            simulation_protocols.production_simulation.id,
-        )
-        statistics_source = ProtocolPath(
-            "statistics_file_path",
-            simulation_protocols.converge_uncertainty.id,
-            simulation_protocols.production_simulation.id,
-        )
-
-        reweight_enthalpy_template = reweighting.ReweightStatistics("")
-        reweight_enthalpy_template.statistics_type = ObservableType.PotentialEnergy
-        reweight_enthalpy_template.statistics_paths = statistics_source
-        reweight_enthalpy_template.reference_reduced_potentials = statistics_source
-
-        (
-            gradient_group,
-            gradient_replicator,
-            gradient_source,
-        ) = generate_gradient_protocol_group(
-            reweight_enthalpy_template,
-            ProtocolPath("force_field_path", "global"),
-            coordinate_source,
-            trajectory_source,
-            statistics_source,
-            replicator_id=gradient_replicator_id,
-            substance_source=built_substance,
-            id_suffix=id_suffix,
-        )
-
-        # Remove the group id from the path.
-        gradient_source.pop_next_in_path()
-
-        if weight_by_mole_fraction:
-
-            # The component workflows need an extra step to multiply their gradients by their
-            # relative mole fraction.
-            weight_gradient = miscellaneous.WeightByMoleFraction(
-                f"weight_gradient_by_mole_fraction{id_suffix}"
-            )
-            weight_gradient.value = gradient_source
-            weight_gradient.full_substance = full_substance_reference
-            weight_gradient.component = component_substance_reference
-
-            gradient_group.add_protocols(weight_gradient)
-            gradient_source = ProtocolPath("weighted_value", weight_gradient.id)
-
-        scale_gradient = miscellaneous.DivideValue(f"scale_gradient{id_suffix}")
-        scale_gradient.value = gradient_source
-        scale_gradient.divisor = number_of_molecules
-
-        gradient_group.add_protocols(scale_gradient)
-        gradient_source = ProtocolPath("result", gradient_group.id, scale_gradient.id)
-
-        return (
-            simulation_protocols,
-            value_source,
-            output_to_store,
-            gradient_group,
-            gradient_replicator,
-            gradient_source,
-        )
-
-    @staticmethod
-    def _get_reweighting_protocols(
-        id_suffix,
-        gradient_replicator_id,
-        data_replicator_id,
-        replicator_id=None,
-        weight_by_mole_fraction=False,
-        substance_reference=None,
-        n_effective_samples=50,
-    ):
-
-        """Returns the set of protocols which when combined in a workflow
-        will yield the enthalpy of a substance by reweighting cached data.
-
-        Parameters
-        ----------
-        id_suffix: str
-            A suffix to append to the id of each of the returned protocols.
-        gradient_replicator_id: str
-            The id of the replicator which will clone those protocols which will
-            estimate the gradient of the enthalpy with respect to a given parameter.
-        data_replicator_id: str
-            The id of the replicator which will be used to clone these protocols
-            for each cached simulation data.
-        replicator_id: str, optional
-            The optional id of the replicator which will be used to clone these
-            protocols, e.g. for each component in the system.
-        weight_by_mole_fraction: bool
-            If true, an extra protocol will be added to weight the calculated
-            enthalpy by the mole fraction of the component.
-        substance_reference: ProtocolPath or PlaceholderValue, optional
-            An optional protocol path (or replicator reference) to the substance
-            whose enthalpy is being estimated.
-        n_effective_samples: int
-            The minimum number of effective samples to require when
-            reweighting the cached simulation data.
-
-        Returns
-        -------
-        BaseReweightingProtocols
-            The protocols used to estimate the enthalpy of a substance.
-        ProtocolPath
-            A reference to the estimated enthalpy.
-        ProtocolReplicator
-            The replicator which will replicate each protocol for each
-            cached simulation datum.
-        ProtocolGroup
-            The group of protocols which will calculate the gradient of the reduced potential
-            with respect to a given property.
-        ProtocolPath
-            A reference to the value of the gradient.
-        """
-
-        if replicator_id is not None:
-            id_suffix = f"{id_suffix}_$({replicator_id})"
-
-        full_id_suffix = id_suffix
-
-        if data_replicator_id is not None:
-            full_id_suffix = f"{id_suffix}_$({data_replicator_id})"
-
-        if substance_reference is None:
-            substance_reference = ProtocolPath("substance", "global")
-
-        extract_enthalpy = analysis.ExtractAverageStatistic(
-            f"extract_enthalpy{full_id_suffix}"
-        )
-        extract_enthalpy.statistics_type = ObservableType.Enthalpy
-        reweight_enthalpy = reweighting.ReweightStatistics(
-            f"reweight_enthalpy{id_suffix}"
-        )
-        reweight_enthalpy.statistics_type = ObservableType.Enthalpy
-        reweight_enthalpy.required_effective_samples = n_effective_samples
-
-        (protocols, data_replicator) = generate_base_reweighting_protocols(
-            analysis_protocol=extract_enthalpy,
-            mbar_protocol=reweight_enthalpy,
-            replicator_id=data_replicator_id,
-            id_suffix=id_suffix,
-        )
-
-        # Make sure we use the reduced internal potential when re-weighting enthalpies
-        protocols.reduced_reference_potential.use_internal_energy = True
-        protocols.reduced_target_potential.use_internal_energy = True
-
-        # Make sure to use the correct substance.
-        protocols.build_target_system.substance = substance_reference
-
-        value_source = ProtocolPath("value", protocols.mbar_protocol.id)
-
-        # Set up the protocols which will be responsible for adding together
-        # the component enthalpies, and subtracting these from the full system enthalpy.
-        weight_enthalpy = None
-
-        if weight_by_mole_fraction is True:
-
-            weight_enthalpy = miscellaneous.WeightByMoleFraction(
-                f"weight_enthalpy{id_suffix}"
-            )
-            weight_enthalpy.value = ProtocolPath("value", protocols.mbar_protocol.id)
-            weight_enthalpy.full_substance = ProtocolPath("substance", "global")
-            weight_enthalpy.component = substance_reference
-
-            value_source = ProtocolPath("weighted_value", weight_enthalpy.id)
-
-        # Divide by the component enthalpies by the number of molecules in the system
-        number_of_molecules = ProtocolPath(
-            "total_number_of_molecules",
-            protocols.unpack_stored_data.id.replace(f"$({data_replicator_id})", "0"),
-        )
-
-        divide_by_molecules = miscellaneous.DivideValue(
-            f"divide_by_molecules{id_suffix}"
-        )
-        divide_by_molecules.value = value_source
-        divide_by_molecules.divisor = number_of_molecules
-
-        value_source = ProtocolPath("result", divide_by_molecules.id)
-
-        # Set up the gradient calculations.
-        reweight_potential_template = copy.deepcopy(reweight_enthalpy)
-        reweight_potential_template.statistics_type = ObservableType.PotentialEnergy
-
-        coordinate_path = ProtocolPath(
-            "output_coordinate_path", protocols.concatenate_trajectories.id
-        )
-        trajectory_path = ProtocolPath(
-            "output_trajectory_path", protocols.concatenate_trajectories.id
-        )
-        statistics_path = ProtocolPath(
-            "statistics_file_path", protocols.reduced_target_potential.id
-        )
-
-        gradient_group, _, gradient_source = generate_gradient_protocol_group(
-            reweight_potential_template,
-            ProtocolPath("force_field_path", "global"),
-            coordinate_path,
-            trajectory_path,
-            statistics_path,
-            replicator_id=gradient_replicator_id,
-            id_suffix=id_suffix,
-            substance_source=substance_reference,
-            effective_sample_indices=ProtocolPath(
-                "effective_sample_indices", protocols.mbar_protocol.id
-            ),
-        )
-
-        # Remove the group id from the path.
-        gradient_source.pop_next_in_path()
-
-        if weight_by_mole_fraction is True:
-
-            # The component workflows need an extra step to multiply their gradients by their
-            # relative mole fraction.
-            weight_gradient = miscellaneous.WeightByMoleFraction(
-                f"weight_gradient_$({gradient_replicator_id})_"
-                f"by_mole_fraction{id_suffix}"
-            )
-            weight_gradient.value = gradient_source
-            weight_gradient.full_substance = ProtocolPath("substance", "global")
-            weight_gradient.component = substance_reference
-
-            gradient_group.add_protocols(weight_gradient)
-            gradient_source = ProtocolPath("weighted_value", weight_gradient.id)
-
-        scale_gradient = miscellaneous.DivideValue(
-            f"scale_gradient_$({gradient_replicator_id}){id_suffix}"
-        )
-        scale_gradient.value = gradient_source
-        scale_gradient.divisor = number_of_molecules
-
-        gradient_group.add_protocols(scale_gradient)
-        gradient_source = ProtocolPath("result", gradient_group.id, scale_gradient.id)
-
-        all_protocols = (*protocols, divide_by_molecules)
-
-        if weight_enthalpy is not None:
-            all_protocols = (*all_protocols, weight_enthalpy)
-
-        return (
-            all_protocols,
-            value_source,
-            data_replicator,
-            gradient_group,
-            gradient_source,
-        )
-
-    @staticmethod
-    def _default_reweighting_storage_query():
-        """Returns the default storage queries to use when
-        retrieving cached simulation data to reweight.
-
-        This will include one query (with the key `"full_system_data"`)
-        to return data for the full mixture system, and another query
-        (with the key `"component_data"`) which will include data for
-        each pure component in the system.
-
-        Returns
-        -------
-        dict of str and SimulationDataQuery
-            The dictionary of queries.
-        """
-
-        mixture_data_query = SimulationDataQuery()
-        mixture_data_query.substance = PlaceholderValue()
-        mixture_data_query.property_phase = PropertyPhase.Liquid
-
-        # Set up a query which will return the data of each
-        # individual component in the system.
-        component_query = SubstanceQuery()
-        component_query.components_only = True
-
-        component_data_query = SimulationDataQuery()
-        component_data_query.property_phase = PropertyPhase.Liquid
-        component_data_query.substance = PlaceholderValue()
-        component_data_query.substance_query = component_query
-
-        return {
-            "full_system_data": mixture_data_query,
-            "component_data": component_data_query,
-        }
-
-    @staticmethod
-    def default_simulation_schema(
-        absolute_tolerance=UNDEFINED, relative_tolerance=UNDEFINED, n_molecules=1000
-    ):
-        """Returns the default calculation schema to use when estimating
-        this class of property from direct simulations.
-
-        Parameters
-        ----------
-        absolute_tolerance: pint.Quantity, optional
-            The absolute tolerance to estimate the property to within.
-        relative_tolerance: float
-            The tolerance (as a fraction of the properties reported
-            uncertainty) to estimate the property to within.
-        n_molecules: int
-            The number of molecules to use in the simulation.
-
-        Returns
-        -------
-        SimulationSchema
-            The schema to follow when estimating this property.
-        """
-        assert absolute_tolerance == UNDEFINED or relative_tolerance == UNDEFINED
-
-        calculation_schema = SimulationSchema()
-        calculation_schema.absolute_tolerance = absolute_tolerance
-        calculation_schema.relative_tolerance = relative_tolerance
-
-        use_target_uncertainty = (
-            absolute_tolerance != UNDEFINED or relative_tolerance != UNDEFINED
-        )
-
-        # Define the id of the replicator which will clone the gradient protocols
-        # for each gradient key to be estimated.
-        gradient_replicator_id = "gradient_replicator"
-
-        # Set up a workflow to calculate the enthalpy of the full, mixed system.
-        (
-            full_system_protocols,
-            full_system_enthalpy,
-            full_output,
-            full_system_gradient_group,
-            full_system_gradient_replicator,
-            full_system_gradient,
-        ) = EnthalpyOfMixing._get_simulation_protocols(
-            "_full",
-            gradient_replicator_id,
-            use_target_uncertainty=use_target_uncertainty,
-            n_molecules=n_molecules,
-        )
-
-        # Set up a general workflow for calculating the enthalpy of one of the system components.
-        component_replicator_id = "component_replicator"
-        component_substance = ReplicatorValue(component_replicator_id)
-
-        # Make sure to weight by the mole fractions of the actual full system as these may be slightly
-        # different to the mole fractions of the measure property due to rounding.
-        full_substance = ProtocolPath(
-            "output_substance", full_system_protocols.build_coordinates.id
-        )
-
-        (
-            component_protocols,
-            component_enthalpies,
-            component_output,
-            component_gradient_group,
-            component_gradient_replicator,
-            component_gradient,
-        ) = EnthalpyOfMixing._get_simulation_protocols(
-            "_component",
-            gradient_replicator_id,
-            replicator_id=component_replicator_id,
-            weight_by_mole_fraction=True,
-            component_substance_reference=component_substance,
-            full_substance_reference=full_substance,
-            use_target_uncertainty=use_target_uncertainty,
-            n_molecules=n_molecules,
-        )
-
-        # Finally, set up the protocols which will be responsible for adding together
-        # the component enthalpies, and subtracting these from the mixed system enthalpy.
-        add_component_enthalpies = miscellaneous.AddValues("add_component_enthalpies")
-        add_component_enthalpies.values = component_enthalpies
-
-        calculate_enthalpy_of_mixing = miscellaneous.SubtractValues(
-            "calculate_enthalpy_of_mixing"
-        )
-        calculate_enthalpy_of_mixing.value_b = full_system_enthalpy
-        calculate_enthalpy_of_mixing.value_a = ProtocolPath(
-            "result", add_component_enthalpies.id
-        )
-
-        # Create the replicator object which defines how the pure component
-        # enthalpy estimation protocols will be replicated for each component.
-        component_replicator = ProtocolReplicator(replicator_id=component_replicator_id)
-        component_replicator.template_values = ProtocolPath("components", "global")
-
-        # Combine the gradients.
-        add_component_gradients = miscellaneous.AddValues(
-            f"add_component_gradients" f"_$({gradient_replicator_id})"
-        )
-        add_component_gradients.values = component_gradient
-
-        combine_gradients = miscellaneous.SubtractValues(
-            f"combine_gradients_$({gradient_replicator_id})"
-        )
-        combine_gradients.value_b = full_system_gradient
-        combine_gradients.value_a = ProtocolPath("result", add_component_gradients.id)
-
-        # Combine the gradient replicators.
-        gradient_replicator = ProtocolReplicator(replicator_id=gradient_replicator_id)
-        gradient_replicator.template_values = ProtocolPath(
-            "parameter_gradient_keys", "global"
-        )
-
-        # Build the final workflow schema
-        schema = WorkflowSchema()
-
-        schema.protocol_schemas = [
-            component_protocols.build_coordinates.schema,
-            component_protocols.assign_parameters.schema,
-            component_protocols.energy_minimisation.schema,
-            component_protocols.equilibration_simulation.schema,
-            component_protocols.converge_uncertainty.schema,
-            full_system_protocols.build_coordinates.schema,
-            full_system_protocols.assign_parameters.schema,
-            full_system_protocols.energy_minimisation.schema,
-            full_system_protocols.equilibration_simulation.schema,
-            full_system_protocols.converge_uncertainty.schema,
-            component_protocols.extract_uncorrelated_trajectory.schema,
-            component_protocols.extract_uncorrelated_statistics.schema,
-            full_system_protocols.extract_uncorrelated_trajectory.schema,
-            full_system_protocols.extract_uncorrelated_statistics.schema,
-            add_component_enthalpies.schema,
-            calculate_enthalpy_of_mixing.schema,
-            component_gradient_group.schema,
-            full_system_gradient_group.schema,
-            add_component_gradients.schema,
-            combine_gradients.schema,
-        ]
-
-        schema.protocol_replicators = [gradient_replicator, component_replicator]
-
-        # Finally, tell the schemas where to look for its final values.
-        schema.gradients_sources = [ProtocolPath("result", combine_gradients.id)]
-        schema.final_value_source = ProtocolPath(
-            "result", calculate_enthalpy_of_mixing.id
-        )
-
-        schema.outputs_to_store = {
-            "full_system": full_output,
-            f"component_$({component_replicator_id})": component_output,
-        }
-
-        calculation_schema.workflow_schema = schema
-        return calculation_schema
-
-    @staticmethod
+    @classmethod
+    def _observable_type(cls) -> ObservableType:
+        return ObservableType.Enthalpy
+
+    @classmethod
     def default_reweighting_schema(
-        absolute_tolerance=UNDEFINED,
-        relative_tolerance=UNDEFINED,
-        n_effective_samples=50,
-    ):
-        """Returns the default calculation schema to use when estimating
-        this property by reweighting existing data.
-
-        Parameters
-        ----------
-        absolute_tolerance: pint.Quantity, optional
-            The absolute tolerance to estimate the property to within.
-        relative_tolerance: float
-            The tolerance (as a fraction of the properties reported
-            uncertainty) to estimate the property to within.
-        n_effective_samples: int
-            The minimum number of effective samples to require when
-            reweighting the cached simulation data.
-
-        Returns
-        -------
-        ReweightingSchema
-            The schema to follow when estimating this property.
-        """
-        assert absolute_tolerance == UNDEFINED or relative_tolerance == UNDEFINED
-
-        calculation_schema = ReweightingSchema()
-        calculation_schema.absolute_tolerance = absolute_tolerance
-        calculation_schema.relative_tolerance = relative_tolerance
-
-        # Set up the storage queries
-        calculation_schema.storage_queries = (
-            EnthalpyOfMixing._default_reweighting_storage_query()
-        )
-
-        # Set up a replicator that will re-run the component reweighting workflow for each
-        # component in the system.
-        component_replicator = ProtocolReplicator(replicator_id="component_replicator")
-        component_replicator.template_values = ProtocolPath("components", "global")
-
-        gradient_replicator = ProtocolReplicator("gradient")
-        gradient_replicator.template_values = ProtocolPath(
-            "parameter_gradient_keys", "global"
-        )
-
-        # Set up the protocols which will reweight data for the full system.
-        full_data_replicator_id = "full_data_replicator"
-
-        (
-            full_protocols,
-            full_enthalpy,
-            full_data_replicator,
-            full_gradient_group,
-            full_gradient_source,
-        ) = EnthalpyOfMixing._get_reweighting_protocols(
-            "_full",
-            gradient_replicator.id,
-            full_data_replicator_id,
-            n_effective_samples=n_effective_samples,
-        )
-
-        # Set up the protocols which will reweight data for each component.
-        component_data_replicator_id = (
-            f"component_{component_replicator.placeholder_id}_data_replicator"
-        )
-
-        (
-            component_protocols,
-            component_enthalpies,
-            component_data_replicator,
-            component_gradient_group,
-            component_gradient_source,
-        ) = EnthalpyOfMixing._get_reweighting_protocols(
-            "_component",
-            gradient_replicator.id,
-            component_data_replicator_id,
-            replicator_id=component_replicator.id,
-            weight_by_mole_fraction=True,
-            substance_reference=ReplicatorValue(component_replicator.id),
-            n_effective_samples=n_effective_samples,
-        )
-
-        # Make sure the replicator is only replicating over component data.
-        component_data_replicator.template_values = ProtocolPath(
-            f"component_data[$({component_replicator.id})]", "global"
-        )
-
-        add_component_potentials = miscellaneous.AddValues("add_component_potentials")
-        add_component_potentials.values = component_enthalpies
-
-        calculate_excess_enthalpy = miscellaneous.SubtractValues(
-            "calculate_excess_potential"
-        )
-        calculate_excess_enthalpy.value_b = full_enthalpy
-        calculate_excess_enthalpy.value_a = ProtocolPath(
-            "result", add_component_potentials.id
-        )
-
-        # Combine the gradients.
-        add_component_gradients = miscellaneous.AddValues(
-            f"add_component_gradients" f"_{gradient_replicator.placeholder_id}"
-        )
-        add_component_gradients.values = component_gradient_source
-
-        combine_gradients = miscellaneous.SubtractValues(
-            f"combine_gradients_{gradient_replicator.placeholder_id}"
-        )
-        combine_gradients.value_b = full_gradient_source
-        combine_gradients.value_a = ProtocolPath("result", add_component_gradients.id)
-
-        # Build the final workflow schema.
-        schema = WorkflowSchema()
-
-        schema.protocol_schemas = [
-            *(x.schema for x in full_protocols),
-            *(x.schema for x in component_protocols),
-            add_component_potentials.schema,
-            calculate_excess_enthalpy.schema,
-            full_gradient_group.schema,
-            component_gradient_group.schema,
-            add_component_gradients.schema,
-            combine_gradients.schema,
-        ]
-
-        schema.protocol_replicators = [
-            full_data_replicator,
-            component_replicator,
-            component_data_replicator,
-            gradient_replicator,
-        ]
-
-        schema.gradients_sources = [ProtocolPath("result", combine_gradients.id)]
-        schema.final_value_source = ProtocolPath("result", calculate_excess_enthalpy.id)
-
-        calculation_schema.workflow_schema = schema
-        return calculation_schema
+        cls,
+        absolute_tolerance: unit.Quantity = UNDEFINED,
+        relative_tolerance: float = UNDEFINED,
+        n_effective_samples: int = 50,
+    ) -> ReweightingSchema:
+        raise NotImplementedError()
 
 
 @thermoml_property(
@@ -844,63 +119,68 @@ class EnthalpyOfVaporization(PhysicalProperty):
             absolute_tolerance != UNDEFINED or relative_tolerance != UNDEFINED
         )
 
-        # Define a custom conditional group.
-        converge_uncertainty = groups.ConditionalGroup("converge_uncertainty")
+        # Define a custom conditional group which will ensure both the liquid and
+        # gas enthalpies are estimated to within the specified uncertainty tolerance.
+        converge_uncertainty = groups.ConditionalGroup("conditional_group")
         converge_uncertainty.max_iterations = 100
 
         # Define the protocols to perform the simulation in the liquid phase.
-        extract_liquid_energy = analysis.ExtractAverageStatistic(
-            "extract_liquid_energy"
-        )
-        extract_liquid_energy.statistics_type = ObservableType.PotentialEnergy
-        extract_liquid_energy.divisor = n_molecules
-
+        average_liquid_energy = analysis.AverageObservable("average_liquid_potential")
+        average_liquid_energy.divisor = n_molecules
         (
             liquid_protocols,
             liquid_value_source,
             liquid_output_to_store,
-        ) = generate_base_simulation_protocols(
-            extract_liquid_energy,
+        ) = generate_simulation_protocols(
+            average_liquid_energy,
             use_target_uncertainty,
             "_liquid",
             converge_uncertainty,
+            n_molecules=n_molecules,
         )
-
-        # Make sure the number of molecules in the liquid is consistent.
-        liquid_protocols.build_coordinates.max_molecules = n_molecules
         liquid_output_to_store.property_phase = PropertyPhase.Liquid
 
-        # Define the protocols to perform the simulation in the gas phase.
-        extract_gas_energy = analysis.ExtractAverageStatistic("extract_gas_energy")
-        extract_gas_energy.statistics_type = ObservableType.PotentialEnergy
+        liquid_protocols.analysis_protocol.observable = ProtocolPath(
+            f"observables[{ObservableType.PotentialEnergy.value}]",
+            liquid_protocols.production_simulation.id,
+        )
 
+        # Define the protocols to perform the simulation in the gas phase.
+        average_gas_energy = analysis.AverageObservable("average_gas_potential")
         (
             gas_protocols,
             gas_value_source,
             gas_output_to_store,
-        ) = generate_base_simulation_protocols(
-            extract_gas_energy,
+        ) = generate_simulation_protocols(
+            average_gas_energy,
             use_target_uncertainty,
             "_gas",
             converge_uncertainty,
+            n_molecules=1,
+        )
+        gas_output_to_store.property_phase = PropertyPhase.Gas
+
+        gas_protocols.analysis_protocol.observable = ProtocolPath(
+            f"observables[{ObservableType.PotentialEnergy.value}]",
+            gas_protocols.production_simulation.id,
         )
 
-        # Create only a single molecule in vacuum
+        # Specify that for the gas phase only a single molecule in vacuum should be
+        # created.
         gas_protocols.build_coordinates.max_molecules = 1
         gas_protocols.build_coordinates.mass_density = (
             0.01 * unit.gram / unit.milliliter
         )
-        gas_output_to_store.property_phase = PropertyPhase.Gas
 
-        # Run the gas phase simulations in the NVT ensemble
+        # Run the gas phase simulations in the NVT ensemble without PBC
         gas_protocols.energy_minimisation.enable_pbc = False
         gas_protocols.equilibration_simulation.ensemble = Ensemble.NVT
         gas_protocols.equilibration_simulation.enable_pbc = False
         gas_protocols.production_simulation.ensemble = Ensemble.NVT
+        gas_protocols.production_simulation.enable_pbc = False
         gas_protocols.production_simulation.steps_per_iteration = 15000000
         gas_protocols.production_simulation.output_frequency = 5000
         gas_protocols.production_simulation.checkpoint_frequency = 100
-        gas_protocols.production_simulation.enable_pbc = False
 
         # Due to a bizarre issue where the OMM Reference platform is
         # the fastest at computing properties of a single molecule
@@ -913,8 +193,8 @@ class EnthalpyOfVaporization(PhysicalProperty):
 
         # Combine the values to estimate the final energy of vaporization
         energy_of_vaporization = miscellaneous.SubtractValues("energy_of_vaporization")
-        energy_of_vaporization.value_b = ProtocolPath("value", extract_gas_energy.id)
-        energy_of_vaporization.value_a = ProtocolPath("value", extract_liquid_energy.id)
+        energy_of_vaporization.value_b = ProtocolPath("value", average_gas_energy.id)
+        energy_of_vaporization.value_a = ProtocolPath("value", average_liquid_energy.id)
 
         ideal_volume = miscellaneous.MultiplyValue("ideal_volume")
         ideal_volume.value = 1.0 * unit.molar_gas_constant
@@ -928,7 +208,7 @@ class EnthalpyOfVaporization(PhysicalProperty):
             ProtocolPath("result", ideal_volume.id),
         ]
 
-        # Add the extra protocols and conditions to the custom group.
+        # Add the extra protocols and conditions to the custom conditional group.
         converge_uncertainty.add_protocols(
             energy_of_vaporization, ideal_volume, enthalpy_of_vaporization
         )
@@ -948,96 +228,11 @@ class EnthalpyOfVaporization(PhysicalProperty):
             gas_protocols.production_simulation.total_number_of_iterations = (
                 ProtocolPath("current_iteration", converge_uncertainty.id)
             )
-
             liquid_protocols.production_simulation.total_number_of_iterations = (
                 ProtocolPath("current_iteration", converge_uncertainty.id)
             )
 
             converge_uncertainty.add_condition(condition)
-
-        # Set up the liquid gradient calculations
-        liquid_coordinate_source = ProtocolPath(
-            "output_coordinate_file", liquid_protocols.equilibration_simulation.id
-        )
-        liquid_trajectory_source = ProtocolPath(
-            "trajectory_file_path",
-            liquid_protocols.converge_uncertainty.id,
-            liquid_protocols.production_simulation.id,
-        )
-        liquid_statistics_source = ProtocolPath(
-            "statistics_file_path",
-            liquid_protocols.converge_uncertainty.id,
-            liquid_protocols.production_simulation.id,
-        )
-
-        reweight_potential_template = reweighting.ReweightStatistics("")
-        reweight_potential_template.statistics_type = ObservableType.PotentialEnergy
-        reweight_potential_template.reference_reduced_potentials = (
-            liquid_statistics_source
-        )
-
-        (
-            liquid_gradient_group,
-            liquid_gradient_replicator,
-            liquid_gradient_source,
-        ) = generate_gradient_protocol_group(
-            reweight_potential_template,
-            ProtocolPath("force_field_path", "global"),
-            liquid_coordinate_source,
-            liquid_trajectory_source,
-            liquid_statistics_source,
-            id_suffix="_liquid",
-        )
-
-        # Set up the gas gradient calculations
-        gas_coordinate_source = ProtocolPath(
-            "output_coordinate_file", gas_protocols.equilibration_simulation.id
-        )
-        gas_trajectory_source = ProtocolPath(
-            "trajectory_file_path",
-            gas_protocols.converge_uncertainty.id,
-            gas_protocols.production_simulation.id,
-        )
-        gas_statistics_source = ProtocolPath(
-            "statistics_file_path",
-            gas_protocols.converge_uncertainty.id,
-            gas_protocols.production_simulation.id,
-        )
-
-        reweight_potential_template.reference_reduced_potentials = gas_statistics_source
-
-        (
-            gas_gradient_group,
-            gas_gradient_replicator,
-            gas_gradient_source,
-        ) = generate_gradient_protocol_group(
-            reweight_potential_template,
-            ProtocolPath("force_field_path", "global"),
-            gas_coordinate_source,
-            gas_trajectory_source,
-            gas_statistics_source,
-            id_suffix="_gas",
-            enable_pbc=False,
-        )
-
-        # Combine the gradients.
-        scale_liquid_gradient = miscellaneous.DivideValue(
-            "scale_liquid_gradient_$(repl)"
-        )
-        scale_liquid_gradient.value = liquid_gradient_source
-        scale_liquid_gradient.divisor = n_molecules
-
-        combine_gradients = miscellaneous.SubtractValues("combine_gradients_$(repl)")
-        combine_gradients.value_b = gas_gradient_source
-        combine_gradients.value_a = ProtocolPath("result", scale_liquid_gradient.id)
-
-        # Combine the gradient replicators.
-        gradient_replicator = ProtocolReplicator(
-            replicator_id=liquid_gradient_replicator.id
-        )
-        gradient_replicator.template_values = ProtocolPath(
-            "parameter_gradient_keys", "global"
-        )
 
         # Build the workflow schema.
         schema = WorkflowSchema()
@@ -1047,29 +242,22 @@ class EnthalpyOfVaporization(PhysicalProperty):
             liquid_protocols.assign_parameters.schema,
             liquid_protocols.energy_minimisation.schema,
             liquid_protocols.equilibration_simulation.schema,
+            liquid_protocols.decorrelate_trajectory.schema,
+            liquid_protocols.decorrelate_observables.schema,
             gas_protocols.build_coordinates.schema,
             gas_protocols.assign_parameters.schema,
             gas_protocols.energy_minimisation.schema,
             gas_protocols.equilibration_simulation.schema,
+            gas_protocols.decorrelate_trajectory.schema,
+            gas_protocols.decorrelate_observables.schema,
             converge_uncertainty.schema,
-            liquid_protocols.extract_uncorrelated_trajectory.schema,
-            liquid_protocols.extract_uncorrelated_statistics.schema,
-            gas_protocols.extract_uncorrelated_trajectory.schema,
-            gas_protocols.extract_uncorrelated_statistics.schema,
-            liquid_gradient_group.schema,
-            gas_gradient_group.schema,
-            scale_liquid_gradient.schema,
-            combine_gradients.schema,
         ]
-
-        schema.protocol_replicators = [gradient_replicator]
 
         schema.outputs_to_store = {
             "liquid_data": liquid_output_to_store,
             "gas_data": gas_output_to_store,
         }
 
-        schema.gradients_sources = [ProtocolPath("result", combine_gradients.id)]
         schema.final_value_source = ProtocolPath(
             "result", converge_uncertainty.id, enthalpy_of_vaporization.id
         )
@@ -1077,8 +265,9 @@ class EnthalpyOfVaporization(PhysicalProperty):
         calculation_schema.workflow_schema = schema
         return calculation_schema
 
-    @staticmethod
+    @classmethod
     def default_reweighting_schema(
+        cls,
         absolute_tolerance=UNDEFINED,
         relative_tolerance=UNDEFINED,
         n_effective_samples=50,
@@ -1109,83 +298,53 @@ class EnthalpyOfVaporization(PhysicalProperty):
         calculation_schema.relative_tolerance = relative_tolerance
 
         # Set up the storage queries
-        calculation_schema.storage_queries = (
-            EnthalpyOfVaporization._default_reweighting_storage_query()
-        )
-
-        # Set up the data replicators
-        liquid_data_replicator = ProtocolReplicator("liquid_data_replicator")
-        liquid_data_replicator.template_values = ProtocolPath("liquid_data", "global")
-
-        gas_data_replicator = ProtocolReplicator("gas_data_replicator")
-        gas_data_replicator.template_values = ProtocolPath("gas_data", "global")
-
-        # Set up the gradient replicator
-        gradient_replicator = ProtocolReplicator("gradient_replicator")
-        gradient_replicator.template_values = ProtocolPath(
-            "parameter_gradient_keys", "global"
-        )
+        calculation_schema.storage_queries = cls._default_reweighting_storage_query()
 
         # Set up a protocol to extract the liquid phase energy from the existing data.
-        extract_liquid_energy = analysis.ExtractAverageStatistic(
-            f"extract_liquid_energy_" f"{liquid_data_replicator.placeholder_id}"
-        )
-        extract_liquid_energy.statistics_type = ObservableType.PotentialEnergy
-
-        reweight_liquid_energy = reweighting.ReweightStatistics(
-            "reweight_liquid_energy"
-        )
-        reweight_liquid_energy.statistics_type = ObservableType.PotentialEnergy
-        reweight_liquid_energy.required_effective_samples = n_effective_samples
-
-        liquid_protocols, _ = generate_base_reweighting_protocols(
-            extract_liquid_energy,
-            reweight_liquid_energy,
+        liquid_protocols, liquid_replicator = generate_reweighting_protocols(
+            ObservableType.PotentialEnergy,
             id_suffix="_liquid",
-            replicator_id=liquid_data_replicator.id,
+            replicator_id="liquid_data_replicator",
+        )
+        liquid_replicator.template_values = ProtocolPath("liquid_data", "global")
+        liquid_protocols.reweight_observable.required_effective_samples = (
+            n_effective_samples
         )
 
-        # Extract the number of liquid phase molecules from the first data collection.
-        number_of_liquid_molecules = ProtocolPath(
-            "total_number_of_molecules",
-            liquid_protocols.unpack_stored_data.id.replace(
-                liquid_data_replicator.placeholder_id, "0"
-            ),
-        )
-
+        # Dive the potential by the number of liquid phase molecules from the first
+        # piece of cached data.
         divide_by_liquid_molecules = miscellaneous.DivideValue(
             "divide_by_liquid_molecules"
         )
         divide_by_liquid_molecules.value = ProtocolPath(
-            "value", liquid_protocols.mbar_protocol.id
+            "value", liquid_protocols.reweight_observable.id
         )
-        divide_by_liquid_molecules.divisor = number_of_liquid_molecules
+        divide_by_liquid_molecules.divisor = ProtocolPath(
+            "total_number_of_molecules",
+            liquid_protocols.unpack_stored_data.id.replace(
+                liquid_replicator.placeholder_id, "0"
+            ),
+        )
 
         # Set up a protocol to extract the gas phase energy from the existing data.
-        extract_gas_energy = analysis.ExtractAverageStatistic(
-            "extract_gas_energy_" f"{gas_data_replicator.placeholder_id}"
-        )
-        extract_gas_energy.statistics_type = ObservableType.PotentialEnergy
-
-        reweight_gas_energy = reweighting.ReweightStatistics("reweight_gas_energy")
-        reweight_gas_energy.statistics_type = ObservableType.PotentialEnergy
-        reweight_gas_energy.required_effective_samples = n_effective_samples
-
-        gas_protocols, _ = generate_base_reweighting_protocols(
-            extract_gas_energy,
-            reweight_gas_energy,
+        gas_protocols, gas_replicator = generate_reweighting_protocols(
+            ObservableType.PotentialEnergy,
             id_suffix="_gas",
-            replicator_id=gas_data_replicator.id,
+            replicator_id="gas_data_replicator",
+        )
+        gas_replicator.template_values = ProtocolPath("gas_data", "global")
+        gas_protocols.reweight_observable.required_effective_samples = (
+            n_effective_samples
         )
 
         # Turn of PBC for the gas phase.
-        gas_protocols.reduced_reference_potential.enable_pbc = False
-        gas_protocols.reduced_target_potential.enable_pbc = False
+        gas_protocols.evaluate_reference_potential.enable_pbc = False
+        gas_protocols.evaluate_target_potential.enable_pbc = False
 
         # Combine the values to estimate the final enthalpy of vaporization
         energy_of_vaporization = miscellaneous.SubtractValues("energy_of_vaporization")
         energy_of_vaporization.value_b = ProtocolPath(
-            "value", gas_protocols.mbar_protocol.id
+            "value", gas_protocols.reweight_observable.id
         )
         energy_of_vaporization.value_a = ProtocolPath(
             "result", divide_by_liquid_molecules.id
@@ -1203,99 +362,17 @@ class EnthalpyOfVaporization(PhysicalProperty):
             ProtocolPath("result", ideal_volume.id),
         ]
 
-        # Set up the liquid phase gradient calculations
-        reweight_potential_template = copy.deepcopy(reweight_liquid_energy)
-
-        liquid_coordinate_path = ProtocolPath(
-            "output_coordinate_path", liquid_protocols.concatenate_trajectories.id
-        )
-        liquid_trajectory_path = ProtocolPath(
-            "output_trajectory_path", liquid_protocols.concatenate_trajectories.id
-        )
-        liquid_statistics_path = ProtocolPath(
-            "statistics_file_path", liquid_protocols.reduced_target_potential.id
-        )
-
-        (
-            liquid_gradient_group,
-            _,
-            liquid_gradient_source,
-        ) = generate_gradient_protocol_group(
-            reweight_potential_template,
-            ProtocolPath("force_field_path", "global"),
-            liquid_coordinate_path,
-            liquid_trajectory_path,
-            liquid_statistics_path,
-            replicator_id=gradient_replicator.id,
-            id_suffix="_liquid",
-            effective_sample_indices=ProtocolPath(
-                "effective_sample_indices", liquid_protocols.mbar_protocol.id
-            ),
-        )
-
-        # Set up the gas phase gradient calculations
-        reweight_potential_template = copy.deepcopy(reweight_gas_energy)
-
-        gas_coordinate_path = ProtocolPath(
-            "output_coordinate_path", gas_protocols.concatenate_trajectories.id
-        )
-        gas_trajectory_path = ProtocolPath(
-            "output_trajectory_path", gas_protocols.concatenate_trajectories.id
-        )
-        gas_statistics_path = ProtocolPath(
-            "statistics_file_path", gas_protocols.reduced_target_potential.id
-        )
-
-        gas_gradient_group, _, gas_gradient_source = generate_gradient_protocol_group(
-            reweight_potential_template,
-            ProtocolPath("force_field_path", "global"),
-            gas_coordinate_path,
-            gas_trajectory_path,
-            gas_statistics_path,
-            replicator_id=gradient_replicator.id,
-            id_suffix="_gas",
-            enable_pbc=False,
-            effective_sample_indices=ProtocolPath(
-                "effective_sample_indices", gas_protocols.mbar_protocol.id
-            ),
-        )
-
-        # Combine the gradients.
-        divide_liquid_gradient = miscellaneous.DivideValue(
-            f"divide_liquid_gradient_" f"{gradient_replicator.placeholder_id}"
-        )
-        divide_liquid_gradient.value = liquid_gradient_source
-        divide_liquid_gradient.divisor = number_of_liquid_molecules
-
-        combine_gradients = miscellaneous.SubtractValues(
-            f"combine_gradients_{gradient_replicator.placeholder_id}"
-        )
-        combine_gradients.value_b = gas_gradient_source
-        combine_gradients.value_a = ProtocolPath("result", divide_liquid_gradient.id)
-
         # Build the workflow schema.
         schema = WorkflowSchema()
-
         schema.protocol_schemas = [
-            *(x.schema for x in liquid_protocols),
-            *(x.schema for x in gas_protocols),
+            *(x.schema for x in liquid_protocols if x is not None),
+            *(x.schema for x in gas_protocols if x is not None),
             divide_by_liquid_molecules.schema,
             energy_of_vaporization.schema,
             ideal_volume.schema,
             enthalpy_of_vaporization.schema,
-            liquid_gradient_group.schema,
-            gas_gradient_group.schema,
-            divide_liquid_gradient.schema,
-            combine_gradients.schema,
         ]
-
-        schema.protocol_replicators = [
-            liquid_data_replicator,
-            gas_data_replicator,
-            gradient_replicator,
-        ]
-
-        schema.gradients_sources = [ProtocolPath("result", combine_gradients.id)]
+        schema.protocol_replicators = [liquid_replicator, gas_replicator]
         schema.final_value_source = ProtocolPath("result", enthalpy_of_vaporization.id)
 
         calculation_schema.workflow_schema = schema
@@ -1305,9 +382,6 @@ class EnthalpyOfVaporization(PhysicalProperty):
 # Register the properties via the plugin system.
 register_calculation_schema(
     EnthalpyOfMixing, SimulationLayer, EnthalpyOfMixing.default_simulation_schema
-)
-register_calculation_schema(
-    EnthalpyOfMixing, ReweightingLayer, EnthalpyOfMixing.default_reweighting_schema
 )
 register_calculation_schema(
     EnthalpyOfVaporization,

--- a/openff/evaluator/properties/properties.py
+++ b/openff/evaluator/properties/properties.py
@@ -1,0 +1,436 @@
+import abc
+from typing import Dict, Optional, Tuple
+
+from openff.evaluator import unit
+from openff.evaluator.attributes import UNDEFINED, PlaceholderValue
+from openff.evaluator.datasets import PhysicalProperty, PropertyPhase
+from openff.evaluator.layers.reweighting import ReweightingSchema
+from openff.evaluator.layers.simulation import SimulationSchema
+from openff.evaluator.protocols import analysis, miscellaneous
+from openff.evaluator.protocols.utils import (
+    generate_reweighting_protocols,
+    generate_simulation_protocols,
+)
+from openff.evaluator.storage.query import SimulationDataQuery, SubstanceQuery
+from openff.evaluator.utils.observables import ObservableType
+from openff.evaluator.workflow.schemas import ProtocolReplicator, WorkflowSchema
+from openff.evaluator.workflow.utils import ProtocolPath, ReplicatorValue
+
+
+class EstimableExcessProperty(PhysicalProperty, abc.ABC):
+    """A base class for estimable excess physical properties, such as enthalpies of
+    mixing or excess molar volumes, which provides a common framework for defining
+    estimation workflows.
+    """
+
+    @classmethod
+    @abc.abstractmethod
+    def _observable_type(cls) -> ObservableType:
+        """The type of excess observable that this class corresponds to."""
+        raise NotImplementedError
+
+    @classmethod
+    def _n_molecules_divisor(
+        cls, n_molecules: ProtocolPath, suffix: Optional[str] = None
+    ) -> Tuple[ProtocolPath, Optional[miscellaneous.DivideValue]]:
+        """Returns the number of molecules to scale the value of the observable by.
+        For energies this is just the total number of molecules in the box as they are
+        already in units per mole. For other observables this is the total number of
+        molecules divided by the Avogadro constant.
+
+        Parameters
+        ----------
+        n_molecules
+            A reference to the number of molecules in the simulation box.
+        suffix
+            An optional string to append to the id of the protocol which will
+            normalize the number of molecules by the Avogadro constant. This
+            argument is only used for observables which aren't energies.
+
+        Returns
+        -------
+            A reference to the divisor as well as optionally the protocol from
+            which it is computed.
+        """
+
+        suffix = "" if suffix is None else suffix
+
+        n_molar_molecules = None
+
+        if cls._observable_type() in [
+            ObservableType.Temperature,
+            ObservableType.Volume,
+            ObservableType.Density,
+        ]:
+
+            n_molar_molecules = miscellaneous.DivideValue(f"n_molar_molecules{suffix}")
+            n_molar_molecules.value = n_molecules
+            n_molar_molecules.divisor = (1.0 * unit.avogadro_constant).to("mole**-1")
+
+            n_molecules = ProtocolPath("result", n_molar_molecules.id)
+
+        return n_molecules, n_molar_molecules
+
+    @classmethod
+    def default_simulation_schema(
+        cls,
+        absolute_tolerance=UNDEFINED,
+        relative_tolerance=UNDEFINED,
+        n_molecules=1000,
+    ) -> SimulationSchema:
+        """Returns the default calculation schema to use when estimating
+        this class of property from direct simulations.
+
+        Parameters
+        ----------
+        absolute_tolerance: pint.Quantity, optional
+            The absolute tolerance to estimate the property to within.
+        relative_tolerance: float
+            The tolerance (as a fraction of the properties reported
+            uncertainty) to estimate the property to within.
+        n_molecules: int
+            The number of molecules to use in the simulation.
+
+        Returns
+        -------
+        SimulationSchema
+            The schema to follow when estimating this property.
+        """
+        assert absolute_tolerance == UNDEFINED or relative_tolerance == UNDEFINED
+
+        calculation_schema = SimulationSchema()
+        calculation_schema.absolute_tolerance = absolute_tolerance
+        calculation_schema.relative_tolerance = relative_tolerance
+
+        use_target_uncertainty = (
+            absolute_tolerance != UNDEFINED or relative_tolerance != UNDEFINED
+        )
+
+        # Define the protocols to use for the fully mixed system.
+        (
+            mixture_protocols,
+            mixture_value,
+            mixture_stored_data,
+        ) = generate_simulation_protocols(
+            analysis.AverageObservable("extract_observable_mixture"),
+            use_target_uncertainty,
+            id_suffix="_mixture",
+            n_molecules=n_molecules,
+        )
+        # Specify the average observable which should be estimated.
+        mixture_protocols.analysis_protocol.observable = ProtocolPath(
+            f"observables[{cls._observable_type().value}]",
+            mixture_protocols.production_simulation.id,
+        )
+        (
+            mixture_protocols.analysis_protocol.divisor,
+            mixture_n_molar_molecules,
+        ) = cls._n_molecules_divisor(
+            ProtocolPath(
+                "output_number_of_molecules", mixture_protocols.build_coordinates.id
+            ),
+            "_mixture",
+        )
+
+        # Define the protocols to use for each component, creating a replicator that
+        # will copy these for each component in the mixture substance.
+        component_replicator = ProtocolReplicator("component_replicator")
+        component_replicator.template_values = ProtocolPath("components", "global")
+        component_substance = ReplicatorValue(component_replicator.id)
+
+        component_protocols, _, component_stored_data = generate_simulation_protocols(
+            analysis.AverageObservable("extract_observable_component"),
+            use_target_uncertainty,
+            id_suffix=f"_component_{component_replicator.placeholder_id}",
+            n_molecules=n_molecules,
+        )
+        # Make sure the protocols point to the correct substance.
+        component_protocols.build_coordinates.substance = component_substance
+        # Specify the average observable which should be estimated.
+        component_protocols.analysis_protocol.observable = ProtocolPath(
+            f"observables[{cls._observable_type().value}]",
+            component_protocols.production_simulation.id,
+        )
+        (
+            component_protocols.analysis_protocol.divisor,
+            component_n_molar_molecules,
+        ) = cls._n_molecules_divisor(
+            ProtocolPath(
+                "output_number_of_molecules", component_protocols.build_coordinates.id
+            ),
+            f"_component_{component_replicator.placeholder_id}",
+        )
+
+        # Weight the component value by the mole fraction.
+        weight_by_mole_fraction = miscellaneous.WeightByMoleFraction(
+            f"weight_by_mole_fraction_{component_replicator.placeholder_id}"
+        )
+        weight_by_mole_fraction.value = ProtocolPath(
+            "value", component_protocols.analysis_protocol.id
+        )
+        weight_by_mole_fraction.full_substance = ProtocolPath("substance", "global")
+        weight_by_mole_fraction.component = component_substance
+
+        component_protocols.converge_uncertainty.add_protocols(weight_by_mole_fraction)
+
+        # Make sure the convergence criteria is set to use the per component
+        # uncertainty target.
+        if use_target_uncertainty:
+            component_protocols.converge_uncertainty.conditions[
+                0
+            ].right_hand_value = ProtocolPath("per_component_uncertainty", "global")
+
+        # Finally, set up the protocols which will be responsible for adding together
+        # the component observables, and subtracting these from the mixture system value.
+        add_component_observables = miscellaneous.AddValues("add_component_observables")
+        add_component_observables.values = ProtocolPath(
+            "weighted_value",
+            component_protocols.converge_uncertainty.id,
+            weight_by_mole_fraction.id,
+        )
+
+        calculate_excess_observable = miscellaneous.SubtractValues(
+            "calculate_excess_observable"
+        )
+        calculate_excess_observable.value_b = mixture_value
+        calculate_excess_observable.value_a = ProtocolPath(
+            "result", add_component_observables.id
+        )
+
+        # Build the final workflow schema
+        schema = WorkflowSchema()
+
+        schema.protocol_schemas = [
+            component_protocols.build_coordinates.schema,
+            component_protocols.assign_parameters.schema,
+            component_protocols.energy_minimisation.schema,
+            component_protocols.equilibration_simulation.schema,
+            component_protocols.converge_uncertainty.schema,
+            component_protocols.decorrelate_trajectory.schema,
+            component_protocols.decorrelate_observables.schema,
+            mixture_protocols.build_coordinates.schema,
+            mixture_protocols.assign_parameters.schema,
+            mixture_protocols.energy_minimisation.schema,
+            mixture_protocols.equilibration_simulation.schema,
+            mixture_protocols.converge_uncertainty.schema,
+            mixture_protocols.decorrelate_trajectory.schema,
+            mixture_protocols.decorrelate_observables.schema,
+            add_component_observables.schema,
+            calculate_excess_observable.schema,
+        ]
+
+        if component_n_molar_molecules is not None:
+            schema.protocol_schemas.append(component_n_molar_molecules.schema)
+        if mixture_n_molar_molecules is not None:
+            schema.protocol_schemas.append(mixture_n_molar_molecules.schema)
+
+        schema.protocol_replicators = [component_replicator]
+
+        schema.final_value_source = ProtocolPath(
+            "result", calculate_excess_observable.id
+        )
+
+        schema.outputs_to_store = {
+            "full_system": mixture_stored_data,
+            f"component_{component_replicator.placeholder_id}": component_stored_data,
+        }
+
+        calculation_schema.workflow_schema = schema
+        return calculation_schema
+
+    @classmethod
+    def _default_reweighting_storage_query(cls) -> Dict[str, SimulationDataQuery]:
+        """Returns the default storage queries to use when retrieving cached simulation
+        data to reweight.
+
+        This will include one query (with the key `"full_system_data"`) to return data
+        for the full mixture system, and another query (with the key `"component_data"`)
+        which will include data for each pure component in the system.
+
+        Returns
+        -------
+            The dictionary of queries.
+        """
+        mixture_data_query = SimulationDataQuery()
+        mixture_data_query.substance = PlaceholderValue()
+        mixture_data_query.property_phase = PropertyPhase.Liquid
+
+        # Set up a query which will return the data of each
+        # individual component in the system.
+        component_query = SubstanceQuery()
+        component_query.components_only = True
+
+        component_data_query = SimulationDataQuery()
+        component_data_query.property_phase = PropertyPhase.Liquid
+        component_data_query.substance = PlaceholderValue()
+        component_data_query.substance_query = component_query
+
+        return {
+            "full_system_data": mixture_data_query,
+            "component_data": component_data_query,
+        }
+
+    @classmethod
+    def default_reweighting_schema(
+        cls,
+        absolute_tolerance: unit.Quantity = UNDEFINED,
+        relative_tolerance: float = UNDEFINED,
+        n_effective_samples: int = 50,
+    ) -> ReweightingSchema:
+        """Returns the default calculation schema to use when estimating this class of
+        property by re-weighting cached simulation data.
+
+        Parameters
+        ----------
+        absolute_tolerance
+            The absolute tolerance to estimate the property to within.
+        relative_tolerance
+            The tolerance (as a fraction of the properties reported
+            uncertainty) to estimate the property to within.
+        n_effective_samples
+            The minimum number of effective samples to require when
+            reweighting the cached simulation data.
+
+        Returns
+        -------
+            The default re-weighting calculation schema.
+        """
+        assert absolute_tolerance == UNDEFINED or relative_tolerance == UNDEFINED
+
+        calculation_schema = ReweightingSchema()
+        calculation_schema.absolute_tolerance = absolute_tolerance
+        calculation_schema.relative_tolerance = relative_tolerance
+
+        # Set up the storage queries
+        calculation_schema.storage_queries = cls._default_reweighting_storage_query()
+
+        # Define the protocols which will re-weight the observable computed for the
+        # fully mixed system.
+        mixture_protocols, mixture_data_replicator = generate_reweighting_protocols(
+            cls._observable_type(),
+            "mixture_data_replicator",
+            "_mixture",
+        )
+        mixture_protocols.reweight_observable.required_effective_samples = (
+            n_effective_samples
+        )
+
+        divide_by_mixture_molecules = miscellaneous.DivideValue(
+            "divide_by_mixture_molecules"
+        )
+        divide_by_mixture_molecules.value = ProtocolPath(
+            "value", mixture_protocols.reweight_observable.id
+        )
+        (
+            divide_by_mixture_molecules.divisor,
+            mixture_n_molar_molecules,
+        ) = cls._n_molecules_divisor(
+            ProtocolPath(
+                "total_number_of_molecules",
+                mixture_protocols.unpack_stored_data.id.replace(
+                    mixture_data_replicator.placeholder_id, "0"
+                ),
+            ),
+            "_mixture",
+        )
+
+        # Define the protocols to use for each component, creating a replicator that
+        # will copy these for each component in the full substance.
+        component_replicator = ProtocolReplicator("component_replicator")
+        component_replicator.template_values = ProtocolPath("components", "global")
+
+        component_protocols, component_data_replicator = generate_reweighting_protocols(
+            cls._observable_type(),
+            f"_component_{component_replicator.placeholder_id}",
+            f"component_{component_replicator.placeholder_id}_data_replicator",
+        )
+        component_protocols.reweight_observable.required_effective_samples = (
+            n_effective_samples
+        )
+        component_data_replicator.template_values = ProtocolPath(
+            f"component_data[$({component_replicator.id})]", "global"
+        )
+
+        divide_by_component_molecules = miscellaneous.DivideValue(
+            f"divide_by_component_{component_replicator.placeholder_id}_molecules"
+        )
+        divide_by_component_molecules.value = ProtocolPath(
+            "value", component_protocols.reweight_observable.id
+        )
+        (
+            divide_by_component_molecules.divisor,
+            component_n_molar_molecules,
+        ) = cls._n_molecules_divisor(
+            ProtocolPath(
+                "total_number_of_molecules",
+                component_protocols.unpack_stored_data.id.replace(
+                    component_data_replicator.placeholder_id, "0"
+                ),
+            ),
+            f"_component_{component_replicator.placeholder_id}",
+        )
+
+        # Make sure the protocols point to the correct substance.
+        component_substance = ReplicatorValue(component_replicator.id)
+
+        component_protocols.build_reference_system.substance = component_substance
+        component_protocols.build_target_system.substance = component_substance
+
+        # Weight the component value by the mole fraction.
+        weight_by_mole_fraction = miscellaneous.WeightByMoleFraction(
+            f"weight_by_mole_fraction_{component_replicator.placeholder_id}"
+        )
+        weight_by_mole_fraction.value = ProtocolPath(
+            "result", divide_by_component_molecules.id
+        )
+        weight_by_mole_fraction.full_substance = ProtocolPath("substance", "global")
+        weight_by_mole_fraction.component = component_substance
+
+        # Finally, set up the protocols which will be responsible for adding together
+        # the component observables, and subtracting these from the full system value.
+        add_component_observables = miscellaneous.AddValues("add_component_observables")
+        add_component_observables.values = ProtocolPath(
+            "weighted_value",
+            weight_by_mole_fraction.id,
+        )
+
+        calculate_excess_observable = miscellaneous.SubtractValues(
+            "calculate_excess_observable"
+        )
+        calculate_excess_observable.value_b = ProtocolPath(
+            "value", mixture_protocols.reweight_observable.id
+        )
+        calculate_excess_observable.value_a = ProtocolPath(
+            "result", add_component_observables.id
+        )
+
+        # Build the final workflow schema
+        schema = WorkflowSchema()
+
+        schema.protocol_schemas = [
+            *[x.schema for x in mixture_protocols if x is not None],
+            divide_by_mixture_molecules.schema,
+            *[x.schema for x in component_protocols if x is not None],
+            divide_by_component_molecules.schema,
+            weight_by_mole_fraction.schema,
+            add_component_observables.schema,
+            calculate_excess_observable.schema,
+        ]
+
+        if component_n_molar_molecules is not None:
+            schema.protocol_schemas.append(component_n_molar_molecules.schema)
+        if mixture_n_molar_molecules is not None:
+            schema.protocol_schemas.append(mixture_n_molar_molecules.schema)
+
+        schema.protocol_replicators = [
+            mixture_data_replicator,
+            component_replicator,
+            component_data_replicator,
+        ]
+
+        schema.final_value_source = ProtocolPath(
+            "result", calculate_excess_observable.id
+        )
+
+        calculation_schema.workflow_schema = schema
+        return calculation_schema

--- a/openff/evaluator/properties/solvation.py
+++ b/openff/evaluator/properties/solvation.py
@@ -81,8 +81,8 @@ class SolvationFreeEnergy(PhysicalProperty):
         # Perform a quick minimisation of the full system to give
         # YANK a better starting point for its minimisation.
         energy_minimisation = openmm.OpenMMEnergyMinimisation("energy_minimisation")
-        energy_minimisation.system_path = ProtocolPath(
-            "system_path", assign_full_parameters.id
+        energy_minimisation.parameterized_system = ProtocolPath(
+            "parameterized_system", assign_full_parameters.id
         )
         energy_minimisation.input_coordinate_file = ProtocolPath(
             "coordinate_file_path", build_full_coordinates.id
@@ -96,8 +96,8 @@ class SolvationFreeEnergy(PhysicalProperty):
         equilibration_simulation.thermodynamic_state = ProtocolPath(
             "thermodynamic_state", "global"
         )
-        equilibration_simulation.system_path = ProtocolPath(
-            "system_path", assign_full_parameters.id
+        equilibration_simulation.parameterized_system = ProtocolPath(
+            "parameterized_system", assign_full_parameters.id
         )
         equilibration_simulation.input_coordinate_file = ProtocolPath(
             "output_coordinate_file", energy_minimisation.id
@@ -145,17 +145,17 @@ class SolvationFreeEnergy(PhysicalProperty):
             "output_coordinate_file", equilibration_simulation.id
         )
         run_yank.solvent_1_system = ProtocolPath(
-            "system_path", assign_full_parameters.id
+            "parameterized_system", assign_full_parameters.id
         )
         run_yank.solvent_2_coordinates = ProtocolPath(
             "coordinate_file_path", build_vacuum_coordinates.id
         )
         run_yank.solvent_2_system = ProtocolPath(
-            "system_path", assign_vacuum_parameters.id
+            "parameterized_system", assign_vacuum_parameters.id
         )
 
-        # Set up the group which will run yank until the free energy has been determined to within
-        # a given uncertainty
+        # Set up the group which will run yank until the free energy has been determined
+        # to within a given uncertainty
         conditional_group = groups.ConditionalGroup("conditional_group")
         conditional_group.max_iterations = 20
 


### PR DESCRIPTION
## Description
This PR updates each of the physical property workflows to use the new thermodynamic derivatives rather than the old finite difference code. This includes a large refactor of the excess physical property workflows to make use of the same workflow generation code to remove redundancy.

For now computations of enthalpies of mixing by re-weighting are not supported until a valid workflow can be produced.

## Status
- [X] Ready to go