### PR TITLE
Updates for `pint >=0.21`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,6 +117,7 @@ jobs:
       - name: Code coverage
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           flags: unittests
           name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -16,7 +16,7 @@ dependencies:
   - foyer
 
     # Shim
-  - pint =0.20.1
+  - pint >=0.21,<0.25
 
     # Standard dependencies
   - openff-toolkit >=0.14.3

--- a/openff/evaluator/forcefield/gradients.py
+++ b/openff/evaluator/forcefield/gradients.py
@@ -160,4 +160,6 @@ class ParameterGradient:
         )
 
 
-pint.compat.upcast_types.append(ParameterGradient)
+pint.compat.upcast_type_map[
+    "openff.evaluator.forcefield.gradients.ParameterGradient"
+] = ParameterGradient

--- a/openff/evaluator/utils/observables.py
+++ b/openff/evaluator/utils/observables.py
@@ -872,5 +872,9 @@ def bootstrap(
     )
 
 
-pint.compat.upcast_types.append(Observable)
-pint.compat.upcast_types.append(ObservableArray)
+pint.compat.upcast_type_map.update(
+    {
+        "openff.evaluator.utils.observables.Observable": Observable,
+        "openff.evaluator.utils.observables.ObservableArray": ObservableArray,
+    }
+)


### PR DESCRIPTION
## Description
There is a `pint =0.20.1` shim in place which I neglected to fix in the past year or two. The API break is minor but hidden in a submodule.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Provide compatibility for `pint >=0.21`


## Status
- [ ] Ready to go