### PR TITLE
Drop Dynamic Pint Classes

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -19,7 +19,7 @@ dependencies:
   - pandas
   - openmm
   - networkx
-  - pint >=0.10.1,<0.15
+  - pint >=0.16.1
   - packmol
   - pymbar >=3.0.5
   - mdtraj >=1.9.3

--- a/docs/layers/workflowlayer.rst
+++ b/docs/layers/workflowlayer.rst
@@ -26,7 +26,7 @@
 
 .. |parameter_gradient_key|       replace:: :py:class:`~openff.evaluator.forcefield.ParameterGradientKey`
 
-.. |quantity|                     replace:: :py:class:`~pint.Quantity`
+.. |quantity|                     replace:: :py:class:`~openff.evaluator.utils.units.Quantity`
 
 Workflow Layers
 ===============

--- a/docs/observables/observables.rst
+++ b/docs/observables/observables.rst
@@ -11,8 +11,8 @@
 .. |parameter_gradient|      replace:: :py:class:`~openff.evaluator.forcefield.ParameterGradient`
 .. |parameter_gradient_key|  replace:: :py:class:`~openff.evaluator.forcefield.ParameterGradientKey`
 
-.. |quantity|                replace:: :py:class:`~pint.Quantity`
-.. |measurement|             replace:: :py:class:`~pint.Measurement`
+.. |quantity|                replace:: :py:class:`~openff.evaluator.utils.units.Quantity`
+.. |measurement|             replace:: :py:class:`~openff.evaluator.utils.units.Measurement`
 
 .. |float|                   replace:: :py:class:`~float`
 .. |int|                     replace:: :py:class:`~int`
@@ -57,17 +57,17 @@ Supported Operations
 
 .. rst-class:: spaced-list
 
-    - **+ and -**: |observable| objects can be summed with and subtracted from other |observable| objects, pint
+    - **+ and -**: |observable| objects can be summed with and subtracted from other |observable| objects,
       |quantity| objects, floats or integers. When two |observable| objects are summed / subtracted, their gradients are
       combined by summing / subtracting also. When an |observable| is summed / subtracted with a |quantity|,
       |float| or |int| object it is assumed that these objects do not depend on any force field parameters.
 
-    - **\***: |observable| objects may be multiplied by other |observable| objects, pint |quantity| objects, and |float|
+    - **\***: |observable| objects may be multiplied by other |observable| objects, |quantity| objects, and |float|
       or |int| objects. When two |observable| objects are multiplied their gradients are propagated using the product
       rule. When an |observable| is multiplied by a |quantity|, |float| or |int| object it is assumed that these
       objects do not depend on any force field parameters.
 
-    - **/**: |observable| objects may be divided by other |observable| objects, pint |quantity| objects, and |float| or
+    - **/**: |observable| objects may be divided by other |observable| objects, |quantity| objects, and |float| or
       |int| objects. Gradients are propagated through the division using the quotient rule. When an |observable| is
       divided by a |quantity|, |float| or |int| object (or when these objects are divided by an |observable| object)
       it is assumed that these objects do not depend on any force field parameters.

--- a/docs/workflows/protocols.rst
+++ b/docs/workflows/protocols.rst
@@ -69,7 +69,7 @@ The inputs and outputs of a protocol are defined using the custom |input_attribu
         # once it is executed.
         result = OutputAttribute(
             docstring="The sum of the values.",
-            type_hint=typing.Union[int, float, pint.Measurement, pint.Quantity],
+            type_hint=typing.Union[int, float, unit.Measurement, unit.Quantity],
         )
 
         def _execute(self, directory, available_resources):
@@ -193,7 +193,7 @@ just wish to take the larger / smaller of the two inputs::
 
     timestep = InputAttribute(
         docstring="The timestep to evolve the system by at each step.",
-        type_hint=pint.Quantity,
+        type_hint=unit.Quantity,
         merge_behavior=InequalityMergeBehaviour.SmallestValue,
         default_value=2.0 * unit.femtosecond,
     )

--- a/docs/workflows/replicators.rst
+++ b/docs/workflows/replicators.rst
@@ -33,7 +33,7 @@
 .. |replicator_value|             replace:: :py:class:`~openff.evaluator.workflow.utils.ReplicatorValue`
 .. |placeholder_id|               replace:: :py:attr:`~openff.evaluator.workflow.schemas.ProtocolReplicator.placeholder_id`
 
-.. |quantity|                     replace:: :py:class:`~pint.Quantity`
+.. |quantity|                     replace:: :py:class:`~openff.evaluator.utils.units.Quantity`
 
 Replicators
 ===========

--- a/openff/evaluator/__init__.py
+++ b/openff/evaluator/__init__.py
@@ -3,20 +3,11 @@ openff-evaluator
 A physical property evaluation toolkit from the Open Forcefield Consortium.
 """
 
-import warnings
-
-import pint
-
 from ._version import get_versions
 from .plugins import register_default_plugins, register_external_plugins
+from .utils.units import DEFAULT_UNIT_REGISTRY
 
-unit = pint.UnitRegistry()
-unit.default_format = "~"
-pint.set_application_registry(unit)
-
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    pint.Quantity([])
+unit = DEFAULT_UNIT_REGISTRY
 
 # Load the default plugins
 register_default_plugins()

--- a/openff/evaluator/backends/backends.py
+++ b/openff/evaluator/backends/backends.py
@@ -5,8 +5,6 @@ import abc
 import re
 from enum import Enum
 
-import pint
-
 from openff.evaluator import unit
 
 
@@ -157,7 +155,7 @@ class QueueWorkerResources(ComputeResources):
         assert self._per_thread_memory_limit is not None
 
         assert (
-            isinstance(self._per_thread_memory_limit, pint.Quantity)
+            isinstance(self._per_thread_memory_limit, unit.Quantity)
             and unit.get_base_units(unit.byte)[-1]
             == unit.get_base_units(self._per_thread_memory_limit.units)[-1]
         )

--- a/openff/evaluator/data/units/constants.txt
+++ b/openff/evaluator/data/units/constants.txt
@@ -1,0 +1,44 @@
+# Based on the default Pint constants definition file (0.16.1)
+#   https://github.com/hgrecco/pint/tree/master/pint
+#
+# Based on the International System of Units
+# Language: english
+# Source: https://physics.nist.gov/cuu/Constants/
+#         https://physics.nist.gov/PhysRefData/XrayTrans/Html/search.html
+# :copyright: 2013,2019 by Pint Authors, see https://github.com/hgrecco/pint/blob/0.16.1/AUTHORS for more details.
+
+#### MATHEMATICAL CONSTANTS ####
+# As computed by Maxima with fpprec:50
+
+pi     = 3.1415926535897932384626433832795028841971693993751 = π  # pi
+
+#### DEFINED EXACT CONSTANTS ####
+# Recommended CODATA-2018 values
+
+speed_of_light = 299792458 m/s = c = c_0                      # since 1983
+planck_constant = 6.62607015e-34 J s = h                      # since May 2019
+elementary_charge = 1.602176634e-19 C = e                     # since May 2019
+avogadro_number = 6.02214076e23                               # since May 2019
+boltzmann_constant = 1.380649e-23 J K^-1 = k = k_B            # since May 2019
+standard_atmosphere = 1.01325e5 Pa = atm = atmosphere         # since 1954
+
+#### DERIVED EXACT CONSTANTS ####
+# Floating-point conversion may introduce inaccuracies
+
+zeta = c / (cm/s) = ζ
+dirac_constant = h / (2 * π) = ħ = hbar = atomic_unit_of_action = a_u_action
+avogadro_constant = avogadro_number * mol^-1 = N_A
+molar_gas_constant = k * N_A = R
+
+#### MEASURED CONSTANTS ####
+# Recommended CODATA-2018 values
+
+rydberg_constant = 1.0973731568160e7 * m^-1 = R_∞ = R_inf                                  # (21)
+atomic_mass_constant = 1.66053906660e-27 kg = m_u                                          # (50)
+electron_mass = 9.1093837015e-31 kg = m_e = atomic_unit_of_mass = a_u_mass                 # (28)
+
+#### DERIVED CONSTANTS ####
+
+fine_structure_constant = (2 * h * R_inf / (m_e * c)) ** 0.5 = α = alpha
+vacuum_permeability = 2 * α * h / (e ** 2 * c) = µ_0 = mu_0 = mu0 = magnetic_constant
+vacuum_permittivity = e ** 2 / (2 * α * h * c) = ε_0 = epsilon_0 = eps_0 = eps0 = electric_constant

--- a/openff/evaluator/data/units/defaults.txt
+++ b/openff/evaluator/data/units/defaults.txt
@@ -1,0 +1,164 @@
+# Based on the default Pint defaults definition file (0.16.1)
+#   https://github.com/hgrecco/pint/tree/master/pint
+#
+# Based on the International System of Units
+# Language: english
+# :copyright: 2013,2019 by Pint Authors, see https://github.com/hgrecco/pint/blob/0.16.1/AUTHORS for more details.
+
+@defaults
+    group = international
+    system = mks
+@end
+
+
+#### PREFIXES ####
+
+# decimal prefixes
+yocto- = 1e-24 = y-
+zepto- = 1e-21 = z-
+atto- =  1e-18 = a-
+femto- = 1e-15 = f-
+pico- =  1e-12 = p-
+nano- =  1e-9  = n-
+micro- = 1e-6  = µ- = u-
+milli- = 1e-3  = m-
+centi- = 1e-2  = c-
+deci- =  1e-1  = d-
+deca- =  1e+1  = da- = deka-
+hecto- = 1e2   = h-
+kilo- =  1e3   = k-
+mega- =  1e6   = M-
+giga- =  1e9   = G-
+tera- =  1e12  = T-
+peta- =  1e15  = P-
+exa- =   1e18  = E-
+zetta- = 1e21  = Z-
+yotta- = 1e24  = Y-
+
+# binary_prefixes
+kibi- = 2**10 = Ki-
+mebi- = 2**20 = Mi-
+gibi- = 2**30 = Gi-
+tebi- = 2**40 = Ti-
+pebi- = 2**50 = Pi-
+exbi- = 2**60 = Ei-
+zebi- = 2**70 = Zi-
+yobi- = 2**80 = Yi-
+
+
+#### BASE UNITS ####
+
+meter = [length] = m = metre
+second = [time] = s = sec
+ampere = [current] = A = amp
+gram = [mass] = g
+mole = [substance] = mol
+kelvin = [temperature]; offset: 0 = K = degK = °K = degree_Kelvin = degreeK  # older names supported for compatibility
+radian = [] = rad
+bit = []
+count = []
+
+
+#### CONSTANTS ####
+
+@import constants.txt
+
+
+#### UNITS ####
+
+# Angle
+degree = π / 180 * radian = deg = arcdeg = arcdegree = angular_degree
+
+# Information
+byte = 8 * bit = B = octet
+
+# Length
+angstrom = 1e-10 * meter = Å = ångström = Å
+micron = micrometer = µ
+fermi = femtometer = fm
+bohr = hbar / (alpha * m_e * c) = a_0 = a0 = bohr_radius = atomic_unit_of_length = a_u_length
+
+# Mass
+unified_atomic_mass_unit = atomic_mass_constant = u = amu
+dalton = atomic_mass_constant = Da
+
+# Time
+minute = 60 * second = min
+hour = 60 * minute = hr
+day = 24 * hour = d
+week = 7 * day
+year = 365.25 * day = a = yr = julian_year
+month = year / 12
+
+# Temperature
+degree_Celsius = kelvin; offset: 273.15 = °C = celsius = degC = degreeC
+
+# Volume
+[volume] = [length] ** 3
+liter = decimeter ** 3 = l = L = litre
+
+# Frequency
+[frequency] = 1 / [time]
+hertz = 1 / second = Hz
+
+# Wavenumber
+[wavenumber] = 1 / [length]
+reciprocal_centimeter = 1 / cm = cm_1 = kayser
+
+# Velocity
+[velocity] = [length] / [time] = [speed]
+
+# Acceleration
+[acceleration] = [velocity] / [time]
+
+# Force
+[force] = [mass] * [acceleration]
+newton = kilogram * meter / second ** 2 = N
+
+# Energy
+[energy] = [force] * [length]
+joule = newton * meter = J
+erg = dyne * centimeter
+rydberg = h * c * R_inf = Ry
+hartree = 2 * rydberg = E_h = Eh = hartree_energy = atomic_unit_of_energy = a_u_energy
+calorie = 4.184 * joule = cal = thermochemical_calorie = cal_th
+
+# Momentum
+[momentum] = [length] * [mass] / [time]
+
+# Density (as auxiliary for pressure)
+[density] = [mass] / [volume]
+
+# Pressure
+[pressure] = [force] / [area]
+pascal = newton / meter ** 2 = Pa
+bar = 1e5 * pascal
+
+# Concentration
+[concentration] = [substance] / [volume]
+molar = mole / liter = M
+
+# Charge
+[charge] = [current] * [time]
+coulomb = ampere * second = C
+faraday = e * N_A * mole
+
+# Electric potential
+[electric_potential] = [energy] / [charge]
+volt = joule / coulomb = V
+
+# Capacitance
+[capacitance] = [charge] / [electric_potential]
+farad = coulomb / volt = F
+
+# Electric dipole moment
+[electric_dipole] = [charge] * [length]
+debye = 1e-9 / ζ * coulomb * angstrom = D  # formally 1 D = 1e-10 Fr*Å, but we generally want to use it outside the Gaussian context
+
+#### SYSTEMS OF UNITS ####
+
+@system mks using international
+    meter
+    kilogram
+    second
+@end

--- a/openff/evaluator/datasets/datasets.py
+++ b/openff/evaluator/datasets/datasets.py
@@ -9,7 +9,6 @@ from enum import IntFlag, unique
 
 import numpy
 import pandas
-import pint
 
 from openff.evaluator import unit
 from openff.evaluator.attributes import UNDEFINED, Attribute, AttributeClass
@@ -95,7 +94,7 @@ class PhysicalProperty(AttributeClass, abc.ABC):
     @classmethod
     @abc.abstractmethod
     def default_unit(cls):
-        """pint.Unit: The default unit (e.g. g / mol) associated with this
+        """openff.evaluator.unit.Unit: The default unit (e.g. g / mol) associated with this
         class of property."""
         raise NotImplementedError()
 
@@ -121,11 +120,11 @@ class PhysicalProperty(AttributeClass, abc.ABC):
 
     value = Attribute(
         docstring="The measured / estimated value of this property.",
-        type_hint=pint.Quantity,
+        type_hint=unit.Quantity,
     )
     uncertainty = Attribute(
         docstring="The uncertainty in measured / estimated value of this property.",
-        type_hint=pint.Quantity,
+        type_hint=unit.Quantity,
         optional=True,
     )
 
@@ -167,9 +166,9 @@ class PhysicalProperty(AttributeClass, abc.ABC):
             The phase that the property was measured in.
         substance : Substance
             The composition of the substance that was measured.
-        value: pint.Quantity
+        value: openff.evaluator.unit.Quantity
             The value of the measured physical property.
-        uncertainty: pint.Quantity
+        uncertainty: openff.evaluator.unit.Quantity
             The uncertainty in the measured value.
         source: Source
             The source of this property.

--- a/openff/evaluator/datasets/thermoml/thermoml.py
+++ b/openff/evaluator/datasets/thermoml/thermoml.py
@@ -10,7 +10,6 @@ from urllib.error import HTTPError
 from xml.etree import ElementTree
 
 import numpy as np
-import pint
 import requests
 
 from openff.evaluator import unit
@@ -36,7 +35,7 @@ def _unit_from_thermoml_string(full_string):
 
     Returns
     ----------
-    pint.Unit
+    openff.evaluator.unit.Unit
         The parsed unit.
     """
 
@@ -47,7 +46,7 @@ def _unit_from_thermoml_string(full_string):
     # Convert symbols like dm3 to dm**3
     unit_string = re.sub(r"([a-z])([0-9]+)", r"\1**\2", unit_string.strip())
 
-    return pint.Unit(unit_string)
+    return unit.Unit(unit_string)
 
 
 def _phase_from_thermoml_string(string):
@@ -214,7 +213,7 @@ class _Constraint:
         ----------
         variable: _VariableDefinition
             The variable to convert.
-        value: pint.Quantity
+        value: openff.evaluator.unit.Quantity
             The value of the constant.
 
         Returns
@@ -842,7 +841,7 @@ class _PureOrMixtureData:
 
         Returns
         -------
-        pint.Quantity
+        openff.evaluator.unit.Quantity
             The molecular weight.
         """
 
@@ -878,7 +877,7 @@ class _PureOrMixtureData:
 
         Parameters
         ----------
-        solvent_mass: pint.Quantity
+        solvent_mass: openff.evaluator.unit.Quantity
             The total mass of the solvent in units compatible with kg.
         solvent_mole_fractions: dict of int and float
             The mole fractions of any solvent compounds in the system.
@@ -887,7 +886,7 @@ class _PureOrMixtureData:
 
         Returns
         -------
-        dict of int and pint.Quantity
+        dict of int and openff.evaluator.unit.Quantity
             A dictionary of the moles of each solvent compound.
         """
         weighted_molecular_weights = 0.0 * unit.gram / unit.mole
@@ -944,7 +943,7 @@ class _PureOrMixtureData:
 
             mole_fraction = constraint.value
 
-            if isinstance(mole_fraction, pint.Quantity):
+            if isinstance(mole_fraction, unit.Quantity):
                 mole_fraction = mole_fraction.to(unit.dimensionless).magnitude
 
             mole_fractions[constraint.compound_index] = mole_fraction
@@ -1030,7 +1029,7 @@ class _PureOrMixtureData:
 
             mass_fraction = constraint.value
 
-            if isinstance(mass_fraction, pint.Quantity):
+            if isinstance(mass_fraction, unit.Quantity):
                 mass_fraction = mass_fraction.to(unit.dimensionless).magnitude
 
             mass_fractions[constraint.compound_index] = mass_fraction
@@ -1060,7 +1059,7 @@ class _PureOrMixtureData:
                     continue
 
                 mass_fractions[compound_index] = 1.0 - total_mass_fraction
-                if isinstance(mass_fractions[compound_index], pint.Quantity):
+                if isinstance(mass_fractions[compound_index], unit.Quantity):
                     mass_fractions[compound_index] = (
                         mass_fractions[compound_index].to(unit.dimensionless).magnitude
                     )
@@ -1436,7 +1435,7 @@ class _PureOrMixtureData:
         # Make sure we haven't picked up a dimensionless unit be accident.
         for compound_index in mole_fractions:
 
-            if isinstance(mole_fractions[compound_index], pint.Quantity):
+            if isinstance(mole_fractions[compound_index], unit.Quantity):
                 mole_fractions[compound_index] = (
                     mole_fractions[compound_index].to(unit.dimensionless).magnitude
                 )
@@ -2002,14 +2001,14 @@ class ThermoMLProperty:
 
         Parameters
         ----------
-        value: float or pint.Quantity
+        value: float or unit.Quantity
             The value of the property
-        uncertainty: float or pint.Quantity, optional
+        uncertainty: float or unit.Quantity, optional
             The uncertainty in the value.
         """
         value_quantity = value
 
-        if not isinstance(value_quantity, pint.Quantity):
+        if not isinstance(value_quantity, unit.Quantity):
             value_quantity = value * self.default_unit
 
         self.value = value_quantity
@@ -2018,7 +2017,7 @@ class ThermoMLProperty:
 
             uncertainty_quantity = uncertainty
 
-            if not isinstance(uncertainty_quantity, pint.Quantity):
+            if not isinstance(uncertainty_quantity, unit.Quantity):
                 uncertainty_quantity = uncertainty * self.default_unit
 
             self.uncertainty = uncertainty_quantity

--- a/openff/evaluator/forcefield/forcefield.py
+++ b/openff/evaluator/forcefield/forcefield.py
@@ -132,7 +132,7 @@ class TLeapForceFieldSource(ForceFieldSource):
 
     @property
     def cutoff(self):
-        """pint.Quantity: The non-bonded interaction cutoff."""
+        """openff.evaluator.unit.Quantity: The non-bonded interaction cutoff."""
         return self._cutoff
 
     def __init__(self, leap_source="leaprc.gaff2", cutoff=9.0 * unit.angstrom):
@@ -144,7 +144,7 @@ class TLeapForceFieldSource(ForceFieldSource):
             The parameter file which should be sourced by `leap`
             when applying the force field. Currently only
             `'leaprc.gaff'` and `'leaprc.gaff2'` are supported.
-        cutoff: pint.Quantity
+        cutoff: openff.evaluator.unit.Quantity
             The non-bonded interaction cutoff.
 
         Examples
@@ -205,7 +205,7 @@ class LigParGenForceFieldSource(ForceFieldSource):
 
     @property
     def cutoff(self):
-        """pint.Quantity: The non-bonded interaction cutoff."""
+        """openff.evaluator.unit.Quantity: The non-bonded interaction cutoff."""
         return self._cutoff
 
     @property
@@ -235,7 +235,7 @@ class LigParGenForceFieldSource(ForceFieldSource):
             (e.g. 1.14*CM1A-LBCC may only be applied to neutral
             molecules) and so another model may be applied in its
             place.
-        cutoff: pint.Quantity
+        cutoff: openff.evaluator.unit.Quantity
             The non-bonded interaction cutoff.
         request_url: str
             The URL of the LIGPARGEN server file to send the parametrization to request to.

--- a/openff/evaluator/forcefield/gradients.py
+++ b/openff/evaluator/forcefield/gradients.py
@@ -1,6 +1,7 @@
 import numpy
-import pint
 import pint.compat
+
+from openff.evaluator import unit
 
 
 class ParameterGradientKey:
@@ -122,13 +123,13 @@ class ParameterGradient:
         """
         Parameters
         ----------
-        other: float, int, pint.Quantity
+        other: float, int, openff.evaluator.unit.Quantity
         """
 
         if (
             not isinstance(other, float)
             and not isinstance(other, int)
-            and not isinstance(other, pint.Quantity)
+            and not isinstance(other, unit.Quantity)
         ):
 
             raise ValueError(
@@ -145,13 +146,13 @@ class ParameterGradient:
         """
         Parameters
         ----------
-        other: float, int, pint.Quantity
+        other: float, int, openff.evaluator.unit.Quantity
         """
 
         if (
             not isinstance(other, float)
             and not isinstance(other, int)
-            and not isinstance(other, pint.Quantity)
+            and not isinstance(other, unit.Quantity)
         ):
 
             raise ValueError(

--- a/openff/evaluator/layers/layers.py
+++ b/openff/evaluator/layers/layers.py
@@ -6,8 +6,7 @@ import collections
 import logging
 from os import path
 
-import pint
-
+from openff.evaluator import unit
 from openff.evaluator.attributes import (
     UNDEFINED,
     Attribute,
@@ -67,7 +66,7 @@ class CalculationLayerSchema(AttributeClass):
         docstring="The absolute uncertainty that the property should "
         "be estimated to within. This attribute is mutually exclusive "
         "with the `relative_tolerance` attribute.",
-        type_hint=pint.Quantity,
+        type_hint=unit.Quantity,
         default_value=UNDEFINED,
         optional=True,
     )

--- a/openff/evaluator/layers/reweighting.py
+++ b/openff/evaluator/layers/reweighting.py
@@ -9,7 +9,6 @@ import time
 
 import dateutil.parser
 import numpy
-import pint
 
 from openff.evaluator import unit
 from openff.evaluator.attributes import Attribute, PlaceholderValue
@@ -68,7 +67,7 @@ class ReweightingSchema(WorkflowCalculationSchema):
         docstring="The maximum difference between the target temperature "
         "and the temperature at which cached data was collected to. Data "
         "collected for temperatures outside of this cutoff will be ignored.",
-        type_hint=pint.Quantity,
+        type_hint=unit.Quantity,
         default_value=5.0 * unit.kelvin,
     )
 
@@ -108,9 +107,9 @@ class ReweightingLayer(WorkflowCalculationLayer):
         data_list: list of tuple of str, StoredSimulationData and str
             A list of query results which take the form
             (storage_key, data_object, data_directory_path).
-        target_temperature: pint.Quantity
+        target_temperature: openff.evaluator.unit.Quantity
             The temperature that the data will be reweighted to.
-        temperature_cutoff: pint.Quantity
+        temperature_cutoff: openff.evaluator.unit.Quantity
             The maximum difference in the target and data temperatures.
 
         Returns

--- a/openff/evaluator/properties/density.py
+++ b/openff/evaluator/properties/density.py
@@ -37,7 +37,7 @@ class Density(PhysicalProperty):
 
         Parameters
         ----------
-        absolute_tolerance: pint.Quantity, optional
+        absolute_tolerance: openff.evaluator.unit.Quantity, optional
             The absolute tolerance to estimate the property to within.
         relative_tolerance: float
             The tolerance (as a fraction of the properties reported
@@ -102,7 +102,7 @@ class Density(PhysicalProperty):
 
         Parameters
         ----------
-        absolute_tolerance: pint.Quantity, optional
+        absolute_tolerance: openff.evaluator.unit.Quantity, optional
             The absolute tolerance to estimate the property to within.
         relative_tolerance: float
             The tolerance (as a fraction of the properties reported

--- a/openff/evaluator/properties/dielectric.py
+++ b/openff/evaluator/properties/dielectric.py
@@ -46,7 +46,7 @@ class DielectricConstant(PhysicalProperty):
 
         Parameters
         ----------
-        absolute_tolerance: pint.Quantity, optional
+        absolute_tolerance: openff.evaluator.unit.Quantity, optional
             The absolute tolerance to estimate the property to within.
         relative_tolerance: float
             The tolerance (as a fraction of the properties reported
@@ -129,7 +129,7 @@ class DielectricConstant(PhysicalProperty):
 
         Parameters
         ----------
-        absolute_tolerance: pint.Quantity, optional
+        absolute_tolerance: openff.evaluator.unit.Quantity, optional
             The absolute tolerance to estimate the property to within.
         relative_tolerance: float
             The tolerance (as a fraction of the properties reported

--- a/openff/evaluator/properties/enthalpy.py
+++ b/openff/evaluator/properties/enthalpy.py
@@ -123,7 +123,7 @@ class EnthalpyOfVaporization(PhysicalProperty):
 
         Parameters
         ----------
-        absolute_tolerance: pint.Quantity, optional
+        absolute_tolerance: openff.evaluator.unit.Quantity, optional
             The absolute tolerance to estimate the property to within.
         relative_tolerance: float
             The tolerance (as a fraction of the properties reported
@@ -304,7 +304,7 @@ class EnthalpyOfVaporization(PhysicalProperty):
 
         Parameters
         ----------
-        absolute_tolerance: pint.Quantity, optional
+        absolute_tolerance: openff.evaluator.unit.Quantity, optional
             The absolute tolerance to estimate the property to within.
         relative_tolerance: float
             The tolerance (as a fraction of the properties reported

--- a/openff/evaluator/properties/properties.py
+++ b/openff/evaluator/properties/properties.py
@@ -83,7 +83,7 @@ class EstimableExcessProperty(PhysicalProperty, abc.ABC):
 
         Parameters
         ----------
-        absolute_tolerance: pint.Quantity, optional
+        absolute_tolerance: openff.evaluator.unit.Quantity, optional
             The absolute tolerance to estimate the property to within.
         relative_tolerance: float
             The tolerance (as a fraction of the properties reported

--- a/openff/evaluator/properties/solvation.py
+++ b/openff/evaluator/properties/solvation.py
@@ -37,7 +37,7 @@ class SolvationFreeEnergy(PhysicalProperty):
 
         Parameters
         ----------
-        absolute_tolerance: pint.Quantity, optional
+        absolute_tolerance: openff.evaluator.unit.Quantity, optional
             The absolute tolerance to estimate the property to within.
         relative_tolerance: float
             The tolerance (as a fraction of the properties reported

--- a/openff/evaluator/protocols/analysis.py
+++ b/openff/evaluator/protocols/analysis.py
@@ -7,7 +7,6 @@ import typing
 from os import path
 
 import numpy as np
-import pint
 
 from openff.evaluator import unit
 from openff.evaluator.attributes import UNDEFINED
@@ -44,7 +43,7 @@ E0 = 8.854187817e-12 * unit.farad / unit.meter  # Taken from QCElemental
 def compute_dielectric_constant(
     dipole_moments: ObservableArray,
     volumes: ObservableArray,
-    temperature: pint.Quantity,
+    temperature: unit.Quantity,
     average_function,
 ) -> Observable:
     """A function to compute the average dielectric constant from an array of
@@ -352,7 +351,7 @@ class AverageObservable(BaseAverageObservable):
     divisor = InputAttribute(
         docstring="A value to divide the statistic by. This is useful if a statistic "
         "(such as enthalpy) needs to be normalised by the number of molecules.",
-        type_hint=typing.Union[int, float, pint.Quantity],
+        type_hint=typing.Union[int, float, unit.Quantity],
         default_value=1.0,
     )
 
@@ -424,7 +423,7 @@ class AverageFreeEnergies(Protocol):
     result = OutputAttribute(docstring="The sum of the values.", type_hint=Observable)
     confidence_intervals = OutputAttribute(
         docstring="The 95% confidence intervals on the average free energy.",
-        type_hint=pint.Quantity,
+        type_hint=unit.Quantity,
     )
 
     def _execute(self, directory, available_resources):

--- a/openff/evaluator/protocols/coordinates.py
+++ b/openff/evaluator/protocols/coordinates.py
@@ -7,7 +7,6 @@ from enum import Enum
 from os import path
 
 import numpy as np
-import pint
 from simtk.openmm import app
 
 from openff.evaluator import unit
@@ -43,7 +42,7 @@ class BuildCoordinatesPackmol(Protocol):
     )
     mass_density = InputAttribute(
         docstring="The target density of the created system.",
-        type_hint=pint.Quantity,
+        type_hint=unit.Quantity,
         default_value=0.95 * unit.grams / unit.milliliters,
     )
 
@@ -61,7 +60,7 @@ class BuildCoordinatesPackmol(Protocol):
     tolerance = InputAttribute(
         docstring="The packmol distance tolerance in units compatible "
         "with angstroms.",
-        type_hint=pint.Quantity,
+        type_hint=unit.Quantity,
         default_value=2.0 * unit.angstrom,
     )
 

--- a/openff/evaluator/protocols/forcefield.py
+++ b/openff/evaluator/protocols/forcefield.py
@@ -282,9 +282,9 @@ class TemplateBuildSystem(BaseBuildSystem, abc.ABC):
 
         Parameters
         ----------
-        cutoff: simtk.pint.Quantity
+        cutoff: openff.evaluator.unit.Quantity
             The non-bonded cutoff.
-        cell_vectors: simtk.pint.Quantity
+        cell_vectors: openff.evaluator.unit.Quantity
             The full system's cell vectors.
 
         Returns

--- a/openff/evaluator/protocols/groups.py
+++ b/openff/evaluator/protocols/groups.py
@@ -13,8 +13,7 @@ import typing
 from enum import Enum, unique
 from os import path
 
-import pint
-
+from openff.evaluator import unit
 from openff.evaluator.attributes import UNDEFINED, Attribute, AttributeClass
 from openff.evaluator.workflow import ProtocolGroup, workflow_protocol
 from openff.evaluator.workflow.attributes import (
@@ -49,11 +48,11 @@ class ConditionalGroup(ProtocolGroup):
 
         left_hand_value = Attribute(
             docstring="The left-hand value to compare.",
-            type_hint=typing.Union[int, float, pint.Quantity],
+            type_hint=typing.Union[int, float, unit.Quantity],
         )
         right_hand_value = Attribute(
             docstring="The right-hand value to compare.",
-            type_hint=typing.Union[int, float, pint.Quantity],
+            type_hint=typing.Union[int, float, unit.Quantity],
         )
 
         type = Attribute(
@@ -135,8 +134,8 @@ class ConditionalGroup(ProtocolGroup):
         if left_hand_value == UNDEFINED or right_hand_value == UNDEFINED:
             return False
 
-        if isinstance(right_hand_value, pint.Quantity) and isinstance(
-            left_hand_value, pint.Quantity
+        if isinstance(right_hand_value, unit.Quantity) and isinstance(
+            left_hand_value, unit.Quantity
         ):
             right_hand_value = right_hand_value.to(left_hand_value.units)
 

--- a/openff/evaluator/protocols/miscellaneous.py
+++ b/openff/evaluator/protocols/miscellaneous.py
@@ -5,8 +5,8 @@ math operations.
 import typing
 
 import numpy as np
-import pint
 
+from openff.evaluator import unit
 from openff.evaluator.attributes import UNDEFINED
 from openff.evaluator.forcefield import ParameterGradient, ParameterGradientKey
 from openff.evaluator.substances import Component, MoleFraction, Substance
@@ -21,8 +21,9 @@ class AddValues(Protocol):
 
     Notes
     -----
-    The `values` input must either be a list of pint.Quantity, a ProtocolPath to a list
-    of pint.Quantity, or a list of ProtocolPath which each point to a pint.Quantity.
+    The `values` input must either be a list of openff.evaluator.unit.Quantity, a
+    ProtocolPath to a list of openff.evaluator.unit.Quantity, or a list of ProtocolPath
+    which each point to a openff.evaluator.unit.Quantity.
     """
 
     values = InputAttribute(
@@ -34,8 +35,8 @@ class AddValues(Protocol):
         type_hint=typing.Union[
             int,
             float,
-            pint.Measurement,
-            pint.Quantity,
+            unit.Measurement,
+            unit.Quantity,
             ParameterGradient,
             Observable,
             ObservableArray,
@@ -65,8 +66,8 @@ class SubtractValues(Protocol):
         type_hint=typing.Union[
             int,
             float,
-            pint.Measurement,
-            pint.Quantity,
+            unit.Measurement,
+            unit.Quantity,
             ParameterGradient,
             Observable,
             ObservableArray,
@@ -78,8 +79,8 @@ class SubtractValues(Protocol):
         type_hint=typing.Union[
             int,
             float,
-            pint.Measurement,
-            pint.Quantity,
+            unit.Measurement,
+            unit.Quantity,
             ParameterGradient,
             Observable,
             ObservableArray,
@@ -92,8 +93,8 @@ class SubtractValues(Protocol):
         type_hint=typing.Union[
             int,
             float,
-            pint.Measurement,
-            pint.Quantity,
+            unit.Measurement,
+            unit.Quantity,
             ParameterGradient,
             Observable,
             ObservableArray,
@@ -113,8 +114,8 @@ class MultiplyValue(Protocol):
         type_hint=typing.Union[
             int,
             float,
-            pint.Measurement,
-            pint.Quantity,
+            unit.Measurement,
+            unit.Quantity,
             ParameterGradient,
             Observable,
             ObservableArray,
@@ -123,7 +124,7 @@ class MultiplyValue(Protocol):
     )
     multiplier = InputAttribute(
         docstring="The scalar to multiply by.",
-        type_hint=typing.Union[int, float, pint.Quantity],
+        type_hint=typing.Union[int, float, unit.Quantity],
         default_value=UNDEFINED,
     )
 
@@ -132,8 +133,8 @@ class MultiplyValue(Protocol):
         type_hint=typing.Union[
             int,
             float,
-            pint.Measurement,
-            pint.Quantity,
+            unit.Measurement,
+            unit.Quantity,
             ParameterGradient,
             Observable,
             ObservableArray,
@@ -153,8 +154,8 @@ class DivideValue(Protocol):
         type_hint=typing.Union[
             int,
             float,
-            pint.Measurement,
-            pint.Quantity,
+            unit.Measurement,
+            unit.Quantity,
             ParameterGradient,
             Observable,
             ObservableArray,
@@ -163,7 +164,7 @@ class DivideValue(Protocol):
     )
     divisor = InputAttribute(
         docstring="The scalar to divide by.",
-        type_hint=typing.Union[int, float, pint.Quantity],
+        type_hint=typing.Union[int, float, unit.Quantity],
         default_value=UNDEFINED,
     )
 
@@ -172,8 +173,8 @@ class DivideValue(Protocol):
         type_hint=typing.Union[
             int,
             float,
-            pint.Measurement,
-            pint.Quantity,
+            unit.Measurement,
+            unit.Quantity,
             ParameterGradient,
             Observable,
             ObservableArray,
@@ -195,8 +196,8 @@ class WeightByMoleFraction(Protocol):
         type_hint=typing.Union[
             int,
             float,
-            pint.Measurement,
-            pint.Quantity,
+            unit.Measurement,
+            unit.Quantity,
             ParameterGradient,
             Observable,
             ObservableArray,
@@ -222,8 +223,8 @@ class WeightByMoleFraction(Protocol):
         type_hint=typing.Union[
             int,
             float,
-            pint.Measurement,
-            pint.Quantity,
+            unit.Measurement,
+            unit.Quantity,
             ParameterGradient,
             Observable,
             ObservableArray,
@@ -240,7 +241,7 @@ class WeightByMoleFraction(Protocol):
 
         Returns
         -------
-        float, int, pint.Measurement, pint.Quantity, ParameterGradient
+        float, int, openff.evaluator.unit.Measurement, openff.evaluator.unit.Quantity, ParameterGradient
             The weighted value.
         """
         return self.value * mole_fraction
@@ -365,8 +366,8 @@ class DummyProtocol(Protocol):
             str,
             int,
             float,
-            pint.Quantity,
-            pint.Measurement,
+            unit.Quantity,
+            unit.Measurement,
             Observable,
             ObservableArray,
             ParameterGradient,
@@ -385,8 +386,8 @@ class DummyProtocol(Protocol):
             str,
             int,
             float,
-            pint.Quantity,
-            pint.Measurement,
+            unit.Quantity,
+            unit.Measurement,
             Observable,
             ObservableArray,
             ParameterGradient,

--- a/openff/evaluator/protocols/openmm.py
+++ b/openff/evaluator/protocols/openmm.py
@@ -548,9 +548,9 @@ class OpenMMSimulation(BaseSimulation):
 
         Parameters
         ----------
-        temperature: simtk.pint.Quantity
+        temperature: openff.evaluator.unit.Quantity
             The temperature to run the simulation at.
-        pressure: simtk.pint.Quantity
+        pressure: openff.evaluator.unit.Quantity
             The pressure to run the simulation at.
         available_resources: ComputeResources
             The resources available to run on.
@@ -879,9 +879,9 @@ class OpenMMSimulation(BaseSimulation):
 
         Parameters
         ----------
-        temperature: pint.Quantity
+        temperature: openff.evaluator.unit.Quantity
             The temperature that the simulation is being run at.
-        pressure: pint.Quantity
+        pressure: openff.evaluator.unit.Quantity
             The pressure that the simulation is being run at.
         """
         observables = ObservableFrame.from_openmm(self._local_statistics_path, pressure)

--- a/openff/evaluator/protocols/simulation.py
+++ b/openff/evaluator/protocols/simulation.py
@@ -5,8 +5,6 @@ as OpenMM or Gromacs.
 """
 import abc
 
-import pint
-
 from openff.evaluator import unit
 from openff.evaluator.attributes import UNDEFINED
 from openff.evaluator.forcefield.system import ParameterizedSystem
@@ -37,7 +35,7 @@ class BaseEnergyMinimisation(Protocol, abc.ABC):
 
     tolerance = InputAttribute(
         docstring="The energy tolerance to which the system should be minimized.",
-        type_hint=pint.Quantity,
+        type_hint=unit.Quantity,
         default_value=10 * unit.kilojoules / unit.mole,
     )
     max_iterations = InputAttribute(
@@ -103,7 +101,7 @@ class BaseSimulation(Protocol, abc.ABC):
 
     timestep = InputAttribute(
         docstring="The timestep to evolve the system by at each step.",
-        type_hint=pint.Quantity,
+        type_hint=unit.Quantity,
         merge_behavior=InequalityMergeBehaviour.SmallestValue,
         default_value=2.0 * unit.femtosecond,
     )
@@ -121,7 +119,7 @@ class BaseSimulation(Protocol, abc.ABC):
 
     thermostat_friction = InputAttribute(
         docstring="The thermostat friction coefficient.",
-        type_hint=pint.Quantity,
+        type_hint=unit.Quantity,
         merge_behavior=InequalityMergeBehaviour.SmallestValue,
         default_value=1.0 / unit.picoseconds,
     )

--- a/openff/evaluator/protocols/yank.py
+++ b/openff/evaluator/protocols/yank.py
@@ -11,7 +11,6 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import numpy as np
-import pint
 import yaml
 
 from openff.evaluator import unit
@@ -98,7 +97,7 @@ class BaseYankProtocol(Protocol, abc.ABC):
 
     timestep = InputAttribute(
         docstring="The length of the timestep to take.",
-        type_hint=pint.Quantity,
+        type_hint=unit.Quantity,
         merge_behavior=InequalityMergeBehaviour.SmallestValue,
         default_value=2 * unit.femtosecond,
     )

--- a/openff/evaluator/substances/substances.py
+++ b/openff/evaluator/substances/substances.py
@@ -359,7 +359,7 @@ class Substance(AttributeClass):
 
         Parameters
         ----------
-        ionic_strength: pint.Quantity
+        ionic_strength: openff.evaluator.unit.Quantity
             The ionic string in units of molar.
 
         Returns

--- a/openff/evaluator/tests/test_attributes/test_typing.py
+++ b/openff/evaluator/tests/test_attributes/test_typing.py
@@ -5,7 +5,6 @@ Units tests for openff.evaluator.attributes.typing
 import typing
 from random import random
 
-import pint
 import pytest
 
 from openff.evaluator import unit
@@ -21,12 +20,12 @@ from openff.evaluator.attributes.typing import (
         (int, int),
         (int, float),
         (float, float),
-        (int, typing.Union[int, float, pint.Quantity]),
-        (float, typing.Union[int, float, pint.Quantity]),
-        (pint.Quantity, typing.Union[int, float, pint.Quantity]),
-        (typing.Union[int, float, pint.Quantity], int),
-        (typing.Union[int, float, pint.Quantity], float),
-        (typing.Union[int, float, pint.Quantity], pint.Quantity),
+        (int, typing.Union[int, float, unit.Quantity]),
+        (float, typing.Union[int, float, unit.Quantity]),
+        (unit.Quantity, typing.Union[int, float, unit.Quantity]),
+        (typing.Union[int, float, unit.Quantity], int),
+        (typing.Union[int, float, unit.Quantity], float),
+        (typing.Union[int, float, unit.Quantity], unit.Quantity),
     ],
 )
 def test_positive_is_type_subclass_of_type(type_a, type_b):
@@ -38,12 +37,12 @@ def test_positive_is_type_subclass_of_type(type_a, type_b):
     "type_a, type_b",
     [
         (float, int),
-        (int, typing.Union[pint.Quantity]),
-        (float, typing.Union[int, pint.Quantity]),
-        (pint.Quantity, typing.Union[int, float]),
-        (typing.Union[float, pint.Quantity], int),
-        (typing.Union[pint.Quantity], float),
-        (typing.Union[int, float], pint.Quantity),
+        (int, typing.Union[unit.Quantity]),
+        (float, typing.Union[int, unit.Quantity]),
+        (unit.Quantity, typing.Union[int, float]),
+        (typing.Union[float, unit.Quantity], int),
+        (typing.Union[unit.Quantity], float),
+        (typing.Union[int, float], unit.Quantity),
     ],
 )
 def test_negative_is_type_subclass_of_type(type_a, type_b):
@@ -57,9 +56,9 @@ def test_negative_is_type_subclass_of_type(type_a, type_b):
         (int(random()), int),
         (int(random()), float),
         (random(), float),
-        (int(random()), typing.Union[int, float, pint.Quantity]),
-        (random(), typing.Union[int, float, pint.Quantity]),
-        (random() * unit.kelvin, typing.Union[int, float, pint.Quantity]),
+        (int(random()), typing.Union[int, float, unit.Quantity]),
+        (random(), typing.Union[int, float, unit.Quantity]),
+        (random() * unit.kelvin, typing.Union[int, float, unit.Quantity]),
     ],
 )
 def test_positive_is_instance_of_type(object_a, type_a):
@@ -71,8 +70,8 @@ def test_positive_is_instance_of_type(object_a, type_a):
     "object_a, type_a",
     [
         (random() + 0.0001, int),
-        (int(random()), typing.Union[pint.Quantity]),
-        (random(), typing.Union[int, pint.Quantity]),
+        (int(random()), typing.Union[unit.Quantity]),
+        (random(), typing.Union[int, unit.Quantity]),
         (random() * unit.kelvin, typing.Union[int, float]),
     ],
 )

--- a/openff/evaluator/tests/test_datasets/test_thermoml.py
+++ b/openff/evaluator/tests/test_datasets/test_thermoml.py
@@ -1,7 +1,6 @@
 """
 Units tests for openff.evaluator.datasets
 """
-import pint
 import pytest
 
 from openff.evaluator import unit
@@ -66,7 +65,7 @@ def test_thermoml_unit_from_string(unit_string):
     dummy_string = f"Property, {unit_string}"
 
     returned_unit = _unit_from_thermoml_string(dummy_string)
-    assert returned_unit is not None and isinstance(returned_unit, pint.Unit)
+    assert returned_unit is not None and isinstance(returned_unit, unit.Unit)
 
 
 def test_thermoml_from_url():

--- a/openff/evaluator/tests/test_utils/test_openmm.py
+++ b/openff/evaluator/tests/test_utils/test_openmm.py
@@ -1,4 +1,3 @@
-import inspect
 from random import randint, random
 
 import mdtraj
@@ -22,51 +21,9 @@ from openff.evaluator.utils import get_data_filename
 from openff.evaluator.utils.observables import ObservableArray, ObservableFrame
 from openff.evaluator.utils.openmm import (
     openmm_quantity_to_pint,
-    openmm_unit_to_pint,
     pint_quantity_to_openmm,
-    pint_unit_to_openmm,
     system_subset,
-    unsupported_openmm_units,
 )
-
-
-def _get_all_openmm_units():
-    """Returns a list of all of the defined OpenMM units.
-
-    Returns
-    -------
-    list of simtk.unit.Unit
-    """
-
-    all_openmm_units = set(
-        [
-            unit_type
-            for _, unit_type in inspect.getmembers(simtk_unit)
-            if isinstance(unit_type, simtk_unit.Unit)
-        ]
-    )
-
-    all_openmm_units = all_openmm_units.difference(unsupported_openmm_units)
-
-    return all_openmm_units
-
-
-def _get_all_pint_units():
-    """Returns a list of all of the pint units which
-    could be converted from all OpenMM units.
-
-    Returns
-    -------
-    list of pint.Unit
-    """
-
-    all_openmm_units = _get_all_openmm_units()
-
-    all_pint_units = [
-        openmm_unit_to_pint(openmm_unit) for openmm_unit in all_openmm_units
-    ]
-
-    return all_pint_units
 
 
 def test_daltons():
@@ -80,12 +37,24 @@ def test_daltons():
     assert np.allclose(openmm_raw_value, pint_raw_value)
 
 
-@pytest.mark.parametrize("openmm_unit", _get_all_openmm_units())
+@pytest.mark.parametrize(
+    "openmm_unit",
+    [
+        simtk_unit.dalton,
+        simtk_unit.kilojoules_per_mole,
+        simtk_unit.angstrom,
+        simtk_unit.kelvin,
+        simtk_unit.atmosphere,
+        simtk_unit.gram,
+        simtk_unit.liter,
+        simtk_unit.gram / simtk_unit.liter,
+    ],
+)
 @pytest.mark.parametrize(
     "value",
     [random(), randint(1, 10), [random(), random()], np.array([random(), random()])],
 )
-def test_openmm_unit_to_pint(openmm_unit, value):
+def test_openmm_to_pint(openmm_unit, value):
 
     openmm_quantity = value * openmm_unit
     openmm_raw_value = openmm_quantity.value_in_unit(openmm_unit)
@@ -96,7 +65,19 @@ def test_openmm_unit_to_pint(openmm_unit, value):
     assert np.allclose(openmm_raw_value, pint_raw_value)
 
 
-@pytest.mark.parametrize("pint_unit", _get_all_pint_units())
+@pytest.mark.parametrize(
+    "pint_unit",
+    [
+        unit.dalton,
+        unit.kilojoules / unit.mole,
+        unit.angstrom,
+        unit.kelvin,
+        unit.atmosphere,
+        unit.gram,
+        unit.liter,
+        unit.gram / unit.liter,
+    ],
+)
 @pytest.mark.parametrize(
     "value",
     [random(), randint(1, 10), [random(), random()], np.array([random(), random()])],
@@ -108,102 +89,6 @@ def test_pint_to_openmm(pint_unit, value):
 
     openmm_quantity = pint_quantity_to_openmm(pint_quantity)
     openmm_raw_value = openmm_quantity.value_in_unit(openmm_quantity.unit)
-
-    assert np.allclose(openmm_raw_value, pint_raw_value)
-
-
-def test_combinatorial_pint_to_openmm():
-
-    all_pint_units = _get_all_pint_units()
-
-    for i in range(len(all_pint_units)):
-
-        for j in range(i, len(all_pint_units)):
-
-            pint_unit = all_pint_units[i] * all_pint_units[j]
-
-            pint_quantity = random() * pint_unit
-            pint_raw_value = pint_quantity.magnitude
-
-            openmm_quantity = pint_quantity_to_openmm(pint_quantity)
-            openmm_raw_value = openmm_quantity.value_in_unit(openmm_quantity.unit)
-
-            assert np.isclose(openmm_raw_value, pint_raw_value)
-
-
-def test_combinatorial_openmm_to_pint():
-
-    all_openmm_units = list(_get_all_openmm_units())
-
-    for i in range(len(all_openmm_units)):
-
-        for j in range(i, len(all_openmm_units)):
-
-            openmm_unit = all_openmm_units[i] * all_openmm_units[j]
-
-            openmm_quantity = random() * openmm_unit
-            openmm_raw_value = openmm_quantity.value_in_unit(openmm_unit)
-
-            pint_quantity = openmm_quantity_to_pint(openmm_quantity)
-            pint_raw_value = pint_quantity.magnitude
-
-            assert np.isclose(openmm_raw_value, pint_raw_value)
-
-
-@pytest.mark.parametrize(
-    "openmm_unit",
-    {*_get_all_openmm_units(), simtk_unit.dalton ** 2, simtk_unit.dalton ** 3},
-)
-@pytest.mark.parametrize(
-    "value",
-    [random(), randint(1, 10), [random(), random()], np.array([random(), random()])],
-)
-def test_openmm_unit_conversions(openmm_unit, value):
-
-    openmm_quantity = value * openmm_unit
-
-    openmm_base_quantity = openmm_quantity.in_unit_system(simtk_unit.md_unit_system)
-
-    if not isinstance(openmm_base_quantity, simtk_unit.Quantity):
-        openmm_base_quantity *= simtk_unit.dimensionless
-
-    pint_base_quantity = openmm_quantity_to_pint(openmm_base_quantity)
-
-    pint_unit = openmm_unit_to_pint(openmm_unit)
-    pint_quantity = pint_base_quantity.to(pint_unit)
-
-    pint_raw_value = pint_quantity.magnitude
-    openmm_raw_value = openmm_quantity.value_in_unit(openmm_unit)
-
-    assert np.allclose(openmm_raw_value, pint_raw_value)
-
-
-@pytest.mark.parametrize("pint_unit", _get_all_pint_units())
-@pytest.mark.parametrize(
-    "value",
-    [random(), randint(1, 10), [random(), random()], np.array([random(), random()])],
-)
-def test_pint_unit_conversions(pint_unit, value):
-
-    pint_quantity = value * pint_unit
-
-    pint_base_quantity = pint_quantity.to_base_units()
-    openmm_base_quantity = pint_quantity_to_openmm(pint_base_quantity)
-
-    openmm_unit = pint_unit_to_openmm(pint_unit)
-    openmm_quantity = openmm_base_quantity.in_units_of(openmm_unit)
-
-    pint_raw_value = pint_quantity.magnitude
-
-    if pint_unit == unit.dimensionless and (
-        isinstance(openmm_quantity, float)
-        or isinstance(openmm_quantity, int)
-        or isinstance(openmm_quantity, list)
-        or isinstance(openmm_quantity, np.ndarray)
-    ):
-        openmm_raw_value = openmm_quantity
-    else:
-        openmm_raw_value = openmm_quantity.value_in_unit(openmm_unit)
 
     assert np.allclose(openmm_raw_value, pint_raw_value)
 
@@ -228,15 +113,6 @@ def test_constants():
         ),
         (1.0 * unit.molar_gas_constant)
         .to(unit.joule / unit.kelvin / unit.mole)
-        .magnitude,
-    )
-
-    assert np.isclose(
-        simtk_unit.GRAVITATIONAL_CONSTANT_G.value_in_unit(
-            simtk_unit.meter ** 2 * simtk_unit.newton / simtk_unit.kilogram ** 2
-        ),
-        (1.0 * unit.newtonian_constant_of_gravitation)
-        .to(unit.meter ** 2 * unit.newton / unit.kilogram ** 2)
         .magnitude,
     )
 

--- a/openff/evaluator/tests/test_workflow/utils.py
+++ b/openff/evaluator/tests/test_workflow/utils.py
@@ -1,7 +1,6 @@
 from typing import Union
 
-import pint
-
+from openff.evaluator import unit
 from openff.evaluator.attributes import UNDEFINED
 from openff.evaluator.layers import registered_calculation_schemas
 from openff.evaluator.workflow import Protocol, Workflow, workflow_protocol
@@ -62,7 +61,7 @@ class DummyReplicableProtocol(Protocol):
     replicated_value_b = InputAttribute(
         docstring="", type_hint=Union[str, int, float], default_value=UNDEFINED
     )
-    final_value = OutputAttribute(docstring="", type_hint=pint.Measurement)
+    final_value = OutputAttribute(docstring="", type_hint=unit.Measurement)
 
     def _execute(self, directory, available_resources):
         pass

--- a/openff/evaluator/thermodynamics.py
+++ b/openff/evaluator/thermodynamics.py
@@ -3,8 +3,6 @@ Defines an API for defining thermodynamic states.
 """
 from enum import Enum
 
-import pint
-
 from openff.evaluator import unit
 from openff.evaluator.attributes import UNDEFINED, Attribute, AttributeClass
 
@@ -36,10 +34,10 @@ class ThermodynamicState(AttributeClass):
     """
 
     temperature = Attribute(
-        docstring="The external temperature.", type_hint=pint.Quantity
+        docstring="The external temperature.", type_hint=unit.Quantity
     )
     pressure = Attribute(
-        docstring="The external pressure.", type_hint=pint.Quantity, optional=True
+        docstring="The external pressure.", type_hint=unit.Quantity, optional=True
     )
 
     @property
@@ -59,9 +57,9 @@ class ThermodynamicState(AttributeClass):
 
         Parameters
         ----------
-        temperature : pint.Quantity
+        temperature : openff.evaluator.unit.Quantity
             The external temperature
-        pressure : pint.Quantity
+        pressure : openff.evaluator.unit.Quantity
             The external pressure
         """
         if temperature is not None:

--- a/openff/evaluator/utils/observables.py
+++ b/openff/evaluator/utils/observables.py
@@ -229,7 +229,7 @@ class _Observable(abc.ABC):
 
         if isinstance(self._value, unit.Measurement):
             # Fix a quirk where a quantity divided by a measurement is a unit wrapped
-            # uncertainty object rather than a full pint measurement object.
+            # uncertainty object rather than a full measurement object.
             value = unit.Measurement(
                 value.magnitude.nominal_value * value.units,
                 value.magnitude.std_dev * value.units,
@@ -288,7 +288,7 @@ class Observable(_Observable):
     ):
 
         if value is not None and not isinstance(
-            value, (pint.Quantity, unit.Quantity, pint.Measurement, unit.Measurement)
+            value, (unit.Quantity, unit.Measurement)
         ):
 
             raise TypeError(
@@ -296,9 +296,7 @@ class Observable(_Observable):
                 "an `openff.evaluator.unit.Quantity`."
             )
 
-        if value is not None and not isinstance(
-            value, (pint.Measurement, unit.Measurement)
-        ):
+        if value is not None and not isinstance(value, unit.Measurement):
 
             if value is not None and not isinstance(value.magnitude, (int, float)):
                 raise TypeError("The value must be a unit-wrapped integer or float.")
@@ -549,7 +547,7 @@ class ObservableFrame(MutableMapping[Union[str, ObservableType], ObservableArray
     enumerated by the ``ObservableType`` enum.
     """
 
-    _units: Dict[ObservableType, pint.Unit] = {
+    _units: Dict[ObservableType, unit.Unit] = {
         ObservableType.PotentialEnergy: unit.kilojoules / unit.mole,
         ObservableType.KineticEnergy: unit.kilojoules / unit.mole,
         ObservableType.TotalEnergy: unit.kilojoules / unit.mole,

--- a/openff/evaluator/utils/openmm.py
+++ b/openff/evaluator/utils/openmm.py
@@ -6,7 +6,6 @@ import logging
 from typing import TYPE_CHECKING, Optional, Tuple
 
 import numpy
-import pint
 from pint import UndefinedUnitError
 from simtk import openmm
 from simtk import unit as simtk_unit
@@ -106,44 +105,17 @@ def setup_platform_with_resources(compute_resources, high_precision=False):
     return platform
 
 
-# Some openmm units are not currently supported.
-unsupported_openmm_units = {
-    simtk_unit.yottojoule,
-    simtk_unit.item,
-    simtk_unit.yottopascal,
-    simtk_unit.century,
-    simtk_unit.yottosecond,
-    simtk_unit.yottogram,
-    simtk_unit.bohr,
-    simtk_unit.yottocalorie,
-    simtk_unit.yottoliter,
-    simtk_unit.yottometer,
-    simtk_unit.debye,
-    simtk_unit.yottonewton,
-    simtk_unit.ban,
-    simtk_unit.yottomolar,
-    simtk_unit.nat,
-    simtk_unit.mmHg,
-    simtk_unit.year,
-    simtk_unit.psi,
-    simtk_unit.pound_mass,
-    simtk_unit.stone,
-    simtk_unit.millenium,
-    simtk_unit.gauss,
-}
-
-
 def openmm_quantity_to_pint(openmm_quantity):
-    """Converts a `simtk.pint.Quantity` to a `pint.Quantity`.
+    """Converts a `simtk.unit.Quantity` to a `openff.evaluator.unit.Quantity`.
 
     Parameters
     ----------
-    openmm_quantity: simtk.pint.Quantity
+    openmm_quantity: simtk.unit.Quantity
         The quantity to convert.
 
     Returns
     -------
-    pint.Quantity
+    openff.evaluator.unit.Quantity
         The converted quantity.
     """
 
@@ -151,13 +123,6 @@ def openmm_quantity_to_pint(openmm_quantity):
         return None
 
     assert isinstance(openmm_quantity, simtk_unit.Quantity)
-
-    if openmm_quantity.unit in unsupported_openmm_units:
-
-        raise ValueError(
-            f"Quantities bearing the {openmm_quantity.unit} are not "
-            f"currently supported by pint."
-        )
 
     openmm_unit = openmm_quantity.unit
     openmm_raw_value = openmm_quantity.value_in_unit(openmm_unit)
@@ -169,7 +134,7 @@ def openmm_quantity_to_pint(openmm_quantity):
 
 
 def openmm_unit_to_pint(openmm_unit):
-    """Converts a `simtk.unit.Unit` to a `pint.Unit`.
+    """Converts a `simtk.unit.Unit` to a `openff.evaluator.unit.Unit`.
 
     Parameters
     ----------
@@ -178,7 +143,7 @@ def openmm_unit_to_pint(openmm_unit):
 
     Returns
     -------
-    pint.Unit
+    openff.evaluator.unit.Unit
         The converted unit.
     """
     from openforcefield.utils import unit_to_string
@@ -187,13 +152,6 @@ def openmm_unit_to_pint(openmm_unit):
         return None
 
     assert isinstance(openmm_unit, simtk_unit.Unit)
-
-    if openmm_unit in unsupported_openmm_units:
-
-        raise ValueError(
-            f"Quantities bearing the {openmm_unit} are not "
-            f"currently supported by pint."
-        )
 
     openmm_unit_string = unit_to_string(openmm_unit)
 
@@ -212,7 +170,7 @@ def openmm_unit_to_pint(openmm_unit):
 
         logger.info(
             f"The {openmm_unit_string} OMM unit string (based on the {openmm_unit} object) "
-            f"is undefined in pint"
+            f"is not supported."
         )
 
         raise
@@ -221,7 +179,7 @@ def openmm_unit_to_pint(openmm_unit):
 
 
 def pint_quantity_to_openmm(pint_quantity):
-    """Converts a `pint.Quantity` to a `simtk.pint.Quantity`.
+    """Converts a `openff.evaluator.unit.Quantity` to a `simtk.unit.Quantity`.
 
     Notes
     -----
@@ -229,19 +187,19 @@ def pint_quantity_to_openmm(pint_quantity):
 
     Parameters
     ----------
-    pint_quantity: pint.Quantity
+    pint_quantity: openff.evaluator.unit.Quantity
         The quantity to convert.
 
     Returns
     -------
-    simtk.pint.Quantity
+    simtk.unit.Quantity
         The converted quantity.
     """
 
     if pint_quantity is None or isinstance(pint_quantity, UndefinedAttribute):
         return None
 
-    assert isinstance(pint_quantity, pint.Quantity)
+    assert isinstance(pint_quantity, unit.Quantity)
 
     pint_unit = pint_quantity.units
     pint_raw_value = pint_quantity.magnitude
@@ -253,7 +211,7 @@ def pint_quantity_to_openmm(pint_quantity):
 
 
 def pint_unit_to_openmm(pint_unit):
-    """Converts a `pint.Unit` to a `simtk.unit.Unit`.
+    """Converts a `openff.evaluator.unit.Unit` to a `simtk.unit.Unit`.
 
     Notes
     -----
@@ -261,7 +219,7 @@ def pint_unit_to_openmm(pint_unit):
 
     Parameters
     ----------
-    pint_unit: pint.Unit
+    pint_unit: openff.evaluator.unit.Unit
         The unit to convert.
 
     Returns
@@ -274,7 +232,7 @@ def pint_unit_to_openmm(pint_unit):
     if pint_unit is None or isinstance(pint_unit, UndefinedAttribute):
         return None
 
-    assert isinstance(pint_unit, pint.Unit)
+    assert isinstance(pint_unit, unit.Unit)
 
     pint_unit_string = f"{pint_unit:!s}"
 

--- a/openff/evaluator/utils/packmol.py
+++ b/openff/evaluator/utils/packmol.py
@@ -72,10 +72,10 @@ def _validate_inputs(
         equal to the length of `molecules`.
     structure_to_solvate: str, optional
         A file path to the PDB coordinates of the structure to be solvated.
-    box_size : pint.Quantity, optional
+    box_size : openff.evaluator.unit.Quantity, optional
         The size of the box to generate in units compatible with angstroms.
         If `None`, `mass_density` must be provided.
-    mass_density : pint.Quantity, optional
+    mass_density : openff.evaluator.unit.Quantity, optional
         Target mass density for final system with units compatible with g / mL.
          If `None`, `box_size` must be provided.
     box_aspect_ratio: list of float, optional
@@ -87,7 +87,9 @@ def _validate_inputs(
         raise ValueError("Either a `box_size` or `mass_density` must be specified.")
 
     if box_size is not None and len(box_size) != 3:
-        raise ValueError("`box_size` must be a pint.Quantity wrapped list of length 3")
+        raise ValueError(
+            "`box_size` must be a openff.evaluator.unit.Quantity wrapped list of length 3"
+        )
 
     if box_aspect_ratio is not None:
 
@@ -123,7 +125,7 @@ def _approximate_box_size_by_density(
         The molecules in the system.
     n_copies : list of int
         The number of copies of each molecule.
-    mass_density : pint.Quantity
+    mass_density : openff.evaluator.unit.Quantity
         The target mass density for final system. It should have units
         compatible with g / mL.
     box_aspect_ratio: List of float
@@ -135,7 +137,7 @@ def _approximate_box_size_by_density(
 
     Returns
     -------
-    pint.Quantity
+    openff.evaluator.unit.Quantity
         A list of the three box lengths in units compatible with angstroms.
     """
 
@@ -390,9 +392,9 @@ def _build_input_file(
     center_solute: str
         If `True`, the structure to solvate will be centered in the
         simulation box.
-    box_size: pint.Quantity
+    box_size: openff.evaluator.unit.Quantity
         The lengths of each box vector.
-    tolerance: pint.Quantity
+    tolerance: openff.evaluator.unit.Quantity
         The packmol convergence tolerance.
     output_file_name: str
         The path to save the packed pdb to.
@@ -601,13 +603,13 @@ def pack_box(
         If `True`, the structure to solvate will be centered in the
         simulation box. This option is only applied when `structure_to_solvate`
         is set.
-    tolerance : pint.Quantity
+    tolerance : openff.evaluator.unit.Quantity
         The minimum spacing between molecules during packing in units
          compatible with angstroms.
-    box_size : pint.Quantity, optional
+    box_size : openff.evaluator.unit.Quantity, optional
         The size of the box to generate in units compatible with angstroms.
         If `None`, `mass_density` must be provided.
-    mass_density : pint.Quantity, optional
+    mass_density : openff.evaluator.unit.Quantity, optional
         Target mass density for final system with units compatible with g / mL.
          If `None`, `box_size` must be provided.
     box_aspect_ratio: list of float, optional

--- a/openff/evaluator/utils/serialization.py
+++ b/openff/evaluator/utils/serialization.py
@@ -11,7 +11,6 @@ from enum import Enum
 
 import dateutil.parser
 import numpy as np
-import pint
 
 from openff.evaluator import unit
 
@@ -81,26 +80,13 @@ def _type_to_type_string(object_type):
         The converted type.
     """
 
-    if (
-        issubclass(object_type, pint.Unit)
-        or f"{object_type.__module__}.{object_type.__qualname__}"
-        == "pint.quantity.build_quantity_class.<locals>.Unit"
-    ):
+    if issubclass(object_type, unit.Unit):
         return "openff.evaluator.unit.Unit"
 
-    if (
-        issubclass(object_type, pint.Measurement)
-        or f"{object_type.__module__}.{object_type.__qualname__}"
-        == "pint.quantity.build_quantity_class.<locals>.Measurement"
-    ):
-
+    if issubclass(object_type, unit.Measurement):
         return "openff.evaluator.unit.Measurement"
 
-    if (
-        issubclass(object_type, pint.Quantity)
-        or f"{object_type.__module__}.{object_type.__qualname__}"
-        == "pint.quantity.build_quantity_class.<locals>.Quantity"
-    ):
+    if issubclass(object_type, unit.Quantity):
         return "openff.evaluator.unit.Quantity"
 
     qualified_name = object_type.__qualname__
@@ -114,18 +100,18 @@ def _type_to_type_string(object_type):
 
 
 def serialize_quantity(quantity):
-    """Serializes a pint.Quantity into a dictionary of the form
+    """Serializes a openff.evaluator.unit.Quantity into a dictionary of the form
     `{'value': quantity.value_in_unit(quantity.unit), 'unit': quantity.unit}`
 
     Parameters
     ----------
-    quantity : pint.Quantity
+    quantity : openff.evaluator.unit.Quantity
         The quantity to serialize
 
     Returns
     -------
     dict of str and str
-        A dictionary representation of a pint.Quantity
+        A dictionary representation of a openff.evaluator.unit.Quantity
         with keys of {"value", "unit"}
     """
 
@@ -134,17 +120,17 @@ def serialize_quantity(quantity):
 
 
 def deserialize_quantity(serialized):
-    """Deserialize a pint.Quantity from a dictionary.
+    """Deserialize a openff.evaluator.unit.Quantity from a dictionary.
 
     Parameters
     ----------
     serialized : dict of str and str
-        A dictionary representation of a pint.Quantity
+        A dictionary representation of a openff.evaluator.unit.Quantity
         which must have keys {"value", "unit"}
 
     Returns
     -------
-    pint.Quantity
+    openff.evaluator.unit.Quantity
         The deserialized quantity.
     """
 
@@ -160,36 +146,36 @@ def deserialize_quantity(serialized):
 
 
 def serialize_measurement(measurement):
-    """Serializes a `pint.Measurement` into a dictionary of the form
+    """Serializes a `openff.evaluator.unit.Measurement` into a dictionary of the form
     `{'value', 'error'}`.
 
     Parameters
     ----------
-    measurement : pint.Measurement
+    measurement : openff.evaluator.unit.Measurement
         The measurement to serialize
 
     Returns
     -------
     dict of str and str
-        A dictionary representation of a pint.Measurement
+        A dictionary representation of a openff.evaluator.unit.Measurement
         with keys of {"value", "error"}
     """
     return {"value": measurement.value, "error": measurement.error}
 
 
 def deserialize_measurement(serialized):
-    """Deserialize a `pint.Measurement` from a dictionary of the form
+    """Deserialize a `openff.evaluator.unit.Measurement` from a dictionary of the form
     `{'value', 'error'}`.
 
     Parameters
     ----------
     serialized : dict of str and str
-        A dictionary representation of a `pint.Measurement`
+        A dictionary representation of a `openff.evaluator.unit.Measurement`
         which must have keys {"value", "error"}
 
     Returns
     -------
-    pint.Measurement
+    openff.evaluator.unit.Measurement
         The deserialized measurement.
     """
 
@@ -285,8 +271,8 @@ class TypedJSONEncoder(json.JSONEncoder):
 
     _custom_supported_types = {
         Enum: serialize_enum,
-        pint.Measurement: serialize_measurement,
-        pint.Quantity: serialize_quantity,
+        unit.Measurement: serialize_measurement,
+        unit.Quantity: serialize_quantity,
         set: serialize_set,
         frozenset: serialize_frozen_set,
         np.float16: lambda x: {"value": float(x)},
@@ -316,9 +302,9 @@ class TypedJSONEncoder(json.JSONEncoder):
         if type_tag == "openff.evaluator.unit.Unit":
             type_to_serialize = unit.Unit
         if type_tag == "openff.evaluator.unit.Quantity":
-            type_to_serialize = pint.Quantity
+            type_to_serialize = unit.Quantity
         if type_tag == "openff.evaluator.unit.Measurement":
-            type_to_serialize = pint.Measurement
+            type_to_serialize = unit.Measurement
 
         custom_encoder = None
 
@@ -383,8 +369,8 @@ class TypedJSONDecoder(json.JSONDecoder):
 
     _custom_supported_types = {
         Enum: deserialize_enum,
-        pint.Measurement: deserialize_measurement,
-        pint.Quantity: deserialize_quantity,
+        unit.Measurement: deserialize_measurement,
+        unit.Quantity: deserialize_quantity,
         set: deserialize_set,
         frozenset: deserialize_frozen_set,
         np.float16: lambda x: np.float16(x["value"]),

--- a/openff/evaluator/utils/units.py
+++ b/openff/evaluator/utils/units.py
@@ -1,0 +1,79 @@
+"""A module to strip ``pint`` of its dynamic classes."""
+import os
+import uuid
+import warnings
+
+import pint
+from pint.measurement import _Measurement
+from pint.quantity import _Quantity
+from pint.unit import _Unit
+
+from openff.evaluator.utils import get_data_filename
+
+DEFAULT_UNIT_REGISTRY = pint.UnitRegistry(
+    get_data_filename(os.path.join("units", "defaults.txt"))
+)
+
+
+def _unpickle_quantity(cls, *args):
+    """Rebuild quantity upon unpickling using the application registry."""
+    return pint._unpickle(DEFAULT_UNIT_REGISTRY.Quantity, *args)
+
+
+def _unpickle_unit(cls, *args):
+    """Rebuild unit upon unpickling using the application registry."""
+    return pint._unpickle(DEFAULT_UNIT_REGISTRY.Unit, *args)
+
+
+def _unpickle_measurement(cls, *args):
+    """Rebuild measurement upon unpickling using the application registry."""
+    return pint._unpickle(DEFAULT_UNIT_REGISTRY.Measurement, *args)
+
+
+class Unit(_Unit):
+    _REGISTRY = DEFAULT_UNIT_REGISTRY
+
+    def __reduce__(self):
+        return _unpickle_unit, (Unit, self._units)
+
+
+class Quantity(_Quantity):
+    _REGISTRY = DEFAULT_UNIT_REGISTRY
+
+    def __reduce__(self):
+        return _unpickle_quantity, (Quantity, self.magnitude, self._units)
+
+    def __dask_tokenize__(self):
+        return uuid.uuid4().hex
+
+    @staticmethod
+    def _dask_finalize(results, func, args, units):
+        values = func(results, *args)
+        return Quantity(values, units)
+
+
+class Measurement(_Measurement):
+    _REGISTRY = DEFAULT_UNIT_REGISTRY
+
+    def __reduce__(self):
+        return _unpickle_measurement, (Measurement, self.magnitude, self._units)
+
+    def __dask_tokenize__(self):
+        return uuid.uuid4().hex
+
+    @staticmethod
+    def _dask_finalize(results, func, args, units):
+        values = func(results, *args)
+        return Measurement(values, units)
+
+
+DEFAULT_UNIT_REGISTRY.Unit = Unit
+DEFAULT_UNIT_REGISTRY.Quantity = Quantity
+DEFAULT_UNIT_REGISTRY.Measurement = Measurement
+
+pint.set_application_registry(DEFAULT_UNIT_REGISTRY)
+DEFAULT_UNIT_REGISTRY.default_format = "~"
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    Quantity([])

--- a/openff/evaluator/workflow/workflow.py
+++ b/openff/evaluator/workflow/workflow.py
@@ -9,8 +9,7 @@ from math import sqrt
 from os import makedirs, path
 from shutil import copy as file_copy
 
-import pint
-
+from openff.evaluator import unit
 from openff.evaluator.attributes import UNDEFINED, Attribute, AttributeClass
 from openff.evaluator.backends import ComputeResources
 from openff.evaluator.forcefield import (
@@ -635,7 +634,7 @@ class Workflow:
         parameter_gradient_keys: list of ParameterGradientKey
                 A list of references to all of the parameters which all observables
                 should be differentiated with respect to.
-        target_uncertainty: pint.Quantity, optional
+        target_uncertainty: openff.evaluator.unit.Quantity, optional
             The uncertainty which the property should be estimated to
             within.
 
@@ -651,11 +650,11 @@ class Workflow:
             - substance: `Substance` - The composition of the system of interest.
             - components: list of `Substance` - The components present in the system for
                                               which the property is being estimated.
-            - target_uncertainty: pint.Quantity - The target uncertainty with which
-                                                        properties should be estimated.
-            - per_component_uncertainty: pint.Quantity - The target uncertainty divided
-                                                               by the sqrt of the number of
-                                                               components in the system + 1
+            - target_uncertainty: openff.evaluator.unit.Quantity - The target uncertainty with which
+                                                                   properties should be estimated.
+            - per_component_uncertainty: openff.evaluator.unit.Quantity - The target uncertainty divided
+                                                                          by the sqrt of the number of
+                                                                          components in the system + 1
             - force_field_path: str - A path to the force field parameters with which the
                                       property should be evaluated with.
             - parameter_gradient_keys: list of ParameterGradientKey - A list of references to all of the
@@ -786,7 +785,7 @@ class WorkflowResult(AttributeClass):
     value = Attribute(
         docstring="The estimated value of the property and the uncertainty "
         "in that value.",
-        type_hint=pint.Measurement,
+        type_hint=unit.Measurement,
         optional=True,
     )
     gradients = Attribute(


### PR DESCRIPTION
## Description
This PR replaces the dynamic pint `Unit`, `Quantity` and `Measurement` classes with a set of static variants which use the fixed built-in application registry. 

The dynamic variants which ship with pint typically don't work well with with serialisation and type checking which has in the past lead to frequent incompatibilities with new pint versions and workaround code to overcome these issues.

This PR also now directly includes the pint registry files (defaults and constants) based on CODATA 2018 - this makes the code more resilient to changes in `pint` and gives fuller control over which constants and units to include.

## Status
- [ ] Ready to go