### PR TITLE
Add Dummy Miscellaneous Protocol

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -497,6 +497,7 @@ Built-in Workflow Protocols
     DivideValue
     WeightByMoleFraction
     FilterSubstanceByRole
+    DummyProtocol
 
 **OpenMM**
 

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -38,6 +38,7 @@ New Features
 * PR `#309 <https://github.com/openforcefield/openff-evaluator/pull/309>`_: Add a date to the timestamp logging output.
 * PR `#311 <https://github.com/openforcefield/openff-evaluator/pull/311>`_: Initial solvation free energy gradient support.
 * PR `#312 <https://github.com/openforcefield/openff-evaluator/pull/312>`_: Support caching free energy data.
+* PR `#324 <https://github.com/openforcefield/openff-evaluator/pull/324>`_: Adds new miscellaneous ``DummyProtocol`` protocol.
 
 Behaviour Changes
 """""""""""""""""

--- a/openff/evaluator/protocols/miscellaneous.py
+++ b/openff/evaluator/protocols/miscellaneous.py
@@ -8,7 +8,7 @@ import numpy as np
 import pint
 
 from openff.evaluator.attributes import UNDEFINED
-from openff.evaluator.forcefield import ParameterGradient
+from openff.evaluator.forcefield import ParameterGradient, ParameterGradientKey
 from openff.evaluator.substances import Component, MoleFraction, Substance
 from openff.evaluator.utils.observables import Observable, ObservableArray
 from openff.evaluator.workflow import Protocol, workflow_protocol
@@ -352,3 +352,52 @@ class FilterSubstanceByRole(Protocol):
 
         super(FilterSubstanceByRole, self).validate(attribute_type)
         assert all(isinstance(x, Component.Role) for x in self.component_roles)
+
+
+@workflow_protocol()
+class DummyProtocol(Protocol):
+    """A protocol whose only purpose is to return an input value as an output
+    value."""
+
+    input_value = InputAttribute(
+        docstring="A dummy input.",
+        type_hint=typing.Union[
+            str,
+            int,
+            float,
+            pint.Quantity,
+            pint.Measurement,
+            Observable,
+            ObservableArray,
+            ParameterGradient,
+            ParameterGradientKey,
+            list,
+            tuple,
+            dict,
+            set,
+            frozenset,
+        ],
+        default_value=UNDEFINED,
+    )
+    output_value = OutputAttribute(
+        docstring="A dummy output.",
+        type_hint=typing.Union[
+            str,
+            int,
+            float,
+            pint.Quantity,
+            pint.Measurement,
+            Observable,
+            ObservableArray,
+            ParameterGradient,
+            ParameterGradientKey,
+            list,
+            tuple,
+            dict,
+            set,
+            frozenset,
+        ],
+    )
+
+    def _execute(self, directory, available_resources):
+        self.output_value = self.input_value

--- a/openff/evaluator/tests/test_layers/test_workflow_layer.py
+++ b/openff/evaluator/tests/test_layers/test_workflow_layer.py
@@ -7,9 +7,9 @@ from openff.evaluator.client import RequestOptions
 from openff.evaluator.forcefield import SmirnoffForceFieldSource
 from openff.evaluator.layers.simulation import SimulationLayer, SimulationSchema
 from openff.evaluator.properties import Density
+from openff.evaluator.protocols.miscellaneous import DummyProtocol
 from openff.evaluator.server import server
 from openff.evaluator.storage import LocalFileStorage
-from openff.evaluator.tests.test_workflow.utils import DummyInputOutputProtocol
 from openff.evaluator.tests.utils import create_dummy_property
 from openff.evaluator.utils.observables import Observable
 from openff.evaluator.utils.utils import temporarily_change_directory
@@ -30,7 +30,7 @@ def test_workflow_layer():
     # Create a very simple workflow which just returns some placeholder
     # value.
     estimated_value = Observable((1 * unit.kelvin).plus_minus(0.1 * unit.kelvin))
-    protocol_a = DummyInputOutputProtocol("protocol_a")
+    protocol_a = DummyProtocol("protocol_a")
     protocol_a.input_value = estimated_value
 
     schema = WorkflowSchema()

--- a/openff/evaluator/tests/test_protocols/test_groups.py
+++ b/openff/evaluator/tests/test_protocols/test_groups.py
@@ -6,8 +6,7 @@ import pytest
 from openff.evaluator import unit
 from openff.evaluator.backends import ComputeResources
 from openff.evaluator.protocols.groups import ConditionalGroup
-from openff.evaluator.protocols.miscellaneous import AddValues
-from openff.evaluator.tests.test_workflow.utils import DummyInputOutputProtocol
+from openff.evaluator.protocols.miscellaneous import AddValues, DummyProtocol
 from openff.evaluator.workflow.utils import ProtocolPath
 
 
@@ -17,7 +16,7 @@ def test_conditional_protocol_group():
 
         initial_value = 2 * unit.kelvin
 
-        value_protocol_a = DummyInputOutputProtocol("protocol_a")
+        value_protocol_a = DummyProtocol("protocol_a")
         value_protocol_a.input_value = initial_value
 
         add_values = AddValues("add_values")
@@ -49,7 +48,7 @@ def test_conditional_protocol_group_fail():
 
         initial_value = 2 * unit.kelvin
 
-        value_protocol_a = DummyInputOutputProtocol("protocol_a")
+        value_protocol_a = DummyProtocol("protocol_a")
         value_protocol_a.input_value = initial_value
 
         add_values = AddValues("add_values")
@@ -83,7 +82,7 @@ def test_conditional_group_self_reference():
     group = ConditionalGroup("conditional_group")
     group.max_iterations = max_iterations
 
-    protocol = DummyInputOutputProtocol("protocol_a")
+    protocol = DummyProtocol("protocol_a")
     protocol.input_value = ProtocolPath("current_iteration", group.id)
 
     condition_1 = ConditionalGroup.Condition()

--- a/openff/evaluator/tests/test_workflow/test_protocols.py
+++ b/openff/evaluator/tests/test_workflow/test_protocols.py
@@ -11,8 +11,7 @@ from openff.evaluator import unit
 from openff.evaluator.attributes import UNDEFINED
 from openff.evaluator.backends import ComputeResources
 from openff.evaluator.backends.dask import DaskLocalCluster
-from openff.evaluator.protocols.miscellaneous import AddValues
-from openff.evaluator.tests.test_workflow.utils import DummyInputOutputProtocol
+from openff.evaluator.protocols.miscellaneous import AddValues, DummyProtocol
 from openff.evaluator.utils.serialization import TypedJSONDecoder
 from openff.evaluator.workflow import (
     Protocol,
@@ -31,7 +30,7 @@ class ExceptionProtocol(Protocol):
 
 def test_nested_protocol_paths():
 
-    value_protocol_a = DummyInputOutputProtocol("protocol_a")
+    value_protocol_a = DummyProtocol("protocol_a")
     value_protocol_a.input_value = (1 * unit.kelvin).plus_minus(0.1 * unit.kelvin)
 
     assert (
@@ -39,10 +38,10 @@ def test_nested_protocol_paths():
         == value_protocol_a.input_value.value
     )
 
-    value_protocol_b = DummyInputOutputProtocol("protocol_b")
+    value_protocol_b = DummyProtocol("protocol_b")
     value_protocol_b.input_value = (2 * unit.kelvin).plus_minus(0.05 * unit.kelvin)
 
-    value_protocol_c = DummyInputOutputProtocol("protocol_c")
+    value_protocol_c = DummyProtocol("protocol_c")
     value_protocol_c.input_value = (4 * unit.kelvin).plus_minus(0.01 * unit.kelvin)
 
     add_values_protocol = AddValues("add_values")
@@ -72,7 +71,7 @@ def test_nested_protocol_paths():
 
     assert set(add_values_protocol.values) == {0, 1, 2, 5}
 
-    dummy_dict_protocol = DummyInputOutputProtocol("dict_protocol")
+    dummy_dict_protocol = DummyProtocol("dict_protocol")
 
     dummy_dict_protocol.input_value = {
         "value_a": ProtocolPath("output_value", value_protocol_a.id),
@@ -118,20 +117,20 @@ def build_merge(prefix):
     # a - b \
     #       | - e - f
     # c - d /
-    protocol_a = DummyInputOutputProtocol(prefix + "protocol_a")
+    protocol_a = DummyProtocol(prefix + "protocol_a")
     protocol_a.input_value = 1
-    protocol_b = DummyInputOutputProtocol(prefix + "protocol_b")
+    protocol_b = DummyProtocol(prefix + "protocol_b")
     protocol_b.input_value = ProtocolPath("output_value", protocol_a.id)
-    protocol_c = DummyInputOutputProtocol(prefix + "protocol_c")
+    protocol_c = DummyProtocol(prefix + "protocol_c")
     protocol_c.input_value = 2
-    protocol_d = DummyInputOutputProtocol(prefix + "protocol_d")
+    protocol_d = DummyProtocol(prefix + "protocol_d")
     protocol_d.input_value = ProtocolPath("output_value", protocol_c.id)
-    protocol_e = DummyInputOutputProtocol(prefix + "protocol_e")
+    protocol_e = DummyProtocol(prefix + "protocol_e")
     protocol_e.input_value = [
         ProtocolPath("output_value", protocol_b.id),
         ProtocolPath("output_value", protocol_d.id),
     ]
-    protocol_f = DummyInputOutputProtocol(prefix + "protocol_f")
+    protocol_f = DummyProtocol(prefix + "protocol_f")
     protocol_f.input_value = ProtocolPath("output_value", protocol_e.id)
 
     return [
@@ -148,17 +147,17 @@ def build_fork(prefix):
     #          / i - j
     # g - h - |
     #          \ k - l
-    protocol_g = DummyInputOutputProtocol(prefix + "protocol_g")
+    protocol_g = DummyProtocol(prefix + "protocol_g")
     protocol_g.input_value = 3
-    protocol_h = DummyInputOutputProtocol(prefix + "protocol_h")
+    protocol_h = DummyProtocol(prefix + "protocol_h")
     protocol_h.input_value = ProtocolPath("output_value", protocol_g.id)
-    protocol_i = DummyInputOutputProtocol(prefix + "protocol_i")
+    protocol_i = DummyProtocol(prefix + "protocol_i")
     protocol_i.input_value = ProtocolPath("output_value", protocol_h.id)
-    protocol_j = DummyInputOutputProtocol(prefix + "protocol_j")
+    protocol_j = DummyProtocol(prefix + "protocol_j")
     protocol_j.input_value = ProtocolPath("output_value", protocol_i.id)
-    protocol_k = DummyInputOutputProtocol(prefix + "protocol_k")
+    protocol_k = DummyProtocol(prefix + "protocol_k")
     protocol_k.input_value = ProtocolPath("output_value", protocol_h.id)
-    protocol_l = DummyInputOutputProtocol(prefix + "protocol_l")
+    protocol_l = DummyProtocol(prefix + "protocol_l")
     protocol_l.input_value = ProtocolPath("output_value", protocol_k.id)
 
     return [protocol_g, protocol_h, protocol_i, protocol_j, protocol_k, protocol_l]
@@ -166,9 +165,9 @@ def build_fork(prefix):
 
 def build_easy_graph():
 
-    protocol_a = DummyInputOutputProtocol("protocol_a")
+    protocol_a = DummyProtocol("protocol_a")
     protocol_a.input_value = 1
-    protocol_b = DummyInputOutputProtocol("protocol_b")
+    protocol_b = DummyProtocol("protocol_b")
     protocol_b.input_value = 1
 
     return [protocol_a], [protocol_b]
@@ -258,9 +257,9 @@ def test_protocol_graph_execution(calculation_backend, compute_resources):
     if calculation_backend is not None:
         calculation_backend.start()
 
-    protocol_a = DummyInputOutputProtocol("protocol_a")
+    protocol_a = DummyProtocol("protocol_a")
     protocol_a.input_value = 1
-    protocol_b = DummyInputOutputProtocol("protocol_b")
+    protocol_b = DummyProtocol("protocol_b")
     protocol_b.input_value = ProtocolPath("output_value", protocol_a.id)
 
     protocol_graph = ProtocolGraph()
@@ -297,17 +296,17 @@ def test_protocol_group_merging():
         # a - | g - h - |         |
         #     |          \ k - l -|- c
         #     .-------------------.
-        protocol_a = DummyInputOutputProtocol(prefix + "protocol_a")
+        protocol_a = DummyProtocol(prefix + "protocol_a")
         protocol_a.input_value = 1
         fork_protocols = build_fork(prefix)
         fork_protocols[0].input_value = ProtocolPath("output_value", protocol_a.id)
         protocol_group = ProtocolGroup(prefix + "protocol_group")
         protocol_group.add_protocols(*fork_protocols)
-        protocol_b = DummyInputOutputProtocol(prefix + "protocol_b")
+        protocol_b = DummyProtocol(prefix + "protocol_b")
         protocol_b.input_value = ProtocolPath(
             "output_value", protocol_group.id, "protocol_j"
         )
-        protocol_c = DummyInputOutputProtocol(prefix + "protocol_c")
+        protocol_c = DummyProtocol(prefix + "protocol_c")
         protocol_c.input_value = ProtocolPath(
             "output_value", protocol_group.id, "protocol_l"
         )
@@ -332,9 +331,9 @@ def test_protocol_group_merging():
 
 def test_protocol_group_execution():
 
-    protocol_a = DummyInputOutputProtocol("protocol_a")
+    protocol_a = DummyProtocol("protocol_a")
     protocol_a.input_value = 1
-    protocol_b = DummyInputOutputProtocol("protocol_b")
+    protocol_b = DummyProtocol("protocol_b")
     protocol_b.input_value = ProtocolPath("output_value", protocol_a.id)
 
     protocol_group = ProtocolGroup("protocol_group")
@@ -371,9 +370,9 @@ def test_protocol_group_resume():
 
     # Fake a protocol group which executes the first
     # two protocols and then 'gets killed'.
-    protocol_a = DummyInputOutputProtocol("protocol_a")
+    protocol_a = DummyProtocol("protocol_a")
     protocol_a.input_value = 1
-    protocol_b = DummyInputOutputProtocol("protocol_b")
+    protocol_b = DummyProtocol("protocol_b")
     protocol_b.input_value = ProtocolPath("output_value", protocol_a.id)
 
     protocol_group_a = ProtocolGroup("group_a")
@@ -393,13 +392,13 @@ def test_protocol_group_resume():
 
     # Build the 'full' group with the last two protocols which
     # 'had not been exited' after the group was 'killed'
-    protocol_a = DummyInputOutputProtocol("protocol_a")
+    protocol_a = DummyProtocol("protocol_a")
     protocol_a.input_value = 1
-    protocol_b = DummyInputOutputProtocol("protocol_b")
+    protocol_b = DummyProtocol("protocol_b")
     protocol_b.input_value = ProtocolPath("output_value", protocol_a.id)
-    protocol_c = DummyInputOutputProtocol("protocol_c")
+    protocol_c = DummyProtocol("protocol_c")
     protocol_c.input_value = ProtocolPath("output_value", protocol_b.id)
-    protocol_d = DummyInputOutputProtocol("protocol_d")
+    protocol_d = DummyProtocol("protocol_d")
     protocol_d.input_value = ProtocolPath("output_value", protocol_c.id)
 
     protocol_group_a = ProtocolGroup("group_a")

--- a/openff/evaluator/tests/test_workflow/test_replicators.py
+++ b/openff/evaluator/tests/test_workflow/test_replicators.py
@@ -5,11 +5,8 @@ Units tests for openff.evaluator.layers.simulation
 from openff.evaluator import unit
 from openff.evaluator.properties import Density
 from openff.evaluator.protocols.groups import ProtocolGroup
-from openff.evaluator.protocols.miscellaneous import AddValues
-from openff.evaluator.tests.test_workflow.utils import (
-    DummyInputOutputProtocol,
-    DummyReplicableProtocol,
-)
+from openff.evaluator.protocols.miscellaneous import AddValues, DummyProtocol
+from openff.evaluator.tests.test_workflow.utils import DummyReplicableProtocol
 from openff.evaluator.tests.utils import create_dummy_property
 from openff.evaluator.workflow import Workflow, WorkflowSchema
 from openff.evaluator.workflow.schemas import ProtocolReplicator
@@ -22,12 +19,10 @@ def test_simple_replicators():
 
     replicator_id = "replicator"
 
-    dummy_replicated_protocol = DummyInputOutputProtocol(f"dummy_$({replicator_id})")
+    dummy_replicated_protocol = DummyProtocol(f"dummy_$({replicator_id})")
     dummy_replicated_protocol.input_value = ReplicatorValue(replicator_id)
 
-    dummy_protocol_single_value = DummyInputOutputProtocol(
-        f"dummy_single_$({replicator_id})"
-    )
+    dummy_protocol_single_value = DummyProtocol(f"dummy_single_$({replicator_id})")
     dummy_protocol_single_value.input_value = ProtocolPath(
         "output_value", dummy_replicated_protocol.id
     )
@@ -96,15 +91,13 @@ def test_group_replicators():
 
     replicator_id = "replicator"
 
-    dummy_replicated_protocol = DummyInputOutputProtocol(f"dummy_$({replicator_id})")
+    dummy_replicated_protocol = DummyProtocol(f"dummy_$({replicator_id})")
     dummy_replicated_protocol.input_value = ReplicatorValue(replicator_id)
 
     dummy_group = ProtocolGroup("dummy_group")
     dummy_group.add_protocols(dummy_replicated_protocol)
 
-    dummy_protocol_single_value = DummyInputOutputProtocol(
-        f"dummy_single_$({replicator_id})"
-    )
+    dummy_protocol_single_value = DummyProtocol(f"dummy_single_$({replicator_id})")
     dummy_protocol_single_value.input_value = ProtocolPath(
         "output_value", dummy_group.id, dummy_replicated_protocol.id
     )
@@ -173,12 +166,10 @@ def test_advanced_group_replicators():
 
     replicator_id = "replicator"
 
-    dummy_replicated_protocol = DummyInputOutputProtocol(f"dummy_$({replicator_id})")
+    dummy_replicated_protocol = DummyProtocol(f"dummy_$({replicator_id})")
     dummy_replicated_protocol.input_value = ReplicatorValue(replicator_id)
 
-    dummy_replicated_protocol_2 = DummyInputOutputProtocol(
-        f"dummy_2_$({replicator_id})"
-    )
+    dummy_replicated_protocol_2 = DummyProtocol(f"dummy_2_$({replicator_id})")
     dummy_replicated_protocol_2.input_value = ReplicatorValue(replicator_id)
 
     dummy_group_2 = ProtocolGroup(f"dummy_group_2_$({replicator_id})")
@@ -187,16 +178,12 @@ def test_advanced_group_replicators():
     dummy_group = ProtocolGroup(f"dummy_group_$({replicator_id})")
     dummy_group.add_protocols(dummy_replicated_protocol, dummy_group_2)
 
-    dummy_protocol_single_value = DummyInputOutputProtocol(
-        f"dummy_single_$({replicator_id})"
-    )
+    dummy_protocol_single_value = DummyProtocol(f"dummy_single_$({replicator_id})")
     dummy_protocol_single_value.input_value = ProtocolPath(
         "output_value", dummy_group.id, dummy_replicated_protocol.id
     )
 
-    dummy_protocol_2_single_value = DummyInputOutputProtocol(
-        f"dummy_single_2_$({replicator_id})"
-    )
+    dummy_protocol_2_single_value = DummyProtocol(f"dummy_single_2_$({replicator_id})")
     dummy_protocol_2_single_value.input_value = ProtocolPath(
         "output_value", dummy_group.id, dummy_group_2.id, dummy_replicated_protocol_2.id
     )

--- a/openff/evaluator/tests/test_workflow/test_workflow.py
+++ b/openff/evaluator/tests/test_workflow/test_workflow.py
@@ -10,7 +10,7 @@ from openff.evaluator.attributes import UNDEFINED
 from openff.evaluator.backends import ComputeResources
 from openff.evaluator.backends.dask import DaskLocalCluster
 from openff.evaluator.protocols.groups import ConditionalGroup
-from openff.evaluator.tests.test_workflow.utils import DummyInputOutputProtocol
+from openff.evaluator.protocols.miscellaneous import DummyProtocol
 from openff.evaluator.thermodynamics import ThermodynamicState
 from openff.evaluator.workflow import Workflow, WorkflowResult, WorkflowSchema
 from openff.evaluator.workflow.schemas import ProtocolReplicator
@@ -30,9 +30,9 @@ def test_simple_workflow_graph(calculation_backend, compute_resources, exception
 
     expected_value = (1 * unit.kelvin).plus_minus(0.1 * unit.kelvin)
 
-    protocol_a = DummyInputOutputProtocol("protocol_a")
+    protocol_a = DummyProtocol("protocol_a")
     protocol_a.input_value = expected_value
-    protocol_b = DummyInputOutputProtocol("protocol_b")
+    protocol_b = DummyProtocol("protocol_b")
     protocol_b.input_value = ProtocolPath("output_value", protocol_a.id)
 
     schema = WorkflowSchema()
@@ -94,9 +94,9 @@ def test_workflow_with_groups():
 
     expected_value = (1 * unit.kelvin).plus_minus(0.1 * unit.kelvin)
 
-    protocol_a = DummyInputOutputProtocol("protocol_a")
+    protocol_a = DummyProtocol("protocol_a")
     protocol_a.input_value = expected_value
-    protocol_b = DummyInputOutputProtocol("protocol_b")
+    protocol_b = DummyProtocol("protocol_b")
     protocol_b.input_value = ProtocolPath("output_value", protocol_a.id)
 
     conditional_group = ConditionalGroup("conditional_group")
@@ -137,10 +137,10 @@ def test_workflow_with_groups():
 
 def test_nested_input():
 
-    dict_protocol = DummyInputOutputProtocol("dict_protocol")
+    dict_protocol = DummyProtocol("dict_protocol")
     dict_protocol.input_value = {"a": ThermodynamicState(1.0 * unit.kelvin)}
 
-    quantity_protocol = DummyInputOutputProtocol("quantity_protocol")
+    quantity_protocol = DummyProtocol("quantity_protocol")
     quantity_protocol.input_value = ProtocolPath(
         "output_value[a].temperature", dict_protocol.id
     )
@@ -173,9 +173,7 @@ def test_index_replicated_protocol():
     replicator = ProtocolReplicator("replicator")
     replicator.template_values = ["a", "b", "c", "d"]
 
-    replicated_protocol = DummyInputOutputProtocol(
-        f"protocol_{replicator.placeholder_id}"
-    )
+    replicated_protocol = DummyProtocol(f"protocol_{replicator.placeholder_id}")
     replicated_protocol.input_value = ReplicatorValue(replicator.id)
 
     schema = WorkflowSchema()
@@ -184,7 +182,7 @@ def test_index_replicated_protocol():
 
     for index in range(len(replicator.template_values)):
 
-        indexing_protocol = DummyInputOutputProtocol(f"indexing_protocol_{index}")
+        indexing_protocol = DummyProtocol(f"indexing_protocol_{index}")
         indexing_protocol.input_value = ProtocolPath(
             "output_value", f"protocol_{index}"
         )
@@ -198,7 +196,7 @@ def test_index_replicated_protocol():
 
 def test_from_schema():
 
-    protocol_a = DummyInputOutputProtocol("protocol_a")
+    protocol_a = DummyProtocol("protocol_a")
     protocol_a.input_value = 1 * unit.kelvin
 
     schema = WorkflowSchema()

--- a/openff/evaluator/tests/test_workflow/utils.py
+++ b/openff/evaluator/tests/test_workflow/utils.py
@@ -4,7 +4,6 @@ import pint
 
 from openff.evaluator.attributes import UNDEFINED
 from openff.evaluator.layers import registered_calculation_schemas
-from openff.evaluator.utils.observables import Observable, ObservableArray
 from openff.evaluator.workflow import Protocol, Workflow, workflow_protocol
 from openff.evaluator.workflow.attributes import InputAttribute, OutputAttribute
 
@@ -67,46 +66,3 @@ class DummyReplicableProtocol(Protocol):
 
     def _execute(self, directory, available_resources):
         pass
-
-
-@workflow_protocol()
-class DummyInputOutputProtocol(Protocol):
-
-    input_value = InputAttribute(
-        docstring="A dummy input.",
-        type_hint=Union[
-            str,
-            int,
-            float,
-            pint.Quantity,
-            pint.Measurement,
-            Observable,
-            ObservableArray,
-            list,
-            tuple,
-            dict,
-            set,
-            frozenset,
-        ],
-        default_value=UNDEFINED,
-    )
-    output_value = OutputAttribute(
-        docstring="A dummy output.",
-        type_hint=Union[
-            str,
-            int,
-            float,
-            pint.Quantity,
-            pint.Measurement,
-            Observable,
-            ObservableArray,
-            list,
-            tuple,
-            dict,
-            set,
-            frozenset,
-        ],
-    )
-
-    def _execute(self, directory, available_resources):
-        self.output_value = self.input_value


### PR DESCRIPTION
## Description
This PR adds a new miscellaneous `DummyProtocol` protocol which will return its input as an input. While this is mainly useful for testing, it should also be useful in working around limitations with the workflow replication system.

## Status
- [X] Ready to go