### PR TITLE
Add a Date to the Timestamp Logging Output

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -35,6 +35,7 @@ New Features
 """"""""""""
 
 * PR `#280 <https://github.com/openforcefield/openff-evaluator/pull/280>`_: Switch to computing thermodynamic gradients.
+* PR `#309 <https://github.com/openforcefield/openff-evaluator/pull/309>`_: Add a date to the timestamp logging output.
 
 Breaking Changes
 """"""""""""""""

--- a/openff/evaluator/utils/utils.py
+++ b/openff/evaluator/utils/utils.py
@@ -38,7 +38,8 @@ def get_data_filename(relative_path):
 
 
 def setup_timestamp_logging(file_path=None):
-    """Set up timestamp-based logging.
+    """Set up timestamp based logging which outputs in the style of
+    ``YEAR-MONTH-DAY HOUR:MINUTE:SECOND.MILLISECOND LEVEL MESSAGE``.
 
     Parameters
     ----------
@@ -47,7 +48,8 @@ def setup_timestamp_logging(file_path=None):
         print to the terminal.
     """
     formatter = logging.Formatter(
-        fmt="%(asctime)s.%(msecs)03d %(levelname)-8s %(message)s", datefmt="%H:%M:%S"
+        fmt="%(asctime)s.%(msecs)03d %(levelname)-8s %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
     )
 
     if file_path is None:


### PR DESCRIPTION
## Description
This PR updates the `setup_timestamp_logging` utility to include a date in addition to the time when logging.

## Status
- [X] Ready to go