### PR TITLE
Add compatibility for OpenMM 7 and 8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
 
   test:
 
-    name: 💻 ${{ matrix.os }}, 🐍 ${{ matrix.python-version }}, 👀 ${{ matrix.openeye }}, pymbar ${{ matrix.pymbar-version }}
+    name: 💻 ${{ matrix.os }}, 🐍 ${{ matrix.python-version }}, 👀 ${{ matrix.openeye }}, pymbar ${{ matrix.pymbar-version }}, OpenMM ${{ matrix.openmm-version }}
     runs-on: ${{ matrix.os }}
 
     env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,9 @@ jobs:
         pymbar-version:
           - 3
           - 4
+        openmm-version:
+          - 7
+          - 8
         openeye:
           - true
           - false
@@ -54,6 +57,11 @@ jobs:
         shell: bash -l {0}
         run: |
           micromamba install "pymbar =3" -c conda-forge -yq
+
+      - name: Update openmm version
+        shell: bash -l {0}
+        run: |
+          micromamba install "openmm =${{ matrix.openmm-version }}" -c conda-forge -yq
 
       - name: Install OpenEye
         if: matrix.openeye

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -17,7 +17,7 @@ dependencies:
 
     # Standard dependencies
   - openff-toolkit >=0.11.0
-  - openmm =7
+  - openmm =8
   - pymbar >=4
   - dask >=2.7.0
   - distributed >=2.7.0

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -9,6 +9,16 @@ Releases follow the ``major.minor.micro`` scheme recommended by
 * ``micro`` increments represent bugfix releases or improvements in documentation
 
 
+Current development
+-------------------
+
+This is the last release that will support OpenMM 7.
+
+Bugfixes
+""""""""
+
+* PR `#496 <https://github.com/openforcefield/openff-evaluator/pull/495>`_: Add support for OpenMM 8
+
 
 0.4.2
 -----

--- a/openff/evaluator/protocols/openmm.py
+++ b/openff/evaluator/protocols/openmm.py
@@ -415,10 +415,11 @@ class OpenMMSimulation(BaseSimulation):
         openmm file reporters.
         """
 
-        def __init__(self, integrator, topology, system, current_step):
+        def __init__(self, integrator, topology, system, context, current_step):
             self.integrator = integrator
             self.topology = topology
             self.system = system
+            self.context = context
             self.currentStep = current_step
 
     class _DCDReporter:
@@ -959,7 +960,13 @@ class OpenMMSimulation(BaseSimulation):
         # reporters.
         topology = app.PDBFile(self.input_coordinate_file).topology
         system = self.parameterized_system.system
-        simulation = self._Simulation(integrator, topology, system, current_step)
+        simulation = self._Simulation(
+            integrator,
+            topology,
+            system,
+            context,
+            current_step,
+        )
 
         # Perform the simulation.
         checkpoint_counter = 0


### PR DESCRIPTION
## Description
This PR adds support for both OpenMM 7 and 8.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Update `_Simulation` to include `context` attribute
  - [x] Test on OpenMM 7
  - [x] Test on OpenMM 8
  - [x] Include support plans in release notes
 
## Questions
- [ ] Question1

## Status
- [ ] Ready to go