### PR TITLE
Avoid pulling down old `jaxlib` in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,8 @@ jobs:
             python=${{ matrix.python-version }}
             pymbar=${{ matrix.pymbar-version }}
             openmm=${{ matrix.openmm-version }}
+            jax>=0.3
+            jaxlib>=0.3
 
       - name: Install OpenEye
         if: matrix.openeye

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,7 @@ jobs:
         uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: devtools/conda-envs/test_env.yaml
+          channel-priority: flexible
           extra-specs: |
             python=${{ matrix.python-version }}
             pymbar=${{ matrix.pymbar-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,12 @@ jobs:
         run: |
           micromamba install "openmm =${{ matrix.openmm-version }}" "pymbar =${{ matrix.pymbar-version }}" -c conda-forge -yq
 
+      - name: Avoid pulling down old jaxlib
+        shell: bash -l {0}
+        if: ${{ matrix.pymbar-version == 4 }}
+        run: |
+          micromamba install "jax >=3" "jaxlib >=3" -c conda-forge -yq
+
       - name: Install OpenEye
         if: matrix.openeye
         shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
           - 3.8
           - 3.9
         pymbar-version:
-          - 3
+          - 3.1
           - 4
         openmm-version:
           - 7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,17 +51,8 @@ jobs:
           environment-file: devtools/conda-envs/test_env.yaml
           extra-specs: |
             python=${{ matrix.python-version }}
-
-      - name: Update openmm, pymbar versions
-        shell: bash -l {0}
-        run: |
-          micromamba install "openmm =${{ matrix.openmm-version }}" "pymbar =${{ matrix.pymbar-version }}" -c conda-forge -yq
-
-      - name: Avoid pulling down old jaxlib
-        shell: bash -l {0}
-        if: ${{ matrix.pymbar-version == 4 }}
-        run: |
-          micromamba install "jax >=3" "jaxlib >=3" -c conda-forge -yq
+            pymbar=${{ matrix.pymbar-version }}
+            openmm=${{ matrix.openmm-version }}
 
       - name: Install OpenEye
         if: matrix.openeye

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -17,8 +17,8 @@ dependencies:
 
     # Standard dependencies
   - openff-toolkit >=0.11.0
-  - openmm =7.7|8
-  - pymbar =3|4
+  - openmm
+  - pymbar
   - dask >=2.7.0
   - distributed >=2.7.0
   - dask-jobqueue >=0.8.0

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -17,7 +17,7 @@ dependencies:
 
     # Standard dependencies
   - openff-toolkit >=0.11.0
-  - openmm =8
+  - openmm =7.7|8
   - pymbar =3|4
   - dask >=2.7.0
   - distributed >=2.7.0


### PR DESCRIPTION
## Description
Old, incompatible versions of JAX are pulled down in [CI](https://github.com/openforcefield/openff-evaluator/actions/runs/4394859794/jobs/7696189794).

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Ensure old versions not installed in CI

## Questions
- [ ] Why is this happening? The `pymbar` feedstock includes [questionable dependency definitions](https://github.com/conda-forge/pymbar-feedstock/blob/main/recipe/meta.yaml#L34-L35) that might cause the solver issues

## Status
- [x] Ready to go