### PR TITLE
[GRADIENTS] Update Docs After Gradient Refactor

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -430,20 +430,14 @@ Built-in Workflow Protocols
     :nosignatures:
     :toctree: api/generated/
 
-    AveragePropertyProtocol
-    AverageTrajectoryProperty
-    ExtractAverageStatistic
-    ExtractUncorrelatedData
-    ExtractUncorrelatedTrajectoryData
-    ExtractUncorrelatedStatisticsData
-
-
-.. currentmodule:: openff.evaluator.properties.dielectric
-.. autosummary::
-    :nosignatures:
-    :toctree: api/generated/
-
-    ExtractAverageDielectric
+    BaseAverageObservable
+    AverageObservable
+    AverageDielectricConstant
+    AverageFreeEnergies
+    ComputeDipoleMoments
+    BaseDecorrelateProtocol
+    DecorrelateTrajectory
+    DecorrelateObservables
 
 **Coordinate Generation**
 
@@ -475,8 +469,7 @@ Built-in Workflow Protocols
     :nosignatures:
     :toctree: api/generated/
 
-    BaseGradientPotentials
-    CentralDifferenceGradient
+    ZeroGradients
 
 **Groups**
 
@@ -510,8 +503,7 @@ Built-in Workflow Protocols
 
     OpenMMEnergyMinimisation
     OpenMMSimulation
-    OpenMMReducedPotentials
-    OpenMMGradientPotentials
+    OpenMMEvaluateEnergies
 
 **Paprika**
 
@@ -551,18 +543,11 @@ Built-in Workflow Protocols
     :toctree: api/generated/
 
     ConcatenateTrajectories
-    ConcatenateStatistics
-    BaseReducedPotentials
+    ConcatenateObservables
+    BaseEvaluateEnergies
     BaseMBARProtocol
-    ReweightStatistics
-
-.. currentmodule:: openff.evaluator.properties.dielectric
-.. autosummary::
-    :nosignatures:
-    :toctree: api/generated/
-
+    ReweightObservable
     ReweightDielectricConstant
-
 
 **Simulation**
 
@@ -602,11 +587,11 @@ Workflow Construction Utilities
     :nosignatures:
     :toctree: api/generated/
 
-    BaseReweightingProtocols
-    BaseSimulationProtocols
+    SimulationProtocols
+    ReweightingProtocols
     generate_base_reweighting_protocols
-    generate_base_simulation_protocols
-    generate_gradient_protocol_group
+    generate_reweighting_protocols
+    generate_simulation_protocols
 
 Attribute Utilities
 -------------------
@@ -620,6 +605,20 @@ Attribute Utilities
     AttributeClass
     UNDEFINED
     PlaceholderValue
+
+Observable Utilities
+--------------------
+
+.. currentmodule:: openff.evaluator.utils.observables
+.. autosummary::
+    :nosignatures:
+    :toctree: api/generated/
+
+    Observable
+    ObservableArray
+    ObservableType
+    ObservableFrame
+    bootstrap
 
 Plug-in Utilities
 -----------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -164,6 +164,13 @@ See the :doc:`physical properties overview page <properties/properties>` for mor
 .. toctree::
   :maxdepth: 2
   :hidden:
+  :caption: Observables
+
+  Overview <observables/observables>
+
+.. toctree::
+  :maxdepth: 2
+  :hidden:
   :caption: Calculation Backends
 
   Overview <backends/calculationbackend>

--- a/docs/observables/observables.rst
+++ b/docs/observables/observables.rst
@@ -1,0 +1,112 @@
+.. |observable|              replace:: :py:class:`~openff.evaluator.utils.observables.Observable`
+.. |observable_array|        replace:: :py:class:`~openff.evaluator.utils.observables.ObservableArray`
+.. |observable_frame|        replace:: :py:class:`~openff.evaluator.utils.observables.ObservableFrame`
+.. |observable_type|         replace:: :py:class:`~openff.evaluator.utils.observables.ObservableType`
+
+.. |observable_array_join|   replace:: :py:meth:`~openff.evaluator.utils.observables.ObservableArray.join`
+.. |observable_array_subset| replace:: :py:meth:`~openff.evaluator.utils.observables.ObservableArray.subset`
+.. |observable_frame_join|   replace:: :py:meth:`~openff.evaluator.utils.observables.ObservableFrame.join`
+.. |observable_frame_subset| replace:: :py:meth:`~openff.evaluator.utils.observables.ObservableFrame.subset`
+
+.. |parameter_gradient|      replace:: :py:class:`~openff.evaluator.forcefield.ParameterGradient`
+.. |parameter_gradient_key|  replace:: :py:class:`~openff.evaluator.forcefield.ParameterGradientKey`
+
+.. |quantity|                replace:: :py:class:`~pint.Quantity`
+.. |measurement|             replace:: :py:class:`~pint.Measurement`
+
+.. |float|                   replace:: :py:class:`~float`
+.. |int|                     replace:: :py:class:`~int`
+
+Observables
+===========
+
+A key feature of this framework is its ability to compute the gradients of physical properties with respect to the
+force field parameters used to estimate them. This requires the framework be able to, internally, be able to not only
+track the gradients of all quantities which combine to yield the final observable of interest, but to also be able to
+propagate the gradients of those composite quantities through to the final value.
+
+The framework offers three such objects to this end (|observable|, |observable_array| and |observable_frame| objects)
+which will be covered in this document.
+
+.. note:: In future versions of the framework the objects described here will likely be at least in part deprecated
+          in favour of using full automatic differentiation libraries such as `jax <https://github.com/google/jax>`_.
+          Supporting these libraries will take a large re-write of the framework however, as well as full support
+          between differentiable simulation engines like `timemachine <https://github.com/proteneer/timemachine>`_ and
+          the OpenFF toolkit. As such, these objects are implemented as stepping stones which can be gently phased out
+          while working towards that larger, more modern goal.
+
+Observable Objects
+------------------
+
+The base object used to track observables is the |observable| object. It stores the average value, the standard error
+in the value and the gradient of the value with respect to force field parameters of interest.
+
+Currently the value and error are internally stored in a composite |measurement| object, which themselves wrap around
+the `uncertainties <https://pythonhosted.org/uncertainties/>`_ package. This allows uncertainties to be automatically
+propagated through operations without the need for user intervention.
+
+.. note:: Although uncertainties are automatically propagated, it is still up to property estimation workflow authors to
+          ensure that such propagation (assuming a Gaussian error model) is appropriate. An alternative, which is
+          employed throughout the framework is to make use of the bootstrapping technique.
+
+Gradients are stored in a list as |parameter_gradient| gradient objects, which store both the floating value of the
+gradient alongside an identifying |parameter_gradient_key|.
+
+Supported Operations
+""""""""""""""""""""
+
+.. rst-class:: spaced-list
+
+    - **+ and -**: |observable| objects can be summed with and subtracted from other |observable| objects, pint
+      |quantity| objects, floats or integers. When two |observable| objects are summed / subtracted, their gradients are
+      combined by summing / subtracting also. When an |observable| is summed / subtracted with a |quantity|,
+      |float| or |int| object it is assumed that these objects do not depend on any force field parameters.
+
+    - **\***: |observable| objects may be multiplied by other |observable| objects, pint |quantity| objects, and |float|
+      or |int| objects. When two |observable| objects are multiplied their gradients are propagated using the product
+      rule. When an |observable| is multiplied by a |quantity|, |float| or |int| object it is assumed that these
+      objects do not depend on any force field parameters.
+
+    - **/**: |observable| objects may be divided by other |observable| objects, pint |quantity| objects, and |float| or
+      |int| objects. Gradients are propagated through the division using the quotient rule. When an |observable| is
+      divided by a |quantity|, |float| or |int| object (or when these objects are divided by an |observable| object)
+      it is assumed that these objects do not depend on any force field parameters.
+
+In all cases two |observable| objects can only be operated on provided the contain gradient information with respect
+to the same set of force field parameters.
+
+Observable Arrays
+-----------------
+
+An extension of the |observable| object is the |observable_array| object. Unlike an |observable|, an |observable_array| 
+object does not contain error information, but rather the value it stores and the gradients of that value should be a 
+numpy array with ``shape=(n_data_points, n_dimensions)``. It is designed to store information such as the potential 
+energy evaluated at each configuration sampled during a simulation, as well as the gradient of the potential, which can
+then be ensemble averaged using a fluctuation formula to propagate the gradients through to the average.
+
+Like with |observable| objects, gradients are stored in a list as |parameter_gradient| gradient objects. The length
+of the gradients is required to match the length of the value array.
+
+|observable_array| objects may be concatenated together using their |observable_array_join| method or sub-sampled using
+their |observable_array_subset| method.
+
+Supported Operations
+""""""""""""""""""""
+
+The |observable_array| object supports the same operations as the |observable| object, whereby all operations are 
+applied elementwise to the stored arrays. 
+
+Observable Frames
+-----------------
+
+An |observable_frame| is a wrapper around a collection of |observable_array| which contain the types of observable
+specified by the |observable_type| enum. It behaves as a dictionary which can take either an |observable_type| or
+a string value of an |observable_type| as an index.
+
+Like an |observable_array|, observable frames may be concatenated together using their |observable_frame_join| method 
+or sub-sampled using their |observable_frame_subset| method.
+
+Supported Operations
+""""""""""""""""""""
+
+No operations are supported between observable frames.

--- a/docs/properties/commonworkflows.rst
+++ b/docs/properties/commonworkflows.rst
@@ -1,24 +1,25 @@
-.. |build_coordinates_packmol|    replace:: :py:class:`~openff.evaluator.protocols.coordinates.BuildCoordinatesPackmol`
+.. |build_coordinates_packmol|     replace:: :py:class:`~openff.evaluator.protocols.coordinates.BuildCoordinatesPackmol`
 
-.. |build_smirnoff_system|        replace:: :py:class:`~openff.evaluator.protocols.forcefield.BuildSmirnoffSystem`
-.. |build_tleap_system|           replace:: :py:class:`~openff.evaluator.protocols.forcefield.BuildTLeapSystem`
-.. |build_lig_par_gen_system|     replace:: :py:class:`~openff.evaluator.protocols.forcefield.BuildLigParGenSystem`
+.. |build_smirnoff_system|         replace:: :py:class:`~openff.evaluator.protocols.forcefield.BuildSmirnoffSystem`
+.. |build_tleap_system|            replace:: :py:class:`~openff.evaluator.protocols.forcefield.BuildTLeapSystem`
+.. |build_lig_par_gen_system|      replace:: :py:class:`~openff.evaluator.protocols.forcefield.BuildLigParGenSystem`
 
-.. |openmm_energy_minimisation|   replace:: :py:class:`~openff.evaluator.protocols.openmm.OpenMMEnergyMinimisation`
-.. |openmm_simulation|            replace:: :py:class:`~openff.evaluator.protocols.openmm.OpenMMSimulation`
-.. |openmm_reduced_potentials|    replace:: :py:class:`~openff.evaluator.protocols.openmm.OpenMMReducedPotentials`
+.. |openmm_energy_minimisation|    replace:: :py:class:`~openff.evaluator.protocols.openmm.OpenMMEnergyMinimisation`
+.. |openmm_simulation|             replace:: :py:class:`~openff.evaluator.protocols.openmm.OpenMMSimulation`
+.. |openmm_evaluate_energies|      replace:: :py:class:`~openff.evaluator.protocols.openmm.OpenMMEvaluateEnergies`
 
-.. |extract_average_statistic|              replace:: :py:class:`~openff.evaluator.protocols.analysis.ExtractAverageStatistic`
-.. |extract_uncorrelated_statistics_data|   replace:: :py:class:`~openff.evaluator.protocols.analysis.ExtractUncorrelatedStatisticsData`
-.. |extract_uncorrelated_trajectory_data|   replace:: :py:class:`~openff.evaluator.protocols.analysis.ExtractUncorrelatedTrajectoryData`
+.. |average_observable|            replace:: :py:class:`~openff.evaluator.protocols.analysis.AverageObservable`
+.. |decorrelate_trajectory|        replace:: :py:class:`~openff.evaluator.protocols.analysis.DecorrelateTrajectory`
+.. |decorrelate_observables|       replace:: :py:class:`~openff.evaluator.protocols.analysis.DecorrelateObservables`
 
-.. |concatenate_trajectories|          replace:: :py:class:`~openff.evaluator.protocols.reweighting.ConcatenateTrajectories`
-.. |concatenate_statistics|            replace:: :py:class:`~openff.evaluator.protocols.reweighting.ConcatenateStatistics`
-.. |reweight_statistics|               replace:: :py:class:`~openff.evaluator.protocols.reweighting.ReweightStatistics`
+.. |concatenate_trajectories|      replace:: :py:class:`~openff.evaluator.protocols.reweighting.ConcatenateTrajectories`
+.. |concatenate_statistics|        replace:: :py:class:`~openff.evaluator.protocols.reweighting.ConcatenateStatistics`
+.. |reweight_observable|           replace:: :py:class:`~openff.evaluator.protocols.reweighting.ReweightObservable`
 
-.. |unpack_stored_simulation_data|          replace:: :py:class:`~openff.evaluator.protocols.storage.UnpackStoredSimulationData`
+.. |unpack_stored_simulation_data|        replace:: :py:class:`~openff.evaluator.protocols.storage.UnpackStoredSimulationData`
 
-.. |generate_base_simulation_protocols|   replace:: :py:meth:`~openff.evaluator.protocols.utils.generate_base_simulation_protocols`
+.. |generate_simulation_protocols|        replace:: :py:meth:`~openff.evaluator.protocols.utils.generate_simulation_protocols`
+.. |generate_reweighting_protocols|       replace:: :py:meth:`~openff.evaluator.protocols.utils.generate_reweighting_protocols`
 .. |generate_base_reweighting_protocols|  replace:: :py:meth:`~openff.evaluator.protocols.utils.generate_base_reweighting_protocols`
 
 .. |simulation_layer|    replace:: :doc:`Direct Simulation <../layers/simulationlayer>`
@@ -35,7 +36,7 @@ physical property estimation workflows are constructed.
 ------------------
 
 Properties being estimated using the :doc:`direct simulation <../layers/simulationlayer>` calculation layer typically
-base their workflows off of the |generate_base_simulation_protocols| template.
+base their workflows off of the |generate_simulation_protocols| template.
 
 .. note:: This template currently assumes that a liquid phase property is being computed.
 
@@ -43,8 +44,7 @@ The workflow produced by this template proceeds as follows:
 
 .. rst-class:: spaced-list
 
-    1) 1000 molecules are inserted into a simulation box with an approximate density of 0.95 g / mL. property substance
-       using packmol (|build_coordinates_packmol|).
+    1) 1000 molecules are inserted into a simulation box with an approximate density of 0.95 g / mL using `packmol <http://m3g.iqm.unicamp.br/packmol/home.shtml>`_ (|build_coordinates_packmol|).
 
     2) the system is parameterized using either the `OpenFF toolkit <#>`_, `TLeap <#>`_ or `LigParGen <#>`_ depending on the force field being employed (|build_smirnoff_system|, |build_tleap_system| or |build_lig_par_gen_system|).
 
@@ -56,18 +56,18 @@ The workflow produced by this template proceeds as follows:
 
         5a) a longer NPT production simulation is run for 1000000 steps with a timestep of 2 fs and using the OpenMM simulation protocol (|openmm_simulation|) with its default Langevin integrator and Monte Carlo barostat.
 
-        5b) the correlated samples are removed from the simulation outputs and the average value of the observable of interest and its uncertainty are computed by bootstrapping with replacement for 250 iterations (|extract_average_statistic|).  See :cite:`2016:chodera` for details of the decorrelation procedure.
+        5b) the correlated samples are removed from the simulation outputs and the average value of the observable of interest and its uncertainty are computed by bootstrapping with replacement for 250 iterations (|average_observable|).  See :cite:`2016:chodera` for details of the decorrelation procedure.
 
         5c) steps 5a) and 5b) are repeated until the uncertainty condition (if applicable) is met.
 
 The decorrelated simulation outputs are then made available ready to be cached by a
-:doc:`storage backend <../storage/storagebackend>` (|extract_uncorrelated_statistics_data|, |extract_uncorrelated_trajectory_data|).
+:doc:`storage backend <../storage/storagebackend>` (|decorrelate_observables|, |decorrelate_trajectory|).
 
 |reweighting_layer|
 -------------------
 
 Properties being estimated using the :doc:`MBAR reweighting <../layers/reweightinglayer>` calculation layer typically
-base their workflows off of the |generate_base_reweighting_protocols| template.
+base their workflows off of the |generate_reweighting_protocols| template.
 
 The workflow produced by this template proceeds as follows:
 
@@ -77,19 +77,24 @@ The workflow produced by this template proceeds as follows:
 
         1a) the cached data is retrieved from disk (|unpack_stored_simulation_data|)
 
-        1b) the cached data is subsampled so that the data which will be reweighted is decorrelated (|extract_average_statistic|, |extract_uncorrelated_statistics_data|, |extract_uncorrelated_trajectory_data|). See :cite:`2016:chodera` for details of the decorrelation procedure.
-
     2) the cached data from is concatenated together to form a single trajectory of configurations and observables (|concatenate_trajectories|, |concatenate_statistics|).
 
     3) for each stored simulation data:
 
         3a) the system is parameterized using the force field parameters which were used when originally generating the cached data i.e. one of the reference states (|build_smirnoff_system|, |build_tleap_system| or |build_lig_par_gen_system|).
 
-        3b) the reduced potential of each configuration in the concatenated trajectory is evaluated using the parameterized system (|openmm_reduced_potentials|).
+        3b) the reduced potential of each configuration in the concatenated trajectory is evaluated using the parameterized system (|openmm_evaluate_energies|).
 
-    4) the system is parameterized using the force field parameters with which the property of interest should be calculated using i.e. of the target state (|build_smirnoff_system|, |build_tleap_system| or |build_lig_par_gen_system|) and the reduced potential of each configuration in the concatenated trajectory is evaluated using the parameterized system (|openmm_reduced_potentials|).
+    4) the system is parameterized using the force field parameters with which the property of interest should be calculated using i.e. of the target state (|build_smirnoff_system|, |build_tleap_system| or |build_lig_par_gen_system|) and the reduced potential of each configuration in the concatenated trajectory is evaluated using the parameterized system (|openmm_evaluate_energies|).
 
-    5) the MBAR method is employed to compute the average value of the observable of interest and its uncertainty at the target state, taking the reference state reduced potentials as input. See :cite:`2018:messerly-a` for the theory behind this approach. An exception is raised if there are not enough effective samples to reweight (|reweight_statistics|).
+        4a) *(optional)* if the observable of interest is a function of the force field parameters it is recomputed using the target state parameters. These recomputed values then replace the original concatenated observables loaded from the cached data.
+
+    5) the reference potentials, target potentials and the joined observables are sub-sampled to only retain equilibrated, uncorrelated samples (|average_observable|, |decorrelate_observables|, |decorrelate_trajectory|). See :cite:`2016:chodera` for details of the decorrelation procedure.
+
+    6) the MBAR method is employed to compute the average value of the observable of interest and its uncertainty at the target state, taking the reference state reduced potentials as input. See :cite:`2018:messerly-a` for the theory behind this approach. An exception is raised if there are not enough effective samples to reweight (|reweight_observable|).
+
+In more specialised cases the |generate_base_reweighting_protocols| template (which |generate_reweighting_protocols| is
+built off of) is instead used due to its greater flexibility.
 
 References
 ----------

--- a/docs/properties/gradients.bib
+++ b/docs/properties/gradients.bib
@@ -1,20 +1,10 @@
-@article{2008:shirts,
-  title={Statistically optimal analysis of samples from multiple equilibrium states},
-  author={Shirts, Michael R and Chodera, John D},
-  journal={The Journal of chemical physics},
-  volume={129},
-  number={12},
-  pages={124105},
-  year={2008},
-  publisher={American Institute of Physics}
-}
-@article{2018:messerly-b,
-  title={Configuration-sampling-based surrogate models for rapid parameterization of non-bonded interactions},
-  author={Messerly, Richard A and Razavi, S Mostafa and Shirts, Michael R},
-  journal={Journal of Chemical Theory and Computation},
-  volume={14},
-  number={6},
-  pages={3144--3162},
-  year={2018},
+@article{2013:wang,
+  title={Systematic improvement of a classical molecular model of water},
+  author={Wang, Lee-Ping and Head-Gordon, Teresa and Ponder, Jay W and Ren, Pengyu and Chodera, John D and Eastman, Peter K and Martinez, Todd J and Pande, Vijay S},
+  journal={The Journal of Physical Chemistry B},
+  volume={117},
+  number={34},
+  pages={9956--9972},
+  year={2013},
   publisher={ACS Publications}
 }

--- a/docs/workflows/protocolgroups.rst
+++ b/docs/workflows/protocolgroups.rst
@@ -53,11 +53,10 @@ longer and longer until the groups condition has been met::
     # value of the density and its uncertainty.
     simulation = OpenMMSimulation("simulation")
     simulation.input_coordinate_file = "coords.pdb"
-    simulation.system_path = "system.xml"
+    simulation.parameterized_system = ...
 
-    extract_density = ExtractAverageStatistic("extract_density")
-    extract_density.statistics_type = ObservableType.Density
-    extract_density.statistics_path = simulation.statistics_file_path
+    extract_density = AverageObservable("extract_density")
+    extract_density.observable = simulation.observables["Density"]
 
     # Set the total number of iterations the simulation should perform to be equal
     # to the current iteration of the group. I.e the simulation should perform a

--- a/openff/evaluator/protocols/gradients.py
+++ b/openff/evaluator/protocols/gradients.py
@@ -21,12 +21,12 @@ from openff.evaluator.workflow.attributes import InputAttribute, OutputAttribute
 
 @workflow_protocol()
 class ZeroGradients(Protocol, abc.ABC):
-    """Zeros out the gradients of an observable
-    with respect to a set of force field parameters.
+    """Zeros the gradients of an observable with respect to a specified set of force
+    field parameters.
     """
 
     input_observables = InputAttribute(
-        docstring="The observables to differentiate.",
+        docstring="The observable to set the gradients of.",
         type_hint=Union[Observable, ObservableArray],
         default_value=UNDEFINED,
     )


### PR DESCRIPTION
## Description
This PR updates the documentation to reflect the changes made during the large gradient refactoring. This includes:

- updating the gradient documentation page to highlight that fluctuation formula is now being used.
- updating the API docs to reflect the protocol name changes and relocations.
- adding documentation for the new observable classes.
- updating the property estimation documentation to reflect the new protocol names and updated re-weighting workflows.

## Status
- [X] Ready to go