### PR TITLE
Provide bond lengths in virtual site tests

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -14,14 +14,10 @@ dependencies:
   - nbval
   - requests-mock # For testing http requests.
   # smirnoff-plugins =0.0.3
-  - coverage >=4.4
   - foyer
 
-    # Shims
-  - pint =0.20.1
-
     # Standard dependencies
-  - openff-toolkit >=0.11.0
+  - openff-toolkit >=0.14.3
   - openmm
   - pymbar
   - dask >=2.7.0

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -16,8 +16,8 @@ dependencies:
   # smirnoff-plugins =0.0.3
   - foyer
 
-    # Shim
-  - openff-units =0.2.0
+    # Shims
+  - pint =0.20.1
 
     # Standard dependencies
   - openff-toolkit >=0.14.3

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -16,6 +16,9 @@ dependencies:
   # smirnoff-plugins =0.0.3
   - foyer
 
+    # Shim
+  - openff-units =0.2.0
+
     # Standard dependencies
   - openff-toolkit >=0.14.3
   - openmm


### PR DESCRIPTION
## Description
The most recent version of Interchange determines virtual site positions based on geometries determined by the force field, which broke some tests. I think they previously used the atomic coordinates, which might not accurately represent the force field geometries.