### PR TITLE
Use interchange to create openmm system over openff-toolkit

### DIFF
--- a/openff/evaluator/protocols/forcefield.py
+++ b/openff/evaluator/protocols/forcefield.py
@@ -562,10 +562,16 @@ class BuildSmirnoffSystem(BaseBuildSystem):
             pdb_file.topology, unique_molecules=unique_molecules
         )
 
-        interchange = Interchange.from_smirnoff(topology=topology, force_field=force_field)
+        interchange = Interchange.from_smirnoff(
+            topology=topology, force_field=force_field
+        )
         # Do not combine nonbonded forces if any forcefield collection is a plugin
-        combine_nonbonded_forces = not any([collection.is_plugin for collection in interchange.collections.values()])
-        system = interchange.to_openmm(combine_nonbonded_forces=combine_nonbonded_forces)
+        combine_nonbonded_forces = not any(
+            [collection.is_plugin for collection in interchange.collections.values()]
+        )
+        system = interchange.to_openmm(
+            combine_nonbonded_forces=combine_nonbonded_forces
+        )
 
         if system is None:
             raise RuntimeError(

--- a/openff/evaluator/protocols/forcefield.py
+++ b/openff/evaluator/protocols/forcefield.py
@@ -13,6 +13,7 @@ from enum import Enum
 import numpy as np
 import openmm
 import requests
+from openff.interchange import Interchange
 from openff.units import unit
 from openff.units.openmm import to_openmm
 from openmm import app
@@ -561,7 +562,10 @@ class BuildSmirnoffSystem(BaseBuildSystem):
             pdb_file.topology, unique_molecules=unique_molecules
         )
 
-        system = force_field.create_openmm_system(topology)
+        interchange = Interchange.from_smirnoff(topology=topology, force_field=force_field)
+        # Do not combine nonbonded forces if any forcefield collection is a plugin
+        combine_nonbonded_forces = not any([collection.is_plugin for collection in interchange.collections.values()])
+        system = interchange.to_openmm(combine_nonbonded_forces=combine_nonbonded_forces)
 
         if system is None:
             raise RuntimeError(


### PR DESCRIPTION
## Description
Use openff interchange to create openmm system over the openff-toolkit's create_openmm_system

## Todos
Notable points that this PR has either accomplished or will accomplish.
 - [ ] Test with real world simulations

## Status
 - [ ] Ready to go