### PR TITLE
Fix Key Error when Setting Default Calculation Schema

### DIFF
--- a/openff/evaluator/client/client.py
+++ b/openff/evaluator/client/client.py
@@ -593,6 +593,9 @@ class EvaluatorClient:
                 if property_type in properties_without_schemas:
                     properties_without_schemas.remove(property_type)
 
+                if property_type not in options.calculation_schemas:
+                    options.calculation_schemas[property_type] = {}
+
                 options.calculation_schemas[property_type][
                     calculation_layer
                 ] = default_schema


### PR DESCRIPTION
## Description
This PR fixes an exception raised when a user has provided calculation schemas for only a subset of property types which a given layer will attempt to estimate, and the default schema is used for the unspecified property types.

## Status
- [X] Ready to go