### PR TITLE
Fix string formatting for new pint version

### DIFF
--- a/openff/evaluator/utils/openmm.py
+++ b/openff/evaluator/utils/openmm.py
@@ -235,7 +235,7 @@ def pint_unit_to_openmm(pint_unit):
 
     assert isinstance(pint_unit, unit.Unit)
 
-    pint_unit_string = f"{pint_unit:!s}"
+    pint_unit_string = f"{pint_unit:C}"
 
     # Handle a unit name change in pint 0.10.*
     pint_unit_string = pint_unit_string.replace("standard_atmosphere", "atmosphere")


### PR DESCRIPTION
## Description
Pint 0.18, for some reason, doesn't like the `!s` conversion in fstrings

## Todos
- [x] Make tests pass again
- [ ] Open an issue upstream

## Status
- [x] Ready for review