### PR TITLE
Fixes Merging Excess Properties

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -12,11 +12,11 @@ Releases follow the ``major.minor.micro`` scheme recommended by
 0.3.1
 -----
 
-This release is a hot-patch to fix a bug introduced in version 0.3.0 of this framework, whereby the workflows for
-computing excess properties could in rare cases be incorrectly merged leading to downstream protocols taking their
-inputs from the wrong upstream protocol outputs.
+This release fixes a bug introduced in version 0.3.0 of this framework, whereby the default workflows for computing
+excess properties could in rare cases be incorrectly merged leading to downstream protocols taking their inputs from
+the wrong upstream protocol outputs.
 
-While this bug should not affect most calculations, it is recomended that any production calculations performed
+While this bug should not affect most calculations, it is recommended that any production calculations performed
 using version 0.3.0 of this framework be repeated using version 0.3.1.
 
 Bugfixes

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -12,10 +12,17 @@ Releases follow the ``major.minor.micro`` scheme recommended by
 0.3.1
 -----
 
-This release ...
+This release is a hot-patch to fix a bug introduced in version 0.3.0 of this framework, whereby the workflows for
+computing excess properties could in rare cases be incorrectly merged leading to downstream protocols taking their
+inputs from the wrong upstream protocol outputs.
+
+While this bug should not affect most calculations, it is recomended that any production calculations performed
+using version 0.3.0 of this framework be repeated using version 0.3.1.
 
 Bugfixes
 """"""""
+
+* PR `#331 <https://github.com/openforcefield/openff-evaluator/pull/331>`_: Fixes merging excess properties.
 
 0.3.0
 -----

--- a/openff/evaluator/properties/properties.py
+++ b/openff/evaluator/properties/properties.py
@@ -139,7 +139,9 @@ class EstimableExcessProperty(PhysicalProperty, abc.ABC):
         component_substance = ReplicatorValue(component_replicator.id)
 
         component_protocols, _, component_stored_data = generate_simulation_protocols(
-            analysis.AverageObservable("extract_observable_component"),
+            analysis.AverageObservable(
+                f"extract_observable_component_{component_replicator.placeholder_id}"
+            ),
             use_target_uncertainty,
             id_suffix=f"_component_{component_replicator.placeholder_id}",
             n_molecules=n_molecules,


### PR DESCRIPTION
## Description

This PR fixes a bug introduced in #298 whereby the default workflows for computing excess properties could in rare cases be incorrectly merged leading to downstream protocols taking their inputs from the wrong upstream protocol outputs.

This was caused by the workflow code being unable to properly merge workflows which have identical protocol ids, which #298 introduced for excess properties (`extract_observable_component`).

This PR adds extra validation steps to ensure this does not occur in future.

## Status
- [X] Ready to go