### PR TITLE
Fix importing full ThermoML archive

### DIFF
--- a/docs/datasets/curation.rst
+++ b/docs/datasets/curation.rst
@@ -123,9 +123,7 @@ Data Extraction
     )
 
     # Import all data collected from the IJT journal.
-    data_frame = ImportThermoMLData.apply(
-        pandas.DataFrame(), ImportThermoMLDataSchema(journal_names=["IJT"])
-    )
+    data_frame = ImportThermoMLData.apply(pandas.DataFrame(), ImportThermoMLDataSchema())
 
 Filtration
 """"""""""

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -8,6 +8,21 @@ Releases follow the ``major.minor.micro`` scheme recommended by
 * ``minor`` increments add features but do not break API compatibility
 * ``micro`` increments represent bugfix releases or improvements in documentation
 
+0.3.9
+-----
+
+Bugfixes
+""""""""
+
+* PR `#402 <https://github.com/openforcefield/openff-evaluator/pull/402>`_: Fix importing full ThermoML archive
+
+Behaviour Changes
+"""""""""""""""""
+
+The way that ThermoML archive files are served was changed in 2021 so that individual journal archives are no longer
+made available. Instead, now only the full ThermoML archive can be downloaded. Because of this, the ``ImportThermoMLDataSchema``
+schema no longer allows users to select which journal to pull data from.
+
 0.3.8
 -----
 

--- a/openff/evaluator/tests/test_datasets/test_curation/test_thermoml.py
+++ b/openff/evaluator/tests/test_datasets/test_curation/test_thermoml.py
@@ -18,19 +18,20 @@ def test_import_thermoml_data(requests_mock):
     # Create a tarball to be downloaded.
     source_path = get_data_filename(os.path.join("test", "properties", "mass.xml"))
 
-    with NamedTemporaryFile(suffix="tgz") as tar_file:
+    with NamedTemporaryFile(suffix=".tgz") as tar_file:
 
         with tarfile.open(tar_file.name, "w:gz") as tar:
-            tar.add(source_path, arcname=os.path.basename(source_path))
+            tar.add(
+                source_path,
+                arcname=os.path.join("10.1021", os.path.basename(source_path)),
+            )
+
+        schema = ImportThermoMLDataSchema()
 
         with open(tar_file.name, "rb") as file:
 
-            requests_mock.get(
-                "https://trc.nist.gov/ThermoML/IJT.tgz", content=file.read()
-            )
+            requests_mock.get(schema.root_archive_url, content=file.read())
 
-        data_frame = ImportThermoMLData.apply(
-            pandas.DataFrame(), ImportThermoMLDataSchema(journal_names=["IJT"])
-        )
+        data_frame = ImportThermoMLData.apply(pandas.DataFrame(), schema)
 
         assert data_frame is not None and len(data_frame) == 1


### PR DESCRIPTION
## Description

This PR allows the full ThermoML archive to be imported again after NIST changed how the tarballs are served. Supersedes #400.

## Status
- [X] Ready to go