### PR TITLE
Register default methods

### DIFF
--- a/openff/evaluator/properties/density.py
+++ b/openff/evaluator/properties/density.py
@@ -11,13 +11,13 @@ from openff.evaluator.datasets import PhysicalProperty, PropertyPhase
 from openff.evaluator.datasets.thermoml import thermoml_property
 from openff.evaluator.layers import register_calculation_schema
 from openff.evaluator.layers.equilibration import (
+    EquilibrationLayer,
     EquilibrationProperty,
     EquilibrationSchema,
-    EquilibrationLayer
 )
 from openff.evaluator.layers.preequilibrated_simulation import (
+    PreequilibratedSimulationLayer,
     PreequilibratedSimulationSchema,
-    PreequilibratedSimulationLayer
 )
 from openff.evaluator.layers.reweighting import ReweightingLayer, ReweightingSchema
 from openff.evaluator.layers.simulation import SimulationLayer, SimulationSchema
@@ -314,7 +314,9 @@ register_calculation_schema(
     Density, EquilibrationLayer, Density.default_equilibration_schema
 )
 register_calculation_schema(
-    Density, PreequilibratedSimulationLayer, Density.default_preequilibrated_simulation_schema
+    Density,
+    PreequilibratedSimulationLayer,
+    Density.default_preequilibrated_simulation_schema,
 )
 register_calculation_schema(
     ExcessMolarVolume,

--- a/openff/evaluator/properties/density.py
+++ b/openff/evaluator/properties/density.py
@@ -13,9 +13,11 @@ from openff.evaluator.layers import register_calculation_schema
 from openff.evaluator.layers.equilibration import (
     EquilibrationProperty,
     EquilibrationSchema,
+    EquilibrationLayer
 )
 from openff.evaluator.layers.preequilibrated_simulation import (
     PreequilibratedSimulationSchema,
+    PreequilibratedSimulationLayer
 )
 from openff.evaluator.layers.reweighting import ReweightingLayer, ReweightingSchema
 from openff.evaluator.layers.simulation import SimulationLayer, SimulationSchema
@@ -307,6 +309,12 @@ class ExcessMolarVolume(EstimableExcessProperty):
 register_calculation_schema(Density, SimulationLayer, Density.default_simulation_schema)
 register_calculation_schema(
     Density, ReweightingLayer, Density.default_reweighting_schema
+)
+register_calculation_schema(
+    Density, EquilibrationLayer, Density.default_equilibration_schema
+)
+register_calculation_schema(
+    Density, PreequilibratedSimulationLayer, Density.default_preequilibrated_simulation_schema
 )
 register_calculation_schema(
     ExcessMolarVolume,

--- a/openff/evaluator/properties/enthalpy.py
+++ b/openff/evaluator/properties/enthalpy.py
@@ -8,6 +8,8 @@ from openff.evaluator.attributes import UNDEFINED, PlaceholderValue
 from openff.evaluator.datasets import PhysicalProperty, PropertyPhase
 from openff.evaluator.datasets.thermoml import thermoml_property
 from openff.evaluator.layers import register_calculation_schema
+from openff.evaluator.layers.equilibration import EquilibrationLayer
+from openff.evaluator.layers.preequilibrated_simulation import PreequilibratedSimulationLayer
 from openff.evaluator.layers.reweighting import ReweightingLayer, ReweightingSchema
 from openff.evaluator.layers.simulation import SimulationLayer, SimulationSchema
 from openff.evaluator.properties.properties import EstimableExcessProperty
@@ -412,6 +414,14 @@ register_calculation_schema(
 )
 register_calculation_schema(
     EnthalpyOfMixing, ReweightingLayer, EnthalpyOfMixing.default_reweighting_schema
+)
+register_calculation_schema(
+    EnthalpyOfMixing, EquilibrationLayer, EnthalpyOfMixing.default_equilibration_schema
+)
+register_calculation_schema(
+    EnthalpyOfMixing,
+    PreequilibratedSimulationLayer,
+    EnthalpyOfMixing.default_preequilibrated_simulation_schema,
 )
 register_calculation_schema(
     EnthalpyOfVaporization,

--- a/openff/evaluator/properties/enthalpy.py
+++ b/openff/evaluator/properties/enthalpy.py
@@ -9,7 +9,9 @@ from openff.evaluator.datasets import PhysicalProperty, PropertyPhase
 from openff.evaluator.datasets.thermoml import thermoml_property
 from openff.evaluator.layers import register_calculation_schema
 from openff.evaluator.layers.equilibration import EquilibrationLayer
-from openff.evaluator.layers.preequilibrated_simulation import PreequilibratedSimulationLayer
+from openff.evaluator.layers.preequilibrated_simulation import (
+    PreequilibratedSimulationLayer,
+)
 from openff.evaluator.layers.reweighting import ReweightingLayer, ReweightingSchema
 from openff.evaluator.layers.simulation import SimulationLayer, SimulationSchema
 from openff.evaluator.properties.properties import EstimableExcessProperty


### PR DESCRIPTION
## Description
This registers the default schema generation methods for the EquilibrationLayer and PreequilibratedSimulationLayer respectively, which I forgot to do earlier; I think this kicks in when the user does not specify their own workflow schema, which I had been doing throughout all testing.
