### PR TITLE
Pin Pint due to Dask Serialization Bug

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -19,7 +19,7 @@ dependencies:
   - pandas
   - openmm
   - networkx
-  - pint >= 0.10.1
+  - pint >=0.10.1,<0.15
   - packmol
   - pymbar >=3.0.5
   - mdtraj >=1.9.3


### PR DESCRIPTION
## Description
This PR pins pint to avoid a bug introduced in 0.15 and onwards whereby measurements and units are not correctly (de)serialised to the correct types by `dask`.

## Status
- [X] Ready to go