### PR TITLE
fix tleap parameterizing and am1bcc api

### DIFF
--- a/openff/evaluator/protocols/coordinates.py
+++ b/openff/evaluator/protocols/coordinates.py
@@ -438,7 +438,7 @@ class BuildDockedCoordinates(Protocol):
         # Assign AM1-BCC charges to the ligand just as an initial guess
         # for docking. In future, we may want to get the charge model
         # directly from the force field.
-        ligand.compute_partial_charges_am1bcc()
+        ligand.assign_partial_charges(partial_charge_method="am1bcc")
 
         return ligand.to_openeye()
 

--- a/openff/evaluator/protocols/forcefield.py
+++ b/openff/evaluator/protocols/forcefield.py
@@ -8,7 +8,6 @@ import logging
 import os
 import re
 import subprocess
-import textwrap
 from enum import Enum
 
 import numpy as np
@@ -34,6 +33,10 @@ from openff.evaluator.utils.utils import (
 )
 from openff.evaluator.workflow import Protocol, workflow_protocol
 from openff.evaluator.workflow.attributes import InputAttribute, OutputAttribute
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from openff.toolkit.topology import Molecule
 
 logger = logging.getLogger(__name__)
 
@@ -439,7 +442,7 @@ class TemplateBuildSystem(BaseBuildSystem, abc.ABC):
                 for index, atom in enumerate(duplicate_molecule.atoms):
                     index_map[atom.molecule_particle_index] = index
 
-            self._append_system(system, system_template, index_map)
+                self._append_system(system, system_template, index_map)
 
         if openmm_pdb_file.topology.getPeriodicBoxVectors() is not None:
 
@@ -847,7 +850,9 @@ class BuildTLeapSystem(TemplateBuildSystem):
             charges = [x.m_as(unit.elementary_charge) for x in molecule.partial_charges]
 
             with open("charges.txt", "w") as file:
-                file.write(textwrap.fill(" ".join(map(str, charges)), width=70))
+                # file.write(textwrap.fill(" ".join(map(str, charges)), width=70))
+                file.write("\n".join(map(str, charges)))
+                file.write("\n")
 
             if force_field_source.leap_source == "leaprc.gaff2":
                 amber_type = "gaff2"
@@ -972,6 +977,7 @@ class BuildTLeapSystem(TemplateBuildSystem):
 
             with open(input_file_path, "w") as file:
                 file.write("\n".join(template_lines))
+                file.write('\nquit\n')
 
             # Run tleap.
             tleap_process = subprocess.Popen(
@@ -991,8 +997,11 @@ class BuildTLeapSystem(TemplateBuildSystem):
                 raise RuntimeError("tleap failed to execute.")
 
             with open("leap.log", "r") as file:
-
-                if re.search(
+                if re.search("Exiting LEaP: Errors = 0; Warnings = 0; Notes = 0.",
+                            file.read()):
+                    # normal exiting log
+                    pass
+                elif re.search(
                     "ERROR|WARNING|Warning|duplicate|FATAL|Could|Fatal|Error",
                     file.read(),
                 ):
@@ -1004,7 +1013,7 @@ class BuildTLeapSystem(TemplateBuildSystem):
             os.path.join(directory, rst7_file_name),
         )
 
-    def _generate_charges(self, molecule):
+    def _generate_charges(self, molecule: Molecule):
         """Generates a set of partial charges for a molecule using
         the specified charge backend.
 
@@ -1036,7 +1045,9 @@ class BuildTLeapSystem(TemplateBuildSystem):
             raise ValueError("Invalid toolkit specification.")
 
         molecule.generate_conformers(toolkit_registry=toolkit_wrapper)
-        molecule.compute_partial_charges_am1bcc(toolkit_registry=toolkit_wrapper)
+        molecule.assign_partial_charges(partial_charge_method='am1bcc',
+                                        toolkit_registry=toolkit_wrapper,
+                                        normalize_partial_charges=True)
 
     def _parameterize_molecule(self, molecule, force_field_source, cutoff):
         """Parameterize the specified molecule.
@@ -1075,6 +1086,9 @@ class BuildTLeapSystem(TemplateBuildSystem):
     def _execute(self, directory, available_resources):
 
         force_field_source = ForceFieldSource.from_json(self.force_field_path)
+
+        # print('force_field_path', self.force_field_path)
+        # print(force_field_source)
 
         if not isinstance(force_field_source, TLeapForceFieldSource):
 


### PR DESCRIPTION
## Description
fixes TLeap/GAFF forcefield, include:

1. incorrect charges.txt format
2. incorrect indentation leading to incorrect molecule number in assign parameter step after build coordinates
3. incorrect quit command and error log parsing when running tleap
4. outdated compute_am1bcc_charges interface to openff-toolkit

fix outdated api to `assign_partial_charges(partial_charge_method="am1bcc")`

I closed the previous PR #478, and this PR includes necessary changes for the TLeap backend to work properly. 
Other modifications in #478 are either reverted or will be handled by #479 .

## Todos
None

## Questions
None

## Status
- [x] Ready to go