### PR TITLE
Update deprecated collections.Iterable

### DIFF
--- a/openff/evaluator/layers/layers.py
+++ b/openff/evaluator/layers/layers.py
@@ -226,7 +226,7 @@ class CalculationLayer(abc.ABC):
 
             results = list(results_future.result())
 
-            if len(results) > 0 and isinstance(results[0], collections.Iterable):
+            if len(results) > 0 and isinstance(results[0], collections.abc.Iterable):
                 results = results[0]
 
             results_future.release()


### PR DESCRIPTION
## Description
Fix error due to deprecation of `collections.Iterable`:

> `AttributeError: module 'collections' has no attribute 'Iterable'`

## Todos
  - [x] Update deprecated `collections.Iterable` to `collections.abc.Iterable` on line 229.

## Status
- [x] Ready to go