### PR TITLE
Fix #365

### DIFF
--- a/openff/evaluator/datasets/datasets.py
+++ b/openff/evaluator/datasets/datasets.py
@@ -543,7 +543,7 @@ class PhysicalPropertyDataSet(TypedBaseModel):
         from openff.evaluator import properties
 
         property_header_matches = {
-            re.match(r"^([a-zA-Z]+) Value \(([a-zA-Z0-9+-/\s]*)\)$", header)
+            re.match(r"^([a-zA-Z]+) Value \(([a-zA-Z0-9+-/\s*^]*)\)$", header)
             for header in data_frame
             if header.find(" Value ") >= 0
         }


### PR DESCRIPTION
## Description

Fixes #365. The following now successfully roundtrips:

```
x = ThermoMLDataSet.from_doi("10.1016/j.jct.2010.12.028")
y = PhysicalPropertyDataSet.from_pandas(x.to_pandas())
```

## Status
- [X] Ready to go