### PR TITLE
fixes and enhancements

### DIFF
--- a/openff/evaluator/backends/backends.py
+++ b/openff/evaluator/backends/backends.py
@@ -92,6 +92,7 @@ class ComputeResources:
 
         if self._number_of_gpus > 0:
             assert self._preferred_gpu_toolkit is not None
+            assert self._number_of_gpus == 1, f'only 1 gpu per worker is supported'
 
     def __getstate__(self):
         return {

--- a/openff/evaluator/backends/dask.py
+++ b/openff/evaluator/backends/dask.py
@@ -805,14 +805,13 @@ class DaskLocalCluster(BaseDaskBackend):
             if visible_devices is None:
                 raise ValueError("The CUDA_VISIBLE_DEVICES variable is empty.")
 
+            gpu_device_indices = visible_devices.split(",")
 
-            # commented out to allow multiple calculations share one gpu through mps
-            # gpu_device_indices = visible_devices.split(",")
-            # if len(gpu_device_indices) != number_of_workers:
-            #     raise ValueError(
-            #         "The number of available GPUs {} must match "
-            #         "the number of requested workers {}."
-            #     )
+            if len(gpu_device_indices) != number_of_workers:
+                raise ValueError(
+                    "The number of available GPUs {} must match "
+                    "the number of requested workers {}."
+                )
 
     def start(self):
 
@@ -824,21 +823,16 @@ class DaskLocalCluster(BaseDaskBackend):
         )
 
         if self._resources_per_worker.number_of_gpus > 0:
-            assert self._resources_per_worker.number_of_gpus==1 
-            # round-robin assignment of available gpus
-            visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
-            gpu_device_indices = [int(id) for id in visible_devices.split(",")]
-            
 
             if isinstance(self._cluster.workers, dict):
 
                 for index, worker in self._cluster.workers.items():
-                    self._gpu_device_indices_by_worker[worker.id] = str(gpu_device_indices[index%len(gpu_device_indices)])
+                    self._gpu_device_indices_by_worker[worker.id] = str(index)
 
             else:
 
                 for index, worker in enumerate(self._cluster.workers):
-                    self._gpu_device_indices_by_worker[worker.id] = str(gpu_device_indices[index%len(gpu_device_indices)])
+                    self._gpu_device_indices_by_worker[worker.id] = str(index)
 
         super(DaskLocalCluster, self).start()
 

--- a/openff/evaluator/protocols/coordinates.py
+++ b/openff/evaluator/protocols/coordinates.py
@@ -438,7 +438,7 @@ class BuildDockedCoordinates(Protocol):
         # Assign AM1-BCC charges to the ligand just as an initial guess
         # for docking. In future, we may want to get the charge model
         # directly from the force field.
-        ligand.compute_partial_charges_am1bcc()
+        ligand.assign_partial_charges(partial_charge_method="am1bcc")
 
         return ligand.to_openeye()
 

--- a/openff/evaluator/protocols/forcefield.py
+++ b/openff/evaluator/protocols/forcefield.py
@@ -33,7 +33,10 @@ from openff.evaluator.utils.utils import (
 )
 from openff.evaluator.workflow import Protocol, workflow_protocol
 from openff.evaluator.workflow.attributes import InputAttribute, OutputAttribute
-from openff.toolkit.topology import Molecule
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from openff.toolkit.topology import Molecule
 
 logger = logging.getLogger(__name__)
 

--- a/openff/evaluator/protocols/forcefield.py
+++ b/openff/evaluator/protocols/forcefield.py
@@ -1013,7 +1013,7 @@ class BuildTLeapSystem(TemplateBuildSystem):
             os.path.join(directory, rst7_file_name),
         )
 
-    def _generate_charges(self, molecule: Molecule):
+    def _generate_charges(self, molecule: "Molecule"):
         """Generates a set of partial charges for a molecule using
         the specified charge backend.
 

--- a/openff/evaluator/protocols/reweighting.py
+++ b/openff/evaluator/protocols/reweighting.py
@@ -491,7 +491,7 @@ class BaseMBARProtocol(Protocol, abc.ABC):
             observable_dimensions = observable.value.shape[1]
             assert observable_dimensions == 1
 
-            results = mbar.computeExpectations(
+            results = mbar.compute_expectations(
                 observable.value.T.magnitude,
                 target_reduced_potentials.value.T.magnitude,
                 state_dependent=True,

--- a/openff/evaluator/tests/test_datasets/test_curation/test_freesolv.py
+++ b/openff/evaluator/tests/test_datasets/test_curation/test_freesolv.py
@@ -1,4 +1,5 @@
 import pandas
+import pytest
 
 from openff.evaluator.datasets.curation.components.freesolv import (
     ImportFreeSolv,


### PR DESCRIPTION
## Description
This PR includes multiple fixes and features.

# backends.py
restrict to one gpu per worker. I believe this is the normal case since multi-gpu running hurts the performance for the tasks supported in evaluator.

# dask.py
allow multiple workers in DaskLocalCluster backend to share one gpu through cuda-mps to improve hardware utilization and computation throughput. GPUs are assigned using round-robin assignment.

# reweighting.py
fixes `computeExpectations` for pymbar 4 API

# forcefield.py
fixes TLeap/GAFF forcefield, include:
1. incorrect charges.txt format
2. incorrect indentation leading to incorrect molecule number in assign parameter step after build coordinates
3. incorrect quit command and error log parsing when running tleap
4. outdated compute_am1bcc_charges interface to openff-toolkit

