### PR TITLE
Fail individually on bad SMILES

### DIFF
--- a/openff/evaluator/_tests/test_datasets/test_thermoml.py
+++ b/openff/evaluator/_tests/test_datasets/test_thermoml.py
@@ -193,12 +193,19 @@ def test_thermoml_molality_constraints():
     assert len(data_set.properties[0].substance) > 1
 
 
-def test_thermoml_mole_constraints():
+def test_thermoml_mole_constraints(caplog):
     """A collection of tests to ensure that the Mole fraction constraint is
     implemented correctly alongside solvent constraints."""
 
     # Mole fraction
-    data_set = ThermoMLDataSet.from_file(get_data_filename("test/properties/mole.xml"))
+    # This file contains a bad smiles to test Issue #620
+    # Test that the file a) gets parsed
+    # and b) logs a warning about parsing radicals
+
+    with caplog.at_level("WARNING"):
+        data_set = ThermoMLDataSet.from_file(get_data_filename("test/properties/mole.xml"))
+    assert "An error occurred while parsing a compound" in caplog.text
+    assert "radical" in caplog.text
 
     assert data_set is not None
     assert len(data_set) > 0

--- a/openff/evaluator/_tests/test_datasets/test_thermoml.py
+++ b/openff/evaluator/_tests/test_datasets/test_thermoml.py
@@ -203,7 +203,9 @@ def test_thermoml_mole_constraints(caplog):
     # and b) logs a warning about parsing radicals
 
     with caplog.at_level("WARNING"):
-        data_set = ThermoMLDataSet.from_file(get_data_filename("test/properties/mole.xml"))
+        data_set = ThermoMLDataSet.from_file(
+            get_data_filename("test/properties/mole.xml")
+        )
     assert "An error occurred while parsing a compound" in caplog.text
     assert "radical" in caplog.text
 

--- a/openff/evaluator/data/test/properties/mole.xml
+++ b/openff/evaluator/data/test/properties/mole.xml
@@ -11,6 +11,12 @@
   </Compound>
   <Compound>
     <RegNum>
+      <nOrgNum>2</nOrgNum>
+    </RegNum>
+    <sSmiles>C[N]C</sSmiles>
+  </Compound>
+  <Compound>
+    <RegNum>
       <nOrgNum>3</nOrgNum>
     </RegNum>
     <sStandardInChI>InChI=1S/C5H10O2/c1-3-4-5(6)7-2/h3-4H2,1-2H3</sStandardInChI>

--- a/openff/evaluator/datasets/thermoml/thermoml.py
+++ b/openff/evaluator/datasets/thermoml/thermoml.py
@@ -2184,7 +2184,11 @@ class ThermoMLDataSet(PhysicalPropertyDataSet):
 
         # Extract the base compounds present in the xml file
         for node in root_node.findall("ThermoML:Compound", namespace):
-            compound = _Compound.from_xml_node(node, namespace)
+            try:
+                compound = _Compound.from_xml_node(node, namespace)
+            except Exception as e:
+                logger.warning(f"An error occurred while parsing a compound: {e}")
+                continue
 
             if compound is None:
                 continue

--- a/openff/evaluator/datasets/thermoml/thermoml.py
+++ b/openff/evaluator/datasets/thermoml/thermoml.py
@@ -2143,6 +2143,13 @@ class ThermoMLDataSet(PhysicalPropertyDataSet):
     def from_xml(cls, xml, default_source):
         """Load a ThermoML data set from an xml object.
 
+        .. versionchanged:: 0.4.11
+            As of 0.4.11, this will no longer raise an error if
+            the document contains a compound that cannot be parsed.
+            Instead, that compound will simply be skipped and parsing
+            will continue. See Issue #620 for more.
+
+
         Parameters
         ----------
         xml: str


### PR DESCRIPTION
## Description
Fixes #620

Changes:
* adds a bad SMILES to an existing data file to make a test fail
* Wraps Compound creation in a try/except