### PR TITLE
Migrate to the New OpenFF Toolkit Namespace

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,5 +1,6 @@
 name: test
 channels:
+  - conda-forge/label/openff-toolkit_rc
   - conda-forge
   - omnia
 dependencies:
@@ -13,7 +14,7 @@ dependencies:
   - codecov
 
     # Standard dependencies
-  - openforcefield >=0.7.1
+  - openff-toolkit
   - smirnoff99frosst
   - numpy
   - pandas

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,8 +1,6 @@
 name: test
 channels:
-  - conda-forge/label/openff-toolkit_rc
   - conda-forge
-  - omnia
 dependencies:
     # Base depends
   - python

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -132,7 +132,7 @@ intersphinx_mapping = {
     'dask.distributed': ('https://distributed.dask.org/en/latest/', None),
     'distributed': ('https://distributed.dask.org/en/latest/', None),
     'dask_jobqueue': ('https://jobqueue.dask.org/en/latest/', None),
-    'openforcefield': ('https://open-forcefield-toolkit.readthedocs.io/en/latest/', None),
+    'openff.toolkit': ('https://open-forcefield-toolkit.readthedocs.io/en/latest/', None),
     'pint': ('https://pint.readthedocs.io/en/latest/', None)
 }
 

--- a/docs/datasets/thermomldatasets.rst
+++ b/docs/datasets/thermomldatasets.rst
@@ -21,7 +21,7 @@ The API only supports extracting those properties which have been :ref:`register
 with the frameworks plug-in system, and does not currently load the full set of metadata available in the archive files.
 
 .. note:: If the metadata you require is not currently exposed, please open an issue on the `GitHub issue tracker
-   <https://github.com/openforcefield/evaluator/issues>`_ to request it.
+   <https://github.com/openforcefield/openff-evaluator/issues>`_ to request it.
 
 Currently the framework has built-in support for extracting:
 

--- a/docs/tutorials/colab_setup.ipynb
+++ b/docs/tutorials/colab_setup.ipynb
@@ -17,7 +17,7 @@
     "!. /usr/local/etc/profile.d/conda.sh && conda env update --name base --file test_env.yaml && conda install --yes -c conda-forge -c omnia forcebalance && conda list\n",
     "\n",
     "!pip install git+https://github.com/openforcefield/openff-evaluator.git@master\n",
-    "!wget https://raw.githubusercontent.com/openforcefield/openforcefields/7300a486581feff508b9401241443f941924783f/openforcefields/offxml/openff-1.0.0.offxml\n",
+    "!wget https://raw.githubusercontent.com/openforcefield/openff-forcefields/7300a486581feff508b9401241443f941924783f/openforcefields/offxml/openff-1.0.0.offxml\n",
     "\n",
     "import os\n",
     "import sys\n",

--- a/docs/tutorials/tutorial01.ipynb
+++ b/docs/tutorials/tutorial01.ipynb
@@ -114,7 +114,7 @@
     "import warnings\n",
     "warnings.filterwarnings('ignore')\n",
     "import logging\n",
-    "logging.getLogger(\"openforcefield\").setLevel(logging.ERROR)"
+    "logging.getLogger(\"openff.toolkit\").setLevel(logging.ERROR)"
    ],
    "execution_count": 2,
    "outputs": []

--- a/integration-tests/default-workflows/run.py
+++ b/integration-tests/default-workflows/run.py
@@ -1,6 +1,6 @@
 import os
 
-from openforcefield.typing.engines.smirnoff import ForceField
+from openff.toolkit.typing.engines.smirnoff import ForceField
 
 from openff import evaluator
 from openff.evaluator import unit

--- a/integration-tests/paprika/run.py
+++ b/integration-tests/paprika/run.py
@@ -1,6 +1,6 @@
 import os
 
-from openforcefield.typing.engines.smirnoff import ForceField
+from openff.toolkit.typing.engines.smirnoff import ForceField
 
 from openff import evaluator
 from openff.evaluator import unit

--- a/openff/evaluator/client/client.py
+++ b/openff/evaluator/client/client.py
@@ -650,7 +650,7 @@ class EvaluatorClient:
         ----------
         property_set : PhysicalPropertyDataSet
             The set of properties to estimate.
-        force_field_source : ForceFieldSource or openforcefield.typing.engines.smirnoff.ForceField
+        force_field_source : ForceFieldSource or openff.toolkit.typing.engines.smirnoff.ForceField
             The force field parameters to estimate the properties using.
         options : RequestOptions, optional
             A set of estimator options. If `None` default options
@@ -667,7 +667,7 @@ class EvaluatorClient:
         EvaluatorException, optional
             Any exceptions raised while attempting the submit the request.
         """
-        from openforcefield.typing.engines import smirnoff
+        from openff.toolkit.typing.engines import smirnoff
 
         if property_set is None or force_field_source is None:
 

--- a/openff/evaluator/datasets/curation/components/conversion.py
+++ b/openff/evaluator/datasets/curation/components/conversion.py
@@ -58,7 +58,7 @@ class ConvertExcessDensityData(CurationComponent):
     @functools.lru_cache(500)
     def _molecular_weight(cls, smiles):
 
-        from openforcefield.topology import Molecule
+        from openff.toolkit.topology import Molecule
         from simtk import unit as simtk_unit
 
         molecule = Molecule.from_smiles(smiles, allow_undefined_stereo=True)

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -414,7 +414,7 @@ class FilterByElements(CurationComponent):
         cls, data_frame: pandas.DataFrame, schema: FilterByElementsSchema, n_processes
     ) -> pandas.DataFrame:
 
-        from openforcefield.topology import Molecule
+        from openff.toolkit.topology import Molecule
 
         def filter_function(data_row):
 
@@ -646,8 +646,8 @@ class FilterByStereochemistry(CurationComponent):
         n_processes,
     ) -> pandas.DataFrame:
 
-        from openforcefield.topology import Molecule
-        from openforcefield.utils import UndefinedStereochemistryError
+        from openff.toolkit.topology import Molecule
+        from openff.toolkit.utils import UndefinedStereochemistryError
 
         def filter_function(data_row):
 
@@ -683,7 +683,7 @@ class FilterByCharged(CurationComponent):
         cls, data_frame: pandas.DataFrame, schema: FilterByChargedSchema, n_processes
     ) -> pandas.DataFrame:
 
-        from openforcefield.topology import Molecule
+        from openff.toolkit.topology import Molecule
         from simtk import unit as simtk_unit
 
         def filter_function(data_row):
@@ -888,7 +888,7 @@ class FilterBySmirks(CurationComponent):
             The matched smirks patterns.
         """
 
-        from openforcefield.topology import Molecule
+        from openff.toolkit.topology import Molecule
 
         if len(smirks_patterns) == 0:
             return []

--- a/openff/evaluator/datasets/curation/components/selection.py
+++ b/openff/evaluator/datasets/curation/components/selection.py
@@ -176,7 +176,7 @@ class SelectSubstances(CurationComponent):
             OEFPType_Tree,
             OEMakeFP,
         )
-        from openforcefield.topology import Molecule
+        from openff.toolkit.topology import Molecule
 
         oe_molecule = Molecule.from_smiles(smiles).to_openeye()
 

--- a/openff/evaluator/datasets/taproom/taproom.py
+++ b/openff/evaluator/datasets/taproom/taproom.py
@@ -159,7 +159,7 @@ class TaproomDataSet(PhysicalPropertyDataSet):
         str
             The smiles descriptor of the loaded molecule
         """
-        from openforcefield.topology import Molecule
+        from openff.toolkit.topology import Molecule
 
         receptor_molecule = Molecule.from_file(file_path, "MOL2")
         return receptor_molecule.to_smiles()
@@ -188,7 +188,7 @@ class TaproomDataSet(PhysicalPropertyDataSet):
         -------
             The built substance.
         """
-        from openforcefield.topology import Molecule
+        from openff.toolkit.topology import Molecule
         from simtk import unit as simtk_unit
 
         substance = Substance()

--- a/openff/evaluator/datasets/thermoml/thermoml.py
+++ b/openff/evaluator/datasets/thermoml/thermoml.py
@@ -434,8 +434,8 @@ class _Compound:
             None if the identifier cannot be converted, otherwise the converted SMILES pattern.
         """
         from cmiles.utils import load_molecule, mol_to_smiles
-        from openforcefield.topology import Molecule
-        from openforcefield.utils import LicenseError
+        from openff.toolkit.topology import Molecule
+        from openff.toolkit.utils import LicenseError
 
         if common_name is None:
             return None
@@ -845,7 +845,7 @@ class _PureOrMixtureData:
             The molecular weight.
         """
 
-        from openforcefield.topology import Molecule
+        from openff.toolkit.topology import Molecule
         from simtk import unit as simtk_unit
 
         try:

--- a/openff/evaluator/forcefield/forcefield.py
+++ b/openff/evaluator/forcefield/forcefield.py
@@ -51,10 +51,10 @@ class SmirnoffForceFieldSource(ForceFieldSource):
 
         Returns
         -------
-        openforcefield.typing.engines.smirnoff.ForceField
+        openff.toolkit.typing.engines.smirnoff.ForceField
             The created force field.
         """
-        from openforcefield.typing.engines import smirnoff
+        from openff.toolkit.typing.engines import smirnoff
 
         return smirnoff.ForceField(self._inner_xml)
 
@@ -69,7 +69,7 @@ class SmirnoffForceFieldSource(ForceFieldSource):
 
         Parameters
         ----------
-        force_field: openforcefield.typing.engines.smirnoff.ForceField
+        force_field: openff.toolkit.typing.engines.smirnoff.ForceField
             The existing force field.
 
         Returns
@@ -101,7 +101,7 @@ class SmirnoffForceFieldSource(ForceFieldSource):
             The created object.
         """
 
-        from openforcefield.typing.engines.smirnoff import ForceField
+        from openff.toolkit.typing.engines.smirnoff import ForceField
 
         force_field = ForceField(file_path, allow_cosmetic_attributes=True)
         return cls.from_object(force_field)

--- a/openff/evaluator/forcefield/system.py
+++ b/openff/evaluator/forcefield/system.py
@@ -6,7 +6,7 @@ from openff.evaluator.utils.serialization import TypedBaseModel
 
 if TYPE_CHECKING:
 
-    from openforcefield.topology import Topology
+    from openff.toolkit.topology import Topology
     from simtk.openmm import System
 
 
@@ -30,7 +30,7 @@ class ParameterizedSystem(TypedBaseModel):
     @property
     def topology(self) -> "Topology":
 
-        from openforcefield.topology import Molecule, Topology
+        from openff.toolkit.topology import Molecule, Topology
         from simtk.openmm import app
 
         pdb_file = app.PDBFile(self._topology_path)

--- a/openff/evaluator/protocols/coordinates.py
+++ b/openff/evaluator/protocols/coordinates.py
@@ -109,12 +109,12 @@ class BuildCoordinatesPackmol(Protocol):
 
         Returns
         -------
-        list of openforcefield.topology.Molecule
+        list of openff.toolkit.topology.Molecule
             The list of molecules.
         list of int
             The number of each molecule which should be added to the system.
         """
-        from openforcefield.topology import Molecule
+        from openff.toolkit.topology import Molecule
 
         molecules = []
 
@@ -430,7 +430,7 @@ class BuildDockedCoordinates(Protocol):
         openeye.oechem.OEMol
             The OpenEye ligand object with multiple conformers.
         """
-        from openforcefield.topology import Molecule
+        from openff.toolkit.topology import Molecule
 
         ligand = Molecule.from_smiles(self.ligand_substance.components[0].smiles)
         ligand.generate_conformers(n_conformers=self.number_of_ligand_conformers)

--- a/openff/evaluator/protocols/forcefield.py
+++ b/openff/evaluator/protocols/forcefield.py
@@ -349,7 +349,7 @@ class TemplateBuildSystem(BaseBuildSystem, abc.ABC):
 
         Parameters
         ----------
-        molecule: openforcefield.topology.Molecule
+        molecule: openff.toolkit.topology.Molecule
             The molecule to parameterize.
         force_field_source: ForceFieldSource
             The tleap source which describes which parameters to apply.
@@ -365,7 +365,7 @@ class TemplateBuildSystem(BaseBuildSystem, abc.ABC):
 
     def _execute(self, directory, available_resources):
 
-        from openforcefield.topology import Molecule, Topology
+        from openff.toolkit.topology import Molecule, Topology
 
         force_field_source = ForceFieldSource.from_json(self.force_field_path)
         cutoff = pint_quantity_to_openmm(force_field_source.cutoff)
@@ -450,12 +450,12 @@ class TemplateBuildSystem(BaseBuildSystem, abc.ABC):
 @workflow_protocol()
 class BuildSmirnoffSystem(BaseBuildSystem):
     """Parametrise a set of molecules with a given smirnoff force field
-    using the `OpenFF toolkit <https://github.com/openforcefield/openforcefield>`_.
+    using the `OpenFF toolkit <https://github.com/openforcefield/openff-toolkit>`_.
     """
 
     def _execute(self, directory, available_resources):
 
-        from openforcefield.topology import Molecule, Topology
+        from openff.toolkit.topology import Molecule, Topology
 
         pdb_file = app.PDBFile(self.coordinate_file_path)
 
@@ -537,7 +537,7 @@ class BuildLigParGenSystem(TemplateBuildSystem):
 
         Parameters
         ----------
-        molecule: openforcefield.topology.Molecule
+        molecule: openff.toolkit.topology.Molecule
             The molecule to templatize.
         force_field_source: LigParGenForceFieldSource
             The tleap source which describes which parameters to apply.
@@ -810,7 +810,7 @@ class BuildTLeapSystem(TemplateBuildSystem):
 
         Parameters
         ----------
-        molecule: openforcefield.topology.Molecule
+        molecule: openff.toolkit.topology.Molecule
             The molecule to parameterize.
         force_field_source: TLeapForceFieldSource
             The tleap source which describes which parameters to apply.
@@ -1003,19 +1003,19 @@ class BuildTLeapSystem(TemplateBuildSystem):
 
         Parameters
         ----------
-        molecule: openforcefield.topology.Molecule
+        molecule: openff.toolkit.topology.Molecule
             The molecule to assign charges to.
         """
 
         if self.charge_backend == BuildTLeapSystem.ChargeBackend.OpenEye:
 
-            from openforcefield.utils.toolkits import OpenEyeToolkitWrapper
+            from openff.toolkit.utils.toolkits import OpenEyeToolkitWrapper
 
             toolkit_wrapper = OpenEyeToolkitWrapper()
 
         elif self.charge_backend == BuildTLeapSystem.ChargeBackend.AmberTools:
 
-            from openforcefield.utils.toolkits import (
+            from openff.toolkit.utils.toolkits import (
                 AmberToolsToolkitWrapper,
                 RDKitToolkitWrapper,
                 ToolkitRegistry,
@@ -1036,7 +1036,7 @@ class BuildTLeapSystem(TemplateBuildSystem):
 
         Parameters
         ----------
-        molecule: openforcefield.topology.Molecule
+        molecule: openff.toolkit.topology.Molecule
             The molecule to parameterize.
         force_field_source: TLeapForceFieldSource
             The tleap source which describes which parameters to apply.

--- a/openff/evaluator/protocols/openmm.py
+++ b/openff/evaluator/protocols/openmm.py
@@ -42,8 +42,8 @@ from openff.evaluator.workflow import workflow_protocol
 if TYPE_CHECKING:
 
     from mdtraj import Trajectory
-    from openforcefield.topology import Topology
-    from openforcefield.typing.engines.smirnoff import ForceField
+    from openff.toolkit.topology import Topology
+    from openff.toolkit.typing.engines.smirnoff import ForceField
     from simtk import openmm
 
 logger = logging.getLogger(__name__)

--- a/openff/evaluator/protocols/paprika/coordinates.py
+++ b/openff/evaluator/protocols/paprika/coordinates.py
@@ -37,7 +37,7 @@ def _atom_indices_by_role(
     specific role.
     """
     import mdtraj
-    from openforcefield.topology import Molecule, Topology
+    from openff.toolkit.topology import Molecule, Topology
 
     # Split the substance into the components assigned each role.
     components_by_role = _components_by_role(substance)

--- a/openff/evaluator/protocols/yank.py
+++ b/openff/evaluator/protocols/yank.py
@@ -52,8 +52,8 @@ from openff.evaluator.workflow.attributes import (
 
 if TYPE_CHECKING:
     import mdtraj
-    from openforcefield.topology import Topology
-    from openforcefield.typing.engines.smirnoff.forcefield import ForceField
+    from openff.toolkit.topology import Topology
+    from openff.toolkit.typing.engines.smirnoff.forcefield import ForceField
 
 logger = logging.getLogger(__name__)
 
@@ -153,7 +153,7 @@ class BaseYankProtocol(Protocol, abc.ABC):
             The identified residue names.
         """
 
-        from openforcefield.topology import Molecule, Topology
+        from openff.toolkit.topology import Molecule, Topology
         from simtk.openmm import app
 
         if role is None:
@@ -254,7 +254,7 @@ class BaseYankProtocol(Protocol, abc.ABC):
             A yaml compatible dictionary of YANK options.
         """
 
-        from openforcefield.utils import quantity_to_string
+        from openff.toolkit.utils import quantity_to_string
 
         platform_name = "CPU"
 
@@ -1238,7 +1238,7 @@ class SolvationYankProtocol(BaseYankProtocol):
         """Analyzes a particular phase, extracting the relevant free energies
         and computing the required free energies."""
 
-        from openforcefield.topology import Molecule, Topology
+        from openff.toolkit.topology import Molecule, Topology
 
         free_energies = self._analysed_output["free_energy"]
 

--- a/openff/evaluator/tests/test_utils/test_openmm.py
+++ b/openff/evaluator/tests/test_utils/test_openmm.py
@@ -3,9 +3,9 @@ from random import randint, random
 import mdtraj
 import numpy as np
 import pytest
-from openforcefield.topology import Molecule, Topology
-from openforcefield.typing.engines.smirnoff import ForceField, vdWHandler
-from openforcefield.typing.engines.smirnoff.parameters import (
+from openff.toolkit.topology import Molecule, Topology
+from openff.toolkit.typing.engines.smirnoff import ForceField, vdWHandler
+from openff.toolkit.typing.engines.smirnoff.parameters import (
     ChargeIncrementModelHandler,
     ElectrostaticsHandler,
     LibraryChargeHandler,

--- a/openff/evaluator/tests/test_utils/test_packmol.py
+++ b/openff/evaluator/tests/test_utils/test_packmol.py
@@ -11,7 +11,7 @@ from openff.evaluator.utils.packmol import PackmolRuntimeException
 
 def test_packmol_box_size():
 
-    from openforcefield.topology import Molecule
+    from openff.toolkit.topology import Molecule
 
     molecules = [Molecule.from_smiles("O")]
 
@@ -33,7 +33,7 @@ def test_packmol_box_size():
 
 def test_packmol_bad_input():
 
-    from openforcefield.topology import Molecule
+    from openff.toolkit.topology import Molecule
 
     molecules = [Molecule.from_smiles("O")]
 
@@ -43,7 +43,7 @@ def test_packmol_bad_input():
 
 def test_packmol_failed():
 
-    from openforcefield.topology import Molecule
+    from openff.toolkit.topology import Molecule
 
     molecules = [Molecule.from_smiles("O")]
 
@@ -53,7 +53,7 @@ def test_packmol_failed():
 
 def test_packmol_water():
 
-    from openforcefield.topology import Molecule
+    from openff.toolkit.topology import Molecule
 
     molecules = [Molecule.from_smiles("O")]
 
@@ -75,7 +75,7 @@ def test_packmol_water():
 
 def test_packmol_ions():
 
-    from openforcefield.topology import Molecule
+    from openff.toolkit.topology import Molecule
 
     molecules = [
         Molecule.from_smiles("[Na+]"),
@@ -105,7 +105,7 @@ def test_packmol_ions():
 
 def test_packmol_paracetamol():
 
-    from openforcefield.topology import Molecule
+    from openff.toolkit.topology import Molecule
 
     # Test something a bit more tricky than water
     molecules = [Molecule.from_smiles("CC(=O)NC1=CC=C(C=C1)O")]
@@ -150,7 +150,7 @@ def test_amino_acids():
 
     smiles = [*amino_residues]
 
-    from openforcefield.topology import Molecule
+    from openff.toolkit.topology import Molecule
 
     molecules = [Molecule.from_smiles(x) for x in smiles]
     counts = [1] * len(smiles)

--- a/openff/evaluator/tests/utils.py
+++ b/openff/evaluator/tests/utils.py
@@ -229,7 +229,7 @@ def build_tip3p_smirnoff_force_field():
         The force field containing both smirnoff99Frosst-1.1.0
         and TIP3P parameters
     """
-    from openforcefield.typing.engines.smirnoff import ForceField
+    from openff.toolkit.typing.engines.smirnoff import ForceField
 
     smirnoff_force_field_path = "smirnoff99Frosst-1.1.0.offxml"
     tip3p_force_field_path = get_data_filename("forcefield/tip3p.offxml")

--- a/openff/evaluator/utils/checkmol.py
+++ b/openff/evaluator/utils/checkmol.py
@@ -452,7 +452,7 @@ def analyse_functional_groups(smiles):
     import subprocess
     import tempfile
 
-    from openforcefield.topology import Molecule
+    from openff.toolkit.topology import Molecule
 
     if smiles == "O" or smiles == "[H]O[H]":
         return {ChemicalEnvironment.Aqueous: 1}

--- a/openff/evaluator/utils/openmm.py
+++ b/openff/evaluator/utils/openmm.py
@@ -16,8 +16,8 @@ from openff.evaluator.forcefield import ParameterGradientKey
 
 if TYPE_CHECKING:
 
-    from openforcefield.topology import Topology
-    from openforcefield.typing.engines.smirnoff import ForceField
+    from openff.toolkit.topology import Topology
+    from openff.toolkit.typing.engines.smirnoff import ForceField
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +146,7 @@ def openmm_unit_to_pint(openmm_unit):
     openff.evaluator.unit.Unit
         The converted unit.
     """
-    from openforcefield.utils import unit_to_string
+    from openff.toolkit.utils import unit_to_string
 
     if openmm_unit is None or isinstance(openmm_unit, UndefinedAttribute):
         return None
@@ -227,7 +227,7 @@ def pint_unit_to_openmm(pint_unit):
     simtk.unit.Unit
         The converted unit.
     """
-    from openforcefield.utils import string_to_unit
+    from openff.toolkit.utils import string_to_unit
 
     if pint_unit is None or isinstance(pint_unit, UndefinedAttribute):
         return None
@@ -246,7 +246,7 @@ def pint_unit_to_openmm(pint_unit):
 
         logger.info(
             f"The {pint_unit_string} pint unit string (based on the {pint_unit} object) "
-            f"could not be understood by `openforcefield.utils.string_to_unit`"
+            f"could not be understood by `openff.toolkit.utils.string_to_unit`"
         )
 
         raise
@@ -310,7 +310,7 @@ def system_subset(
 
     # As this method deals mainly with the toolkit, we stick to
     # simtk units here.
-    from openforcefield.typing.engines.smirnoff import ForceField
+    from openff.toolkit.typing.engines.smirnoff import ForceField
 
     # Create the force field subset.
     force_field_subset = ForceField()

--- a/openff/evaluator/utils/packmol.py
+++ b/openff/evaluator/utils/packmol.py
@@ -65,7 +65,7 @@ def _validate_inputs(
 
     Parameters
     ----------
-    molecules : list of openforcefield.topology.Molecule
+    molecules : list of openff.toolkit.topology.Molecule
         The molecules in the system.
     number_of_copies : list of int
         A list of the number of copies of each molecule type, of length
@@ -121,7 +121,7 @@ def _approximate_box_size_by_density(
 
     Parameters
     ----------
-    molecules : list of openforcefield.topology.Molecule
+    molecules : list of openff.toolkit.topology.Molecule
         The molecules in the system.
     n_copies : list of int
         The number of copies of each molecule.
@@ -187,7 +187,7 @@ def _generate_residue_name(residue, smiles):
         The SMILES pattern to generate a resiude name for.
     """
     from mdtraj.core import residue_names
-    from openforcefield.topology import Molecule
+    from openff.toolkit.topology import Molecule
 
     # Define the set of residue names which should be discarded
     # if randomly generated as they have a reserved meaning.
@@ -298,7 +298,7 @@ def _ion_residue_name(molecule):
 
     Parameters
     ----------
-    molecule: openforcefield.topology.Molecule
+    molecule: openff.toolkit.topology.Molecule
         The monoatomic ion to generate a resiude name for.
 
     Returns
@@ -337,7 +337,7 @@ def _create_trajectory(molecule):
 
     Parameters
     ----------
-    molecule: openforcefield.topology.Molecule
+    molecule: openff.toolkit.topology.Molecule
         The SMILES pattern.
 
     Returns
@@ -592,7 +592,7 @@ def pack_box(
 
     Parameters
     ----------
-    molecules : list of openforcefield.topology.Molecule
+    molecules : list of openff.toolkit.topology.Molecule
         The molecules in the system.
     number_of_copies : list of int
         A list of the number of copies of each molecule type, of length

--- a/openff/evaluator/workflow/workflow.py
+++ b/openff/evaluator/workflow/workflow.py
@@ -564,7 +564,7 @@ class Workflow:
         list of ParameterGradientKey
             The filtered list of parameter gradient keys.
         """
-        from openforcefield.topology import Molecule, Topology
+        from openff.toolkit.topology import Molecule, Topology
 
         # noinspection PyTypeChecker
         if parameter_gradient_keys == UNDEFINED or len(parameter_gradient_keys) == 0:

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party=cmiles,dask,dask_jobqueue,dateutil,distributed,mdtraj,networkx,numpy,openforcefield,openmmtools,packmol,pandas,pint,pymbar,pytest,requests,scipy,simtk,uncertainties,yaml,yank
+known_third_party=cmiles,dask,dask_jobqueue,dateutil,distributed,mdtraj,networkx,numpy,openmmtools,packmol,pandas,pint,pymbar,pytest,requests,scipy,simtk,uncertainties,yaml,yank
 
 [versioneer]
 # Automatic version numbering scheme


### PR DESCRIPTION
## Description
This PR updates references of `openforcefield` to the new `openff.toolkit` import path.

## Status
- [ ] Ready to go