### PR TITLE
Support gradients of handler attributes

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -8,6 +8,15 @@ Releases follow the ``major.minor.micro`` scheme recommended by
 * ``minor`` increments add features but do not break API compatibility
 * ``micro`` increments represent bugfix releases or improvements in documentation
 
+X.X.X
+-----
+
+A patch release that ...
+
+New Features
+""""""""""""
+
+* PR `#366 <https://github.com/openforcefield/openff-evaluator/pull/366>`_: Support gradients of handler attributes.
 
 0.3.4
 -----
@@ -203,7 +212,7 @@ Breaking Changes
 0.1.2
 -----
 
-A patch release offering minor bug fixes and quality of life improvements. 
+A patch release offering minor bug fixes and quality of life improvements.
 
 Bugfixes
 """"""""
@@ -338,12 +347,12 @@ Bugfixes
 0.0.6 - Solvation Free Energies
 -------------------------------
 
-This release centers around two key changes - 
+This release centers around two key changes -
 
 i) a general refactoring of the protocol classes to be much cleaner and extensible through the removal of the old stub functions and the addition of cleaner descriptors.
 ii) the addition of workflows to estimate solvation free energies via the new ``SolvationYankProtocol`` and ``SolvationFreeEnergy`` classes.
 
-The implemented free energy workflow is still rather basic, and does not yet support calculating parameter gradients or estimation from cached simulation data through reweighting. 
+The implemented free energy workflow is still rather basic, and does not yet support calculating parameter gradients or estimation from cached simulation data through reweighting.
 
 A new table has been added to the documentation to make clear which built-in properties support which features.
 
@@ -427,11 +436,11 @@ remedied by the follow steps:
 * Change all instances of ``PropertyEstimatorClient.request_estimate(force_field=...)`` to ``PropertyEstimatorClient.request_estimate(force_field_source=...)``
 
 
-0.0.3 - ExcessMolarVolume and Typing Improvements 
+0.0.3 - ExcessMolarVolume and Typing Improvements
 -------------------------------------------------
 
 This release implements a number of bug fixes and adds two key new features, namely built in support
-for estimating excess molar volume measurements, and improved type checking for protocol inputs 
+for estimating excess molar volume measurements, and improved type checking for protocol inputs
 and outputs.
 
 New Features

--- a/openff/evaluator/utils/openmm.py
+++ b/openff/evaluator/utils/openmm.py
@@ -338,7 +338,12 @@ def system_subset(
 
     handler = force_field_subset.get_parameter_handler(parameter_key.tag)
 
-    parameter = handler.parameters[parameter_key.smirks]
+    parameter = (
+        handler
+        if parameter_key.smirks is None
+        else handler.parameters[parameter_key.smirks]
+    )
+
     parameter_value = getattr(parameter, parameter_key.attribute)
 
     # Optionally perturb the parameter of interest.


### PR DESCRIPTION
## Description

This PR adds support for computing gradients with respect to handler attributes such as the cutoff or the alpha and beta terms of the double exponential potential defined in `smirnoff-plugins`.

## Status
- [X] Ready to go