### PR TITLE
Typo fix

### DIFF
--- a/openff/evaluator/utils/checkmol.py
+++ b/openff/evaluator/utils/checkmol.py
@@ -207,7 +207,7 @@ class ChemicalEnvironment(Enum):
     BoronicAcidEster = "Boronic Acid Ester"
     Alkene = "Alkene"
     Alkyne = "Alkyne"
-    Aromatic = "Aromaticatic"
+    Aromatic = "Aromatic"
     Heterocycle = "Heterocycle"
     AlphaAminoacid = "Alpha Aminoacid"
     AlphaHydroxyacid = "Alpha Hydroxyacid"


### PR DESCRIPTION
## Description
Fixed typo where "Aromatic" was written "Aromaticatic". See issue #412
