### PR TITLE
Deprecate Yank protocols

### DIFF
--- a/openff/evaluator/protocols/yank.py
+++ b/openff/evaluator/protocols/yank.py
@@ -55,14 +55,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class YankDepcrationWarning(Warning):
+class YankDeprecrationWarning(Warning):
     pass
 
 
 warnings.warn(
     "The YANK protocol has been deprecated and will be removed in a future release. "
     "Free energy calculations will be enabled by Perses in the future.",
-    YankDepcrationWarning,
+    YankDeprecrationWarning,
 )
 
 

--- a/openff/evaluator/protocols/yank.py
+++ b/openff/evaluator/protocols/yank.py
@@ -7,6 +7,7 @@ import logging
 import os
 import shutil
 import threading
+import warnings
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
@@ -52,6 +53,17 @@ if TYPE_CHECKING:
     from openff.toolkit.typing.engines.smirnoff.forcefield import ForceField
 
 logger = logging.getLogger(__name__)
+
+
+class YankDepcrationWarning(Warning):
+    pass
+
+
+warnings.warn(
+    "The YANK protocol has been deprecated and will be removed in a future release. "
+    "Free energy calculations will be enabled by Perses in the future.",
+    YankDepcrationWarning,
+)
 
 
 class BaseYankProtocol(Protocol, abc.ABC):


### PR DESCRIPTION
```python3
>>> from openff.evaluator.protocols.yank import *
Warning on use of the timeseries module: If the inherent timescales of the system are long compared to those being analyzed, this statistical inefficiency may be an underestimate.  The estimate presumes the use of many statistically independent samples.  Tests should be performed to assess whether this condition is satisfied.   Be cautious in the interpretation of the data.
/Users/mattthompson/software/openff-evaluator/openff/evaluator/protocols/yank.py:62: YankDepcrationWarning: The YANK protocol has been deprecated and will be removed in a future release. Free energy calculations will be enabled by Perses in the future.
  warnings.warn(