### PR TITLE
Test with `pymbar` 3 and 4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
 
   test:
 
-    name: 💻 ${{ matrix.os }}, 🐍 ${{ matrix.python-version }}, 👀 ${{ matrix.openeye }}
+    name: 💻 ${{ matrix.os }}, 🐍 ${{ matrix.python-version }}, 👀 ${{ matrix.openeye }}, pymbar ${{ matrix.pymbar-version }}
     runs-on: ${{ matrix.os }}
 
     env:
@@ -31,9 +31,13 @@ jobs:
         python-version:
           - 3.8
           - 3.9
+        pymbar-version:
+          - 3
+          - 4
         openeye:
           - true
           - false
+
 
     steps:
       - uses: actions/checkout@v3.1.0
@@ -44,6 +48,12 @@ jobs:
           environment-file: devtools/conda-envs/test_env.yaml
           extra-specs: |
             python=${{ matrix.python-version }}
+
+      - name: Install pymbar 3
+        if: ${{ matrix.pymbar-version == 3 }}
+        shell: bash -l {0}
+        run: |
+          micromamba install -c "pymbar =3" -c conda-forge -yq
 
       - name: Install OpenEye
         if: matrix.openeye

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         if: ${{ matrix.pymbar-version == 3 }}
         shell: bash -l {0}
         run: |
-          micromamba install -c "pymbar =3" -c conda-forge -yq
+          micromamba install "pymbar =3" -c conda-forge -yq
 
       - name: Install OpenEye
         if: matrix.openeye

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -17,7 +17,7 @@ dependencies:
 
     # Standard dependencies
   - openff-toolkit >=0.11.0
-  - pymbar >=4.0.0
+  - pymbar >=4
   - dask >=2.7.0
   - distributed >=2.7.0
   - dask-jobqueue >=0.8.0

--- a/openff/evaluator/tests/test_utils/test_timeseries.py
+++ b/openff/evaluator/tests/test_utils/test_timeseries.py
@@ -3,7 +3,12 @@ Units tests for openff.evaluator.utils.statistics
 """
 
 import numpy as np
-from pymbar.timeseries import detect_equilibration
+
+try:
+    from pymbar.timeseries import detect_equilibration
+except ImportError:
+    from pymbar.timeseries import detectEquilibration as detect_equilibration
+
 
 from openff.evaluator.utils.timeseries import (
     analyze_time_series,


### PR DESCRIPTION
## Description
This PR updates the test suite to be compatible with both versions 3 and 4 of `pymbar`. The API differences are not accessed in the source code so there's no obvious need to introduce more changes.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add `pymbar 3` to test matrix

## Status
- [x] Ready to go