### PR TITLE
Fix handler attribute gradient skipped by workflow

### DIFF
--- a/openff/evaluator/tests/test_protocols/test_gradient_protocols.py
+++ b/openff/evaluator/tests/test_protocols/test_gradient_protocols.py
@@ -19,14 +19,23 @@ def test_zero_gradient():
         with open(force_field_path, "w") as file:
             file.write(build_tip3p_smirnoff_force_field().json())
 
-        gradient_key = ParameterGradientKey("vdW", "[#1]-[#8X2H2+0:1]-[#1]", "epsilon")
+        gradient_keys = [
+            ParameterGradientKey("vdW", "[#1]-[#8X2H2+0:1]-[#1]", "epsilon"),
+            ParameterGradientKey("vdW", None, "scale14"),
+        ]
 
         zero_gradients = ZeroGradients("")
         zero_gradients.input_observables = ObservableArray(value=0.0 * unit.kelvin)
-        zero_gradients.gradient_parameters = [gradient_key]
+        zero_gradients.gradient_parameters = gradient_keys
         zero_gradients.force_field_path = force_field_path
         zero_gradients.execute()
 
-        assert len(zero_gradients.output_observables.gradients) == 1
-        assert zero_gradients.output_observables.gradients[0].key == gradient_key
-        assert np.allclose(zero_gradients.output_observables.gradients[0].value, 0.0)
+        assert len(zero_gradients.output_observables.gradients) == 2
+
+        assert {
+            gradient.key for gradient in zero_gradients.output_observables.gradients
+        } == {*gradient_keys}
+
+        for gradient in zero_gradients.output_observables.gradients:
+
+            assert np.allclose(gradient.value, 0.0)

--- a/openff/evaluator/workflow/workflow.py
+++ b/openff/evaluator/workflow/workflow.py
@@ -602,7 +602,10 @@ class Workflow:
 
                 for parameter in labelled_molecule[parameter_key.tag].store.values():
 
-                    if parameter.smirks != parameter_key.smirks:
+                    if (
+                        parameter_key.smirks is not None
+                        and parameter.smirks != parameter_key.smirks
+                    ):
                         continue
 
                     contains_parameter = True


### PR DESCRIPTION
## Description

Fixes an omission in #366 noted by @jeff231li whereby the workflow code does not consider gradients of handler attributes when finding relevant gradients to computes.

## Status
- [X] Ready to go