### PR TITLE
Include `VirtualSiteHandler` and dependencies in gradient subset

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -10,6 +10,7 @@ dependencies:
     # Testing and development
   - pytest
   - pytest-cov
+  - pytest-xdist
   - pytest-randomly
   - nbval
   - requests-mock # For testing http requests.

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -11,6 +11,8 @@ Releases follow the ``major.minor.micro`` scheme recommended by
 Current development
 ---------------------
 
+* PR `#534 <https://github.com/openforcefield/openff-evaluator/pull/534>`_: Includes virtual site and related parameters in ``openmm.system`` subset creation when calculating gradients.
+
 * PR `#532 <https://github.com/openforcefield/openff-evaluator/pull/532>`_: Changes ``BaseEnergyMinimisation.tolerance`` to use units of force.
 
 0.4.5 - July 24, 2023

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -11,14 +11,11 @@ Releases follow the ``major.minor.micro`` scheme recommended by
 Current development
 ---------------------
 
-<<<<<<< HEAD
 * PR `#534 <https://github.com/openforcefield/openff-evaluator/pull/534>`_: Includes virtual site and related parameters in ``openmm.system`` subset creation when calculating gradients.
-=======
 * PR `#533 <https://github.com/openforcefield/openff-evaluator/pull/533>`_: Considers ``openmm.AmoebaMultipoleForce`` when disabling PBC.
 
 0.4.6 - October 12, 2023
 ------------------------
->>>>>>> upstream/main
 
 * PR `#532 <https://github.com/openforcefield/openff-evaluator/pull/532>`_: Changes ``BaseEnergyMinimisation.tolerance`` to use units of force.
 

--- a/openff/evaluator/tests/test_utils/test_openmm.py
+++ b/openff/evaluator/tests/test_utils/test_openmm.py
@@ -358,6 +358,10 @@ def test_system_subset_charge_increment():
 )
 def test_system_subset_virtual_site_water(add_nonwater):
     from openff.interchange.drivers.openmm import _get_openmm_energies
+    from packaging.version import Version
+
+    if Version(openmm.__version__).major == 7:
+        pytest.skip("OPC was added in OpenMM 8")
 
     # Create a dummy topology
     water = Molecule.from_mapped_smiles("[H:2][O:1][H:3]")

--- a/openff/evaluator/utils/openmm.py
+++ b/openff/evaluator/utils/openmm.py
@@ -199,7 +199,6 @@ def system_subset(
         # conformer's geometry likely does not match the force field geometry
         handlers_to_register.update(
             {
-                "vdW",
                 "Bonds",
                 "Constraints",
             },

--- a/openff/evaluator/utils/openmm.py
+++ b/openff/evaluator/utils/openmm.py
@@ -199,6 +199,7 @@ def system_subset(
         # conformer's geometry likely does not match the force field geometry
         handlers_to_register.update(
             {
+                "vdW",
                 "Bonds",
                 "Constraints",
             },

--- a/openff/evaluator/utils/openmm.py
+++ b/openff/evaluator/utils/openmm.py
@@ -179,21 +179,28 @@ def system_subset(
 
     handlers_to_register = {parameter_key.tag}
 
-    if parameter_key.tag in {"ChargeIncrementModel", "LibraryCharges"}:
-        # Make sure to retain all of the electrostatic handlers when dealing with
-        # charges as the applied charges will depend on which charges have been applied
-        # by previous handlers.
-        handlers_to_register.update(
-            {"Electrostatics", "ChargeIncrementModel", "LibraryCharges"}
-        )
-
-    if parameter_key.tag in {"VirtualSites"}:
+    if parameter_key.tag in {"ChargeIncrementModel", "LibraryCharges", "VirtualSites"}:
+        # Make sure to retain _all_ of the electrostatic handlers when dealing with any handler
+        # that might modify changes as the applied charges will depend on which charges have been
+        # applied by previous handlers.
         handlers_to_register.update(
             {
                 "Electrostatics",
-                "vdW",
-                "LibraryCharges",
                 "ChargeIncrementModel",
+                "LibraryCharges",
+                "VirtualSiteHandler",
+                "ToolkitAM1BCC",
+            }
+        )
+
+    if parameter_key.tag in {"VirtualSites"}:
+        # Interchange's current implementation uses bonds and constraints to determine the values
+        # OpenMM needs for virtual sites; using positions might not produce accurate results since a
+        # conformer's geometry likely does not match the force field geometry
+        handlers_to_register.update(
+            {
+                "vdW",
+                "Bonds",
                 "Constraints",
             },
         )

--- a/openff/evaluator/utils/openmm.py
+++ b/openff/evaluator/utils/openmm.py
@@ -187,6 +187,17 @@ def system_subset(
             {"Electrostatics", "ChargeIncrementModel", "LibraryCharges"}
         )
 
+    if parameter_key.tag in {"VirtualSites"}:
+        handlers_to_register.update(
+            {
+                "Electrostatics",
+                "vdW",
+                "LibraryCharges",
+                "ChargeIncrementModel",
+                "Constraints",
+            },
+        )
+
     registered_handlers = force_field.registered_parameter_handlers
 
     for handler_to_register in handlers_to_register:


### PR DESCRIPTION
## Description
This PR is a minimal change to get [this](https://github.com/openforcefield/openff-evaluator/issues/486#issuecomment-1658941800) snippet running without (obvious) error.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Include `VirtualSiteHandler` in system subset
  - [x] Include `VirtualSiteHandler`'s dependencies in system subset
  - [x] Add test(s)
    - [x] Halving (`scale_amount=-0.5`) `distance` parameter in OPC
    - [x] Nothing weird happens mixing molecules with and without virtual sites applied
    - [x] OpenMM energies can be evaluated

## Questions
- [ ] Question1

## Status
- [ ] Ready to go