### PR TITLE
Update filtering.py

### DIFF
--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -123,7 +123,7 @@ class FilterDuplicates(CurationComponent):
                 property_data = component_data[component_data[value_header].notna()]
 
                 if uncertainty_header in component_data:
-                    property_data = property_data.sort_values(uncertainty_header)
+                    property_data = property_data.sort_values(uncertainty_header, na_position='first')
 
                 property_data = property_data.drop_duplicates(
                     subset=subset_columns, keep="last"


### PR DESCRIPTION

## Description
Update `filtering.py` to prevent `FilterDuplicates` from selecting measurements with no uncertainty value when measurements with uncertainties are available.

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [ ] Change `na_position` default behavior to `na_position='first'`  in `pandas.sort_values` in `FilterDuplicates`

## Status
- [ ] Ready to go