### PR TITLE
Drop OpenMM 7 in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,24 +39,10 @@ jobs:
         pydantic-version:
           - "2"
         openmm-version:
-          - "7"
           - "8"
         openeye:
           - true
           - false
-        exclude:
-          - python-version: "3.11"
-            openmm-version: "7"
-          - python-version: "3.12"
-            openmm-version: "7"
-          - os: "macos-12"
-            openmm-version: "7"
-          - python-version: "3.12"
-            openeye: true
-          - python-version: "3.11"
-            pymbar-version: "3.1"
-          - python-version: "3.12"
-            pymbar-version: "3.1"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,6 @@ jobs:
         python-version:
           - "3.10"
           - "3.11"
-          - "3.12"
         pymbar-version:
           - "3.1"
         pydantic-version:


### PR DESCRIPTION
## Description
This PR drops OpenMM from the testing matrix. OpenMM 8 has been available for almost two years now.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Drop OpenMM 7 in tests

## Questions
- [ ] Is anybody using OpenMM 7?

## Status
- [x] Ready to go