### PR TITLE
Add link to OpenFF install guide

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,14 +33,12 @@ jobs:
           - 3.9
         pymbar-version:
           - 3.1
-          - 4
         openmm-version:
           - 7
           - 8
         openeye:
           - true
           - false
-
 
     steps:
       - uses: actions/checkout@v3

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -17,7 +17,7 @@ dependencies:
     - distributed >=2.7.0
     - dask-jobqueue >=0.7.0,<=0.8.0
     - uncertainties
-    - openmmtools
+    - openmmtools =0.21.5
     - yank >=0.25.2
     - pyyaml
     - requests

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -24,7 +24,7 @@ dependencies:
   - distributed >=2.7.0
   - dask-jobqueue >=0.8.0
   - uncertainties
-  - openmmtools
+  - openmmtools =0.21.5
   - yank >=0.25.2
   - pyyaml
   - requests

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,6 +128,10 @@ intersphinx_mapping = {
         None,
     ),
     "pint": ("https://pint.readthedocs.io/en/latest/", None),
+    "openff.docs": (
+        "https://docs.openforcefield.org/en/latest/",
+        None,
+    ),
 }
 
 # Set up mathjax.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,6 +16,8 @@ To install the ``openff-evaluator`` from the ``conda-forge`` channel simply run:
 
     conda install -c conda-forge openff-evaluator
 
+If you do not have Conda installed, see the `OpenFF installation guide <openff.docs:install>`_.
+
 Recommended Dependencies
 ------------------------
 


### PR DESCRIPTION
Adds a link to the [ecosystem install guide](https://docs.openforcefield.org/en/latest/install.html) to the project install guide

## Status
- [x] Ready to go