### PR TITLE
Fix import path in Tutorial 4

### DIFF
--- a/docs/tutorials/tutorial04.ipynb
+++ b/docs/tutorials/tutorial04.ipynb
@@ -688,7 +688,7 @@
     "evaluator_options.calculation_layers = [\"SimulationLayer\"]\n",
     "\n",
     "# Reduce the default number of molecules\n",
-    "from evaluator.properties import Density, EnthalpyOfVaporization\n",
+    "from openff.evaluator.properties import Density, EnthalpyOfVaporization\n",
     "\n",
     "density_schema = Density.default_simulation_schema(n_molecules=256)\n",
     "h_vap_schema = EnthalpyOfVaporization.default_simulation_schema(n_molecules=256)\n",


### PR DESCRIPTION
## Description
This PR fixes #416. I couldn't find any other such cases:

```
[openff-evaluator] git checkout upstream/master                                                             1896275  ✱
HEAD is now at 1896275 Use units registry provided by `openff.units` (#399)
[openff-evaluator] grep -r "from evaluator" docs openff                                                     1896275  ✱
docs/tutorials/tutorial04.ipynb:    "from evaluator.properties import Density, EnthalpyOfVaporization\n",
[openff-evaluator] git checkout fix-416                                                                     1896275  ✱
Previous HEAD position was 1896275 Use units registry provided by `openff.units` (#399)
Switched to branch 'fix-416'
[openff-evaluator] grep -r "from evaluator" docs openff                                                     fix-416  ✱
```

## Todos
  - [x] Fix import path missed during namespace migration
  - [x] Cursory check for other errors

## Questions
- [ ] 

## Status
- [x] Ready to go