### PR TITLE
Remove the Unsupported `encoding` JSON Argument

### DIFF
--- a/openff/evaluator/attributes/attributes.py
+++ b/openff/evaluator/attributes/attributes.py
@@ -162,8 +162,8 @@ class AttributeClass(TypedBaseModel):
         attribute._set_value(self, value)
 
     @classmethod
-    def parse_json(cls, string_contents, encoding="utf8"):
-        return_object = super(AttributeClass, cls).parse_json(string_contents, encoding)
+    def parse_json(cls, string_contents):
+        return_object = super(AttributeClass, cls).parse_json(string_contents)
         return_object.validate()
         return return_object
 

--- a/openff/evaluator/utils/serialization.py
+++ b/openff/evaluator/utils/serialization.py
@@ -522,7 +522,7 @@ class TypedBaseModel(ABC):
             return cls.parse_json(file.read())
 
     @classmethod
-    def parse_json(cls, string_contents, encoding="utf8"):
+    def parse_json(cls, string_contents):
         """Parses a typed json string into the corresponding class
         structure.
 
@@ -530,17 +530,13 @@ class TypedBaseModel(ABC):
         ----------
         string_contents: str or bytes
             The typed json string.
-        encoding: str
-            The encoding of the `string_contents`.
 
         Returns
         -------
         Any
             The parsed class.
         """
-        return_object = json.loads(
-            string_contents, encoding=encoding, cls=TypedJSONDecoder
-        )
+        return_object = json.loads(string_contents, cls=TypedJSONDecoder)
         return return_object
 
     @abstractmethod


### PR DESCRIPTION
## Description
From python 3.1 onwards the `encoding` argument to `json` didn't actually do anything, and was [removed in python 3.9](https://docs.python.org/3/whatsnew/3.9.html#removed). This PR removes all instances of it.

## Status
- [X] Ready to go