### PR TITLE
Scale MW back by Avogadro's number

### DIFF
--- a/openff/evaluator/_tests/test_datasets/test_thermoml.py
+++ b/openff/evaluator/_tests/test_datasets/test_thermoml.py
@@ -2,21 +2,20 @@
 Units tests for openff.evaluator.datasets
 """
 
+import numpy as np
 import pytest
 from openff.units import unit
-
-import numpy as np
-
 
 from openff.evaluator.attributes import UNDEFINED
 from openff.evaluator.datasets import PhysicalProperty, PropertyPhase
 from openff.evaluator.datasets.thermoml import thermoml_property
 from openff.evaluator.datasets.thermoml.thermoml import (
     ThermoMLDataSet,
-    _unit_from_thermoml_string,
-    _PureOrMixtureData,
-    _Constraint, _ConstraintType,
     _Compound,
+    _Constraint,
+    _ConstraintType,
+    _PureOrMixtureData,
+    _unit_from_thermoml_string,
 )
 from openff.evaluator.plugins import register_default_plugins
 from openff.evaluator.properties import EnthalpyOfMixing
@@ -229,7 +228,6 @@ def test_thermoml_mole_constraints():
     assert len(data_set) > 0
 
 
-
 class TestPureOrMixtureData:
 
     @staticmethod
@@ -244,15 +242,12 @@ class TestPureOrMixtureData:
 
         return solute, solvent
 
-    @pytest.mark.parametrize("molality, expected_mole_fraction", [
-        (1.0, 0.0176965),
-        (0.0, 0.0),
-        (55.508, 0.5)
-    ])
+    @pytest.mark.parametrize(
+        "molality, expected_mole_fraction",
+        [(1.0, 0.0176965), (0.0, 0.0), (55.508, 0.5)],
+    )
     def test_convert_molality_no_solvent_provided(
-        self,
-        molality: float,
-        expected_mole_fraction: float
+        self, molality: float, expected_mole_fraction: float
     ):
         constraint = _Constraint()
         constraint.type = _ConstraintType.ComponentMolality
@@ -282,7 +277,7 @@ class TestPureOrMixtureData:
             (1.0, 1.0),
             (0.0, 0.0),
             (0.5, 0.528962),
-        ]
+        ],
     )
     def test_convert_mass_fractions(
         self,
@@ -312,14 +307,13 @@ class TestPureOrMixtureData:
             atol=1e-5,
         )
 
-
     @pytest.mark.parametrize(
         "mole_fraction, expected_solute_moles, expected_solvent_moles",
         [
             (1.0, 62.33416, 0.0),
             (0.0, 0.0, 55.5084),
             (0.5, 29.36177, 29.36177),
-        ]
+        ],
     )
     def test_solvent_mole_fractions_to_moles(
         self,
@@ -328,10 +322,7 @@ class TestPureOrMixtureData:
         expected_solvent_moles: float,
     ):
         solvent_mass = 1 * unit.kilogram
-        solvent_mole_fractions = {
-            0: mole_fraction,
-            1: 1 - mole_fraction
-        }
+        solvent_mole_fractions = {0: mole_fraction, 1: 1 - mole_fraction}
         solvent_compounds = dict(enumerate(self._generate_dummy_compounds()))
         moles = _PureOrMixtureData._solvent_mole_fractions_to_moles(
             solvent_mass,

--- a/openff/evaluator/datasets/thermoml/thermoml.py
+++ b/openff/evaluator/datasets/thermoml/thermoml.py
@@ -1709,7 +1709,7 @@ class ThermoMLProperty:
                 )
 
             return standard_state
-        
+
     def __repr__(self):
         return (
             f"<ThermoMLProperty {self.type_string}, substance={self.substance}, "
@@ -1858,7 +1858,7 @@ class ThermoMLProperty:
 
         if method_name_node is None or property_name_node is None:
             raise RuntimeError("A property does not have a name / method entry.")
-        
+
         if property_name_node.text not in ThermoMLDataSet.registered_properties:
             logging.debug(
                 f"An unsupported property was found "

--- a/openff/evaluator/datasets/thermoml/thermoml.py
+++ b/openff/evaluator/datasets/thermoml/thermoml.py
@@ -148,6 +148,9 @@ class _Constraint:
     or composition at which a measurement was recorded.
     """
 
+    def __repr__(self):
+        return f"Constraint(type={self.type}, value={self.value})"
+
     def __init__(self):
         self.type = _ConstraintType.Undefined
         self.value = 0.0
@@ -355,6 +358,9 @@ class _CombinedUncertainty(_PropertyUncertainty):
 
 class _Compound:
     """A wrapper around a ThermoML Compound node."""
+
+    def __repr__(self):
+        return f"Compound(smiles={self.smiles}, index={self.index})"
 
     def __init__(self):
         self.smiles = None
@@ -856,7 +862,7 @@ class _PureOrMixtureData:
 
         # Molecuar weight in Daltons is not per-mol by SI definitions, but
         # divide through by Avogadro's number as if it is
-        return molecular_weight / unit.mol
+        return unit.avogadro_number * molecular_weight / unit.mol
 
     @staticmethod
     def _solvent_mole_fractions_to_moles(
@@ -1043,7 +1049,7 @@ class _PureOrMixtureData:
                         mass_fractions[compound_index].to(unit.dimensionless).magnitude
                     )
 
-        total_mass = 1 * unit.dalton
+        total_mass = 1 * unit.gram
         total_solvent_mass = total_mass
 
         moles = {}
@@ -1703,6 +1709,13 @@ class ThermoMLProperty:
                 )
 
             return standard_state
+        
+    def __repr__(self):
+        return (
+            f"<ThermoMLProperty {self.type_string}, substance={self.substance}, "
+            "thermodynamic_state={self.thermodynamic_state}, "
+            f"value={self.value}, uncertainty={self.uncertainty} >"
+        )
 
     def __init__(self, type_string):
         self.type_string = type_string
@@ -1845,7 +1858,7 @@ class ThermoMLProperty:
 
         if method_name_node is None or property_name_node is None:
             raise RuntimeError("A property does not have a name / method entry.")
-
+        
         if property_name_node.text not in ThermoMLDataSet.registered_properties:
             logging.debug(
                 f"An unsupported property was found "

--- a/openff/evaluator/datasets/thermoml/thermoml.py
+++ b/openff/evaluator/datasets/thermoml/thermoml.py
@@ -148,9 +148,6 @@ class _Constraint:
     or composition at which a measurement was recorded.
     """
 
-    def __repr__(self):
-        return f"Constraint(type={self.type}, value={self.value})"
-
     def __init__(self):
         self.type = _ConstraintType.Undefined
         self.value = 0.0
@@ -358,9 +355,6 @@ class _CombinedUncertainty(_PropertyUncertainty):
 
 class _Compound:
     """A wrapper around a ThermoML Compound node."""
-
-    def __repr__(self):
-        return f"Compound(smiles={self.smiles}, index={self.index})"
 
     def __init__(self):
         self.smiles = None
@@ -862,7 +856,7 @@ class _PureOrMixtureData:
 
         # Molecuar weight in Daltons is not per-mol by SI definitions, but
         # divide through by Avogadro's number as if it is
-        return unit.avogadro_number * molecular_weight / unit.mol
+        return molecular_weight / unit.mol
 
     @staticmethod
     def _solvent_mole_fractions_to_moles(
@@ -1049,7 +1043,7 @@ class _PureOrMixtureData:
                         mass_fractions[compound_index].to(unit.dimensionless).magnitude
                     )
 
-        total_mass = 1 * unit.gram
+        total_mass = 1 * unit.dalton
         total_solvent_mass = total_mass
 
         moles = {}
@@ -1709,13 +1703,6 @@ class ThermoMLProperty:
                 )
 
             return standard_state
-        
-    def __repr__(self):
-        return (
-            f"<ThermoMLProperty {self.type_string}, substance={self.substance}, "
-            "thermodynamic_state={self.thermodynamic_state}, "
-            f"value={self.value}, uncertainty={self.uncertainty} >"
-        )
 
     def __init__(self, type_string):
         self.type_string = type_string
@@ -1858,7 +1845,7 @@ class ThermoMLProperty:
 
         if method_name_node is None or property_name_node is None:
             raise RuntimeError("A property does not have a name / method entry.")
-        
+
         if property_name_node.text not in ThermoMLDataSet.registered_properties:
             logging.debug(
                 f"An unsupported property was found "


### PR DESCRIPTION
## Description
Fixes #568 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - This scales the MW back and adds more granular tests.
  - It also adds some `__repr__` functions I used while debugging, which can be removed but might be nice for future debugging!
