### PR TITLE
Store Workflow Provenance as Serialized String

### DIFF
--- a/openff/evaluator/layers/workflow.py
+++ b/openff/evaluator/layers/workflow.py
@@ -156,7 +156,7 @@ class WorkflowCalculationLayer(CalculationLayer, abc.ABC):
         for workflow in workflows:
 
             provenance[workflow.uuid] = CalculationSource(
-                fidelity=cls.__name__, provenance=workflow.schema
+                fidelity=cls.__name__, provenance=workflow.schema.json()
             )
 
         return workflow_graph, provenance


### PR DESCRIPTION
## Description
This PR reverts #195 which stored the full workflow schema as an object to be de-serialized. There are two main issues with this:

- this adds a somewhat considerable performance overhead in the case of many estimated properties with complex workflows. Each workflow must be de-serialized into a full schema object which is currently not performant.

- this makes results less likely to be forwards compatible with new versions of the framework. Any breaking changes of the workflow schemas or any protocols API will result in previous results to be un-serializable.

Storing the provenance as a JSON string is thus safer as it can be parsed only when needed, and migrations applied in place if really needed.

## Status
- [x] Ready to go