### PR TITLE
Handle 404 raised by requests from ThermoML

### DIFF
--- a/openff/evaluator/datasets/thermoml/thermoml.py
+++ b/openff/evaluator/datasets/thermoml/thermoml.py
@@ -2144,7 +2144,7 @@ class ThermoMLDataSet(PhysicalPropertyDataSet):
 
             return_value = cls.from_xml(request.text, source)
 
-        except HTTPError:
+        except (HTTPError, requests.exceptions.HTTPError):
             logger.warning(f"No ThermoML file could not be found at {url}")
 
         return return_value


### PR DESCRIPTION
This fixes the two tests that were failing in CI with the simplest solution I could think of that closely conforms to the existing behavior; I'm not quite sure if this was a change in ThermoML or an unrelated change in this repo.