### PR TITLE
[DOCS] Pin the Documentation to Python 3.7

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ build:
   image: stable
 
 python:
-  version: 3.6 
+  version: 3.7
   setup_py_install: true
 
 # Build PDF in addition to default HTML and JSON

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,7 +3,7 @@ channels:
     - conda-forge
 dependencies:
     # Base depends
-    - python
+    - python =3.7
     - setuptools
 
     # Sphinx specific


### PR DESCRIPTION
## Description

This PR pins the documentation to build using the most recent supported python version (3.7). This should resolve the current build failures which are attempting to build with 3.9 which not all dependencies on the main channel (which RTD is pulling from) support yet.

## Status
- [X] Ready to go