### PR TITLE
Smirnoff -plugin fixes

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -39,3 +39,4 @@ dependencies:
   - paprika
   - taproom
   - dataclasses
+  - smirnoff-plugins # For testing custom nonbonded forces

--- a/openff/evaluator/forcefield/forcefield.py
+++ b/openff/evaluator/forcefield/forcefield.py
@@ -56,7 +56,7 @@ class SmirnoffForceFieldSource(ForceFieldSource):
         """
         from openff.toolkit.typing.engines import smirnoff
 
-        return smirnoff.ForceField(self._inner_xml)
+        return smirnoff.ForceField(self._inner_xml, load_plugins=True)
 
     @classmethod
     def from_object(cls, force_field):

--- a/openff/evaluator/protocols/openmm.py
+++ b/openff/evaluator/protocols/openmm.py
@@ -340,19 +340,7 @@ class OpenMMEnergyMinimisation(BaseEnergyMinimisation):
         system = self.parameterized_system.system
 
         if not self.enable_pbc:
-
-            for force_index in range(system.getNumForces()):
-
-                force = system.getForce(force_index)
-
-                if not isinstance(
-                    force, (openmm.NonbondedForce, openmm.CustomNonbondedForce)
-                ):
-                    continue
-
-                force.setNonbondedMethod(
-                    0
-                )  # NoCutoff = 0, NonbondedMethod.CutoffNonPeriodic = 1
+            disable_pbc(system=system)
 
         # TODO: Expose the constraint tolerance
         integrator = openmm.VerletIntegrator(0.002 * simtk_unit.picoseconds)

--- a/openff/evaluator/protocols/openmm.py
+++ b/openff/evaluator/protocols/openmm.py
@@ -345,7 +345,9 @@ class OpenMMEnergyMinimisation(BaseEnergyMinimisation):
 
                 force = system.getForce(force_index)
 
-                if not isinstance(force, openmm.NonbondedForce):
+                if not isinstance(
+                    force, (openmm.NonbondedForce, openmm.CustomNonbondedForce)
+                ):
                     continue
 
                 force.setNonbondedMethod(

--- a/openff/evaluator/tests/test_protocols/test_openmm.py
+++ b/openff/evaluator/tests/test_protocols/test_openmm.py
@@ -6,6 +6,15 @@ import os
 import tempfile
 from os import path
 
+import mdtraj
+import numpy
+from openff.toolkit.topology import Molecule, Topology
+from openff.toolkit.typing.engines.smirnoff import ForceField
+from simtk import unit as simtk_unit
+from smirnoff_plugins.handlers.nonbonded import DoubleExponential
+
+from openff.evaluator.forcefield import ParameterGradientKey
+from openff.evaluator.protocols.openmm import _compute_gradients, _evaluate_energies
 from openff.evaluator import unit
 from openff.evaluator.backends import ComputeResources
 from openff.evaluator.protocols.coordinates import BuildCoordinatesPackmol
@@ -161,3 +170,80 @@ def test_evaluate_energies_openmm():
 
         assert ObservableType.ReducedPotential in reduced_potentials.output_observables
         assert ObservableType.PotentialEnergy in reduced_potentials.output_observables
+
+
+def test_smirnoff_plugin_gradients():
+    molecule = Molecule.from_smiles("C")
+    molecule.generate_conformers(n_conformers=1)
+
+    conformer = molecule.conformers[0].value_in_unit(simtk_unit.nanometers)
+    conformer = numpy.vstack([conformer, conformer + 0.5])
+
+    topology = Topology.from_molecules([Molecule.from_smiles("C")] * 2)
+
+    epsilon = 0.1094
+
+    custom_handler = DoubleExponential(version="0.3")
+    custom_handler.add_parameter(
+        parameter_kwargs={
+            "smirks": "[#6X4:1]",
+            "r_min": 1.908 * simtk_unit.angstrom,
+            "epsilon": epsilon * simtk_unit.kilocalories_per_mole,
+        }
+    )
+    custom_handler.add_parameter(
+        parameter_kwargs={
+            "smirks": "[#1:1]-[#6X4]",
+            "r_min": 1.487 * simtk_unit.angstrom,
+            "epsilon": 0.0 * simtk_unit.kilocalories_per_mole,
+        }
+    )
+
+    force_field = ForceField(load_plugins=True)
+    force_field.register_parameter_handler(custom_handler)
+
+    vdw_handler = force_field.get_parameter_handler("vdW")
+    vdw_handler.add_parameter(
+        parameter_kwargs={
+            "smirks": "[*:1]",
+            "epsilon": 0.0 * simtk_unit.kilocalories_per_mole,
+            "sigma": 1.0 * simtk_unit.angstrom,
+        }
+    )
+
+    trajectory = mdtraj.Trajectory(
+        xyz=conformer.reshape((1, 10, 3)) * simtk_unit.nanometers,
+        topology=topology.to_openmm(),
+    )
+
+    observables = _evaluate_energies(
+        ThermodynamicState(
+            temperature=298.15 * unit.kelvin, pressure=1.0 * unit.atmosphere
+        ),
+        force_field.create_openmm_system(topology),
+        trajectory,
+        ComputeResources(),
+        enable_pbc=False,
+    )
+    _compute_gradients(
+        [
+            ParameterGradientKey(
+                tag="DoubleExponential", smirks="[#6X4:1]", attribute="epsilon"
+            )
+        ],
+        observables,
+        force_field,
+        ThermodynamicState(
+            temperature=298.15 * unit.kelvin, pressure=1.0 * unit.atmosphere
+        ),
+        topology,
+        trajectory,
+        ComputeResources(),
+        enable_pbc=False,
+    )
+
+    assert numpy.isclose(
+        observables[ObservableType.PotentialEnergy].gradients[0].value,
+        observables[ObservableType.PotentialEnergy].value
+        / (epsilon * unit.kilocalorie / unit.mole),
+    )

--- a/openff/evaluator/tests/test_protocols/test_openmm.py
+++ b/openff/evaluator/tests/test_protocols/test_openmm.py
@@ -13,16 +13,17 @@ from openff.toolkit.typing.engines.smirnoff import ForceField
 from simtk import unit as simtk_unit
 from smirnoff_plugins.handlers.nonbonded import DoubleExponential
 
-from openff.evaluator.forcefield import ParameterGradientKey
-from openff.evaluator.protocols.openmm import _compute_gradients, _evaluate_energies
 from openff.evaluator import unit
 from openff.evaluator.backends import ComputeResources
+from openff.evaluator.forcefield import ParameterGradientKey
 from openff.evaluator.protocols.coordinates import BuildCoordinatesPackmol
 from openff.evaluator.protocols.forcefield import BuildSmirnoffSystem
 from openff.evaluator.protocols.openmm import (
     OpenMMEnergyMinimisation,
     OpenMMEvaluateEnergies,
     OpenMMSimulation,
+    _compute_gradients,
+    _evaluate_energies,
 )
 from openff.evaluator.substances import Substance
 from openff.evaluator.tests.utils import build_tip3p_smirnoff_force_field

--- a/openff/evaluator/utils/openmm.py
+++ b/openff/evaluator/utils/openmm.py
@@ -345,8 +345,8 @@ def system_subset(
         vdw_handler.add_parameter(
             parameter_kwargs={
                 "smirks": "[*:1]",
-                "epsilon": 0.0 * unit.kilocalories_per_mole,
-                "sigma": 1.0 * unit.angstrom,
+                "epsilon": 0.0 * simtk_unit.kilocalories_per_mole,
+                "sigma": 1.0 * simtk_unit.angstrom,
             }
         )
 

--- a/openff/evaluator/utils/openmm.py
+++ b/openff/evaluator/utils/openmm.py
@@ -338,6 +338,18 @@ def system_subset(
 
     handler = force_field_subset.get_parameter_handler(parameter_key.tag)
 
+    if handler._OPENMMTYPE == openmm.CustomNonbondedForce:
+        vdw_handler = force_field_subset.get_parameter_handler("vdW")
+        # we need a generic blank parameter to work around this toolkit issue
+        # <https://github.com/openforcefield/openff-toolkit/issues/1102>
+        vdw_handler.add_parameter(
+            parameter_kwargs={
+                "smirks": "[*:1]",
+                "epsilon": 0.0 * unit.kilocalories_per_mole,
+                "sigma": 1.0 * unit.angstrom,
+            }
+        )
+
     parameter = (
         handler
         if parameter_key.smirks is None

--- a/openff/evaluator/utils/openmm.py
+++ b/openff/evaluator/utils/openmm.py
@@ -270,7 +270,7 @@ def disable_pbc(system):
 
         force = system.getForce(force_index)
 
-        if not isinstance(force, openmm.NonbondedForce):
+        if not isinstance(force, (openmm.NonbondedForce, openmm.CustomNonbondedForce)):
             continue
 
         force.setNonbondedMethod(


### PR DESCRIPTION
## Description
This PR adds some minor changes to work with smirnoff-plugin modified forcefields. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] load plugins by default

## Questions
- [x] should the `disable_pbc` function be used to consistently modify the openmm system as `_execute` re-impliments this logic.

## Status
- [x] Ready to go