### PR TITLE
Remove use of `pkg_resources`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,13 +4,15 @@ on:
   push:
     branches:
       - "main"
-      - "v0-3-x"
   pull_request:
     branches:
       - "main"
-      - "v0-3-x"
   schedule:
     - cron: "0 0 * * *"
+
+defaults:
+  run:
+    shell: bash -l {0}
 
 jobs:
 
@@ -59,7 +61,6 @@ jobs:
 
       - name: Install OpenEye
         if: matrix.openeye
-        shell: bash -l {0}
         run: |
           echo "${SECRET_OE_LICENSE}" > ${OE_LICENSE}
 
@@ -69,19 +70,14 @@ jobs:
           SECRET_OE_LICENSE: ${{ secrets.OE_LICENSE }}
 
       - name: Install PASCAL Compiler (MacOS)
-        shell: bash -l {0}
         if: startsWith(matrix.os, 'macOS')
-        run: |
-          brew install fpc
+        run: brew install fpc
 
       - name: Install PASCAL Compiler (Ubuntu)
-        shell: bash -l {0}
         if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          sudo apt-get install fp-compiler
+        run: sudo apt-get install fp-compiler
 
       - name: Install checkmol
-        shell: bash -l {0}
         run: |
 
           curl https://homepage.univie.ac.at/norbert.haider/download/chemistry/checkmol/checkmol.pas > checkmol.pas
@@ -89,26 +85,16 @@ jobs:
 
           echo $(pwd) >> $GITHUB_PATH
 
-      - name: Install Package
-        shell: bash -l {0}
-        run: |
-
-          python -m pip install .
+      - name: Install Package and test plugins
+        run: python -m pip install . utilities/test_plugins/
 
       - name: Conda Environment Information
-        shell: bash -l {0}
-        run: |
-          conda info
-          conda list
+        run: conda info && conda list
 
       - name: Run tests
-        shell: bash -l {0}
-        run: |
-
-          python -m pytest -v --cov=openff openff/evaluator/_tests/ --cov-report=xml --color=yes
+        run: python -m pytest -v --cov=openff openff/evaluator/_tests/ --cov-report=xml --color=yes
 
       - name: Run (non-GPU) tutorials
-        shell: bash -l {0}
         if: ${{ matrix.pymbar-version == 3 }}
         run: |
           # ForceBalance requires pymbar 3, so don't run these tests if we are using pymbar 4,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,21 @@
 ci:
   autoupdate_schedule: "monthly"
+files: (^openff|^utilities|^integration-tests)
 repos:
 - repo: https://github.com/psf/black
   rev: 23.9.1
   hooks:
   - id: black
-    files: (^openff|^integration-tests)
   - id: black-jupyter
     files: ^docs/tutorials
 - repo: https://github.com/PyCQA/isort
   rev: 5.12.0
   hooks:
   - id: isort
-    files: (^openff|^integration-tests)
 - repo: https://github.com/PyCQA/flake8
   rev: 6.1.0
   hooks:
   - id: flake8
-    files: (^openff|^integration-tests)
 - repo: https://github.com/nbQA-dev/nbQA
   rev: 1.7.0
   hooks:

--- a/openff/evaluator/_tests/test_plugins.py
+++ b/openff/evaluator/_tests/test_plugins.py
@@ -1,8 +1,6 @@
 """
 Units tests for the openff.evaluator.plugins module.
 """
-import pkg_resources
-
 from openff.evaluator.layers import (
     registered_calculation_layers,
     registered_calculation_schemas,
@@ -20,35 +18,8 @@ def test_register_default_plugins():
 
 
 def test_register_external_plugins(caplog):
-    """This test is based on `this stack overflow answer
-    <https://stackoverflow.com/a/48666503/11808960>`_
-    """
-
-    # Create a fake distribution to insert into the global working_set
-    distribution = pkg_resources.Distribution(__file__)
-
-    # Create the fake entry point definitions
-    valid_entry_point = pkg_resources.EntryPoint.parse(
-        "dummy_1 = openff.evaluator.properties", dist=distribution
-    )
-    bad_entry_point = pkg_resources.EntryPoint.parse(
-        "dummy_2 = openff.evaluator.propertis", dist=distribution
-    )
-
-    # Add the mapping to the fake EntryPoint
-    distribution._ep_map = {
-        "openff_evaluator.plugins": {
-            "dummy_1": valid_entry_point,
-            "dummy_2": bad_entry_point,
-        }
-    }
-
-    # Add the fake distribution to the global working_set
-    pkg_resources.working_set.add(distribution, "dummy_1")
-    pkg_resources.working_set.add(distribution, "dummy_2")
-
     register_external_plugins()
 
     # Check that we could / couldn't load the correct plugins.
-    assert "Could not load the dummy_1" not in caplog.text
-    assert "Could not load the dummy_2" in caplog.text
+    assert "Could not load the Dummy1 plugin" not in caplog.text
+    assert "Could not load the Dummy2 plugin" in caplog.text

--- a/openff/evaluator/_tests/test_plugins.py
+++ b/openff/evaluator/_tests/test_plugins.py
@@ -1,12 +1,20 @@
 """
 Units tests for the openff.evaluator.plugins module.
 """
+import sys
+
 from openff.evaluator.layers import (
     registered_calculation_layers,
     registered_calculation_schemas,
 )
 from openff.evaluator.plugins import register_default_plugins, register_external_plugins
 from openff.evaluator.workflow import registered_workflow_protocols
+
+if sys.version_info[1] < 10:
+    # Backport only for Python 3.9 - drop April 2024
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
 
 
 def test_register_default_plugins():
@@ -18,8 +26,14 @@ def test_register_default_plugins():
 
 
 def test_register_external_plugins(caplog):
+    """This test wass based on `this stack overflow answer
+    <https://stackoverflow.com/a/48666503/11808960>`_, but it relied on
+    functionality not present in `importlib.metadata`.
+    """
     register_external_plugins()
+    names = {
+        entry_point.name
+        for entry_point in entry_points().select(group="openff_evaluator.plugins")
+    }
 
-    # Check that we could / couldn't load the correct plugins.
-    assert "Could not load the Dummy1 plugin" not in caplog.text
-    assert "Could not load the Dummy2 plugin" in caplog.text
+    assert names == {"DummyPlugin"}

--- a/openff/evaluator/datasets/taproom/taproom.py
+++ b/openff/evaluator/datasets/taproom/taproom.py
@@ -431,7 +431,13 @@ class TaproomDataSet(PhysicalPropertyDataSet):
             Whether to add the metadata required for an APR based calculation
             using the ``paprika`` based workflow.
         """
-        from importlib.metadata import entry_points
+        import sys
+
+        if sys.version_info[1] < 10:
+            # Backport only for Python 3.9 - drop April 2024
+            from importlib_metadata import entry_points
+        else:
+            from importlib.metadata import entry_points
 
         installed_benchmarks = {}
 

--- a/openff/evaluator/datasets/taproom/taproom.py
+++ b/openff/evaluator/datasets/taproom/taproom.py
@@ -6,7 +6,6 @@ import logging
 import os
 from typing import Any, Dict, List, Optional
 
-import pkg_resources
 import yaml
 from openff.units import unit
 
@@ -432,10 +431,11 @@ class TaproomDataSet(PhysicalPropertyDataSet):
             Whether to add the metadata required for an APR based calculation
             using the ``paprika`` based workflow.
         """
+        from importlib.metadata import entry_points
 
         installed_benchmarks = {}
 
-        for entry_point in pkg_resources.iter_entry_points(group="taproom.benchmarks"):
+        for entry_point in entry_points().select(group="taproom.benchmarks"):
             installed_benchmarks[entry_point.name] = entry_point.load()
 
         if len(installed_benchmarks) == 0:

--- a/openff/evaluator/plugins.py
+++ b/openff/evaluator/plugins.py
@@ -42,8 +42,8 @@ def register_external_plugins():
     plugin system.
     """
 
-    for entry_point in entry_points().select(group="openff.evaluator.plugins"):
+    for entry_point in entry_points().select(group="openff_evaluator.plugins"):
         try:
             entry_point.load()
         except ImportError:
-            logger.exception(f"Could not load the {entry_point} plugin")
+            logger.exception(f"Could not load the {entry_point.name} plugin")

--- a/openff/evaluator/plugins.py
+++ b/openff/evaluator/plugins.py
@@ -6,7 +6,14 @@ physical properties.
 import importlib
 import logging
 import pkgutil
-from importlib.metadata import entry_points
+import sys
+
+if sys.version_info[1] < 10:
+    # Backport only for Python 3.9 - drop April 2024
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
+
 
 logger = logging.getLogger(__name__)
 

--- a/openff/evaluator/plugins.py
+++ b/openff/evaluator/plugins.py
@@ -6,8 +6,7 @@ physical properties.
 import importlib
 import logging
 import pkgutil
-
-import pkg_resources
+from importlib.metadata import entry_points
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +35,7 @@ def register_external_plugins():
     plugin system.
     """
 
-    for entry_point in pkg_resources.iter_entry_points("openff_evaluator.plugins"):
+    for entry_point in entry_points().select(group="openff.evaluator.plugins"):
         try:
             entry_point.load()
         except ImportError:

--- a/openff/evaluator/utils/utils.py
+++ b/openff/evaluator/utils/utils.py
@@ -1,17 +1,16 @@
 """
 A collection of general utilities.
 """
-import contextlib
 import logging
 import os
 import sys
-from tempfile import TemporaryDirectory
-from typing import Optional
+
+from openff.utilities.utilities import get_data_file_path, temporary_cd
 
 from openff.evaluator.utils.string import extract_variable_index_and_name
 
 
-def get_data_filename(relative_path):
+def get_data_filename(relative_path: str) -> str:
     """Get the full path to one of the reference files in data.
 
     In the source distribution, these files are in ``evaluator/data/``,
@@ -22,19 +21,16 @@ def get_data_filename(relative_path):
     ----------
     relative_path : str
         The relative path of the file to load.
+
+    Returns
+    -------
+        The absolute path to the file.
+
     """
 
-    from pkg_resources import resource_filename
-
-    fn = resource_filename("openff.evaluator", os.path.join("data", relative_path))
-
-    if not os.path.exists(fn):
-        raise ValueError(
-            "Sorry! %s does not exist. If you just added it, you'll have to re-install"
-            % fn
-        )
-
-    return fn
+    return get_data_file_path(
+        relative_path=relative_path, package_name="openff.evaluator"
+    )
 
 
 def timestamp_formatter() -> logging.Formatter:
@@ -214,38 +210,7 @@ def set_nested_attribute(containing_object, name, value):
         setattr(current_attribute, attribute_name, value)
 
 
-@contextlib.contextmanager
-def temporarily_change_directory(directory_path: Optional[str] = None):
-    """Temporarily move the current working directory to the path
-    specified. If no path is given, a temporary directory will be
-    created, moved into, and then destroyed when the context manager
-    is closed.
-
-    Parameters
-    ----------
-    directory_path
-        The directory to change into. If None, a temporary directory will
-        be created and changed into.
-    """
-
-    if directory_path is not None and len(directory_path) == 0:
-        yield
-        return
-
-    old_directory = os.getcwd()
-
-    try:
-        if directory_path is None:
-            with TemporaryDirectory() as new_directory:
-                os.chdir(new_directory)
-                yield
-
-        else:
-            os.chdir(directory_path)
-            yield
-
-    finally:
-        os.chdir(old_directory)
+temporarily_change_directory = temporary_cd
 
 
 def has_openeye():

--- a/utilities/test_plugins/evaluator_plugins/__init__.py
+++ b/utilities/test_plugins/evaluator_plugins/__init__.py
@@ -1,0 +1,1 @@
+from evaluator_plugins.plugins import Dummy1, Dummy2

--- a/utilities/test_plugins/evaluator_plugins/__init__.py
+++ b/utilities/test_plugins/evaluator_plugins/__init__.py
@@ -1,1 +1,0 @@
-from evaluator_plugins.plugins import Dummy1, Dummy2

--- a/utilities/test_plugins/evaluator_plugins/plugins.py
+++ b/utilities/test_plugins/evaluator_plugins/plugins.py
@@ -1,7 +1,2 @@
-class Dummy1:
+class DummyPlugin:
     pass
-
-class Dummy2:
-    raise ImportError(
-        "This plugin should not be loaded; raise an ImportError to mock this."
-    )

--- a/utilities/test_plugins/evaluator_plugins/plugins.py
+++ b/utilities/test_plugins/evaluator_plugins/plugins.py
@@ -1,0 +1,7 @@
+class Dummy1:
+    pass
+
+class Dummy2:
+    raise ImportError(
+        "This plugin should not be loaded; raise an ImportError to mock this."
+    )

--- a/utilities/test_plugins/setup.py
+++ b/utilities/test_plugins/setup.py
@@ -10,8 +10,7 @@ setup(
     include_package_data=True,
     entry_points={
         "openff_evaluator.plugins": [
-            "Dummy1 = evaluator_plugins.plugins:Dummy1",
-            "Dummy2 = evaluator_plugins.plugins:Dummy2",
+            "DummyPlugin = evaluator_plugins.plugins:DummyPlugin",
         ]
     },
 )

--- a/utilities/test_plugins/setup.py
+++ b/utilities/test_plugins/setup.py
@@ -1,0 +1,17 @@
+"""
+test-evaluator-plugins
+A test package used to ensure that parameterhandler plugins are handled correctly
+"""
+from setuptools import setup
+
+setup(
+    name="test_evaluator_plugins",
+    packages=["evaluator_plugins"],
+    include_package_data=True,
+    entry_points={
+        "openff_evaluator.plugins": [
+            "Dummy1 = evaluator_plugins.plugins:Dummy1",
+            "Dummy2 = evaluator_plugins.plugins:Dummy2",
+        ]
+    },
+)


### PR DESCRIPTION
## Description
This PR migrates entry point management and testing to use `importlib.metadata` instead of the deprecated (as an PI) `pkg_resources`. Resolves #505 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Update property plugin management
  - [x] Update taproom plugin management
  - [x] Refactor some common utility functions
  - [x] Update tests

## Status
- [ ] Ready to go