### PR TITLE
Trim data where thermophysical data missing

### DIFF
--- a/openff/evaluator/_tests/test_datasets/test_thermoml.py
+++ b/openff/evaluator/_tests/test_datasets/test_thermoml.py
@@ -5,6 +5,7 @@ Units tests for openff.evaluator.datasets
 import numpy as np
 import pytest
 from openff.units import unit
+from openff.utilities.utilities import get_data_file_path
 
 from openff.evaluator.attributes import UNDEFINED
 from openff.evaluator.datasets import PhysicalProperty, PropertyPhase
@@ -235,6 +236,25 @@ def test_thermoml_mole_constraints(caplog):
 
     assert data_set is not None
     assert len(data_set) > 0
+
+
+def test_trim_missing_from_pandas():
+    """
+    Trim physical properties when some thermophysical data missing.
+
+    See #653 for more context.
+    """
+    import pandas
+
+    ThermoMLDataSet.from_pandas(
+        pandas.read_csv(
+            get_data_file_path(
+                "data/test/properties/osmotic_subset.csv",
+                "openff.evaluator",
+            ),
+            index_col=0,
+        )
+    )
 
 
 class TestPureOrMixtureData:

--- a/openff/evaluator/data/test/properties/osmotic_subset.csv
+++ b/openff/evaluator/data/test/properties/osmotic_subset.csv
@@ -1,0 +1,3 @@
+,Id,Temperature (K),Pressure (kPa),Phase,N Components,Component 1,Role 1,Mole Fraction 1,Exact Amount 1,Component 2,Role 2,Mole Fraction 2,Exact Amount 2,Component 3,Role 3,Mole Fraction 3,Exact Amount 3,Density Value (g / ml),Density Uncertainty (g / ml),Source
+0,670cda59343a479fba5e506b4d21d75b,298.15,101.0,Liquid,3,NCC(=O)O,Solvent,0.008848257766444224,,[Cl-].[Na+],Solvent,0.008848257766444224,,O,Solvent,0.9823034844671115,,,,10.1016/j.jct.2013.08.018
+1,11bc3f8750624123b26ad0ed939e2d9e,298.15,,Liquid + Gas,2,CC[N+](C)(CC)CC.[I-],Solvent,0.000860391575765,,O,Solvent,0.999139608424235,,,,,,,,10.1016/j.fluid.2006.09.025

--- a/openff/evaluator/datasets/datasets.py
+++ b/openff/evaluator/datasets/datasets.py
@@ -562,15 +562,6 @@ class PhysicalPropertyDataSet(TypedBaseModel):
         # Convert the data rows to property objects.
         physical_properties = []
 
-        # Drop data point if thermophysical data is not included (see #578)
-        data_frame = data_frame.dropna(
-            subset=[
-                "Pressure (kPa)",
-                "Temperature (K)",
-                "Phase",
-            ]
-        )
-
         for _, data_row in data_frame.iterrows():
             data_row = data_row.dropna()
 

--- a/openff/evaluator/datasets/datasets.py
+++ b/openff/evaluator/datasets/datasets.py
@@ -562,6 +562,15 @@ class PhysicalPropertyDataSet(TypedBaseModel):
         # Convert the data rows to property objects.
         physical_properties = []
 
+        # Drop data point if thermophysical data is not included (see #578)
+        data_frame = data_frame.dropna(
+            subset=[
+                "Pressure (kPa)",
+                "Temperature (K)",
+                "Phase",
+            ]
+        )
+
         for _, data_row in data_frame.iterrows():
             data_row = data_row.dropna()
 


### PR DESCRIPTION
## Description
Closes #578 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Drops data in `ThermoMLDataSet.from_pandas` when some physical property data is missing

## Status
- [ ] Ready to go