### PR TITLE
fix(ci): migrates to new start/stop gha-runner actions

### DIFF
--- a/.github/workflows/aws.yaml
+++ b/.github/workflows/aws.yaml
@@ -25,13 +25,10 @@ jobs:
           aws-region: us-east-1
       - name: Create cloud runner
         id: aws-start
-        uses: omsf-eco-infra/gha-runner@v0.4.0
+        uses: omsf/start-aws-gha-runner@v1.0.0
         with:
-          provider: "aws"
-          action: "start"
           aws_image_id: ami-0d5079d9be06933e5
           aws_instance_type: g4dn.xlarge
-          aws_region_name: us-east-1
           aws_home_dir: /home/ubuntu
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
@@ -78,11 +75,8 @@ jobs:
           role-to-assume: arn:aws:iam::649715411074:role/gh-actions-runner-role
           aws-region: us-east-1
       - name: Stop instances
-        uses: omsf-eco-infra/gha-runner@v0.4.0
+        uses: omsf/stop-aws-gha-runner@v1.0.0
         with:
-          provider: "aws"
-          action: "stop"
           instance_mapping: ${{ needs.start-aws-runner.outputs.mapping }}
-          aws_region_name: us-east-1
         env:
           GH_PAT: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Description
This PR updates to use the new OMSF start/stop AWS runners, similar to what was done in https://github.com/openforcefield/openff-nagl/pull/196.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Update to the new start/stop runners

## Questions
n/a

## Status
- [x] Ready to go