### PR TITLE
Fix versioneer parsing version prefix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,5 +26,5 @@ VCS = git
 style = pep440
 versionfile_source = openff/evaluator/_version.py
 versionfile_build = openff/evaluator/_version.py
-tag_prefix = ''
+tag_prefix = v
 parentdir_prefix = openff-evaluator-


### PR DESCRIPTION
```shell
$ git checkout upstream/main && python setup.py version && git checkout - && python setup.py version
Note: switching to 'upstream/main'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at e053535 Update versioneer (#537)
/Users/mattthompson/mambaforge/envs/evaluator-test-env/lib/python3.11/site-packages/setuptools/dist.py:314: InformationOnly: Normalizing '0.1.0-beta.4+211.ge053535' to '0.1.0b4+211.ge053535'
  self.metadata.version = self._normalize_version(
running version
keywords are unexpanded, not using
got version from VCS {'version': '0.1.0-beta.4+211.ge053535', 'full-revisionid': 'e05353572f87aa42129b00f62c3f98f405356fc7', 'dirty': False, 'error': None, 'date': '2023-10-19T09:36:53-0500'}
Version: 0.1.0-beta.4+211.ge053535
 full-revisionid: e05353572f87aa42129b00f62c3f98f405356fc7
 dirty: False
 date: 2023-10-19T09:36:53-0500
Previous HEAD position was e053535 Update versioneer (#537)
Switched to branch 'fix-versioneer'
running version
keywords are unexpanded, not using
got version from VCS {'version': '0.4.7+3.gdafc597', 'full-revisionid': 'dafc597f59c6859e473c5634ee29b0f60eae0630', 'dirty': False, 'error': None, 'date': '2023-11-06T10:08:45-0600'}
Version: 0.4.7+3.gdafc597
 full-revisionid: dafc597f59c6859e473c5634ee29b0f60eae0630
 dirty: False
 date: 2023-11-06T10:08:45-0600