### PR TITLE
Catch Packmol exiting

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -8,6 +8,11 @@ Releases follow the ``major.minor.micro`` scheme recommended by
 * ``minor`` increments add features but do not break API compatibility
 * ``micro`` increments represent bugfix releases or improvements in documentation
 
+Current development
+-------------------
+
+* PR `#555 <https://github.com/openforcefield/openff-evaluator/pull/555>`_: More gracefully handle Packmol failures.
+
 0.4.8 - January 30, 2024
 ------------------------
 

--- a/openff/evaluator/utils/packmol.py
+++ b/openff/evaluator/utils/packmol.py
@@ -704,9 +704,12 @@ def pack_box(
         )
 
         with open(input_file_path) as file_handle:
-            result = subprocess.check_output(
-                packmol_path, stdin=file_handle, stderr=subprocess.STDOUT
-            ).decode("utf-8")
+            try:
+                result = subprocess.check_output(
+                    packmol_path, stdin=file_handle, stderr=subprocess.STDOUT
+                ).decode("utf-8")
+            except subprocess.CalledProcessError as error:
+                raise PackmolRuntimeException from error
 
             if verbose:
                 logger.info(result)


### PR DESCRIPTION
## Description
After https://github.com/conda-forge/ambertools-feedstock/pull/137, the vendored packmol might be installed. It has different behavior when failing to arrive at a solution. This patch attempts to minimally capture those failures and raise Evaluator's general "Packmol failed" exception.