### PR TITLE
Fix Compatibility with Bibtex 2.0.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,6 +85,13 @@ suppress_warnings = [
 # nbsphinx settings
 nbsphinx_execute = 'never'
 
+# sphinx bibtext settings
+bibtex_bibfiles = [
+    os.path.join('properties', 'commonworkflows.bib'),
+    os.path.join('properties', 'gradients.bib'),
+    os.path.join('properties', 'properties.bib'),
+]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
## Description
This PR updates the documentation to be compatible with v2.0.0 of the `sphinxcontrib-bibtex` package.

## Status
- [X] Ready to go