### PR TITLE
Drop `importlib.metadata` backport

### DIFF
--- a/openff/evaluator/_tests/test_plugins.py
+++ b/openff/evaluator/_tests/test_plugins.py
@@ -2,7 +2,7 @@
 Units tests for the openff.evaluator.plugins module.
 """
 
-import sys
+from importlib.metadata import entry_points
 
 from openff.evaluator.layers import (
     registered_calculation_layers,
@@ -10,12 +10,6 @@ from openff.evaluator.layers import (
 )
 from openff.evaluator.plugins import register_default_plugins, register_external_plugins
 from openff.evaluator.workflow import registered_workflow_protocols
-
-if sys.version_info[1] < 10:
-    # Backport only for Python 3.9 - drop April 2024
-    from importlib_metadata import entry_points
-else:
-    from importlib.metadata import entry_points
 
 
 def test_register_default_plugins():

--- a/openff/evaluator/datasets/taproom/taproom.py
+++ b/openff/evaluator/datasets/taproom/taproom.py
@@ -432,13 +432,7 @@ class TaproomDataSet(PhysicalPropertyDataSet):
             Whether to add the metadata required for an APR based calculation
             using the ``paprika`` based workflow.
         """
-        import sys
-
-        if sys.version_info[1] < 10:
-            # Backport only for Python 3.9 - drop April 2024
-            from importlib_metadata import entry_points
-        else:
-            from importlib.metadata import entry_points
+        from importlib.metadata import entry_points
 
         installed_benchmarks = {}
 

--- a/openff/evaluator/plugins.py
+++ b/openff/evaluator/plugins.py
@@ -7,14 +7,7 @@ physical properties.
 import importlib
 import logging
 import pkgutil
-import sys
-
-if sys.version_info[1] < 10:
-    # Backport only for Python 3.9 - drop April 2024
-    from importlib_metadata import entry_points
-else:
-    from importlib.metadata import entry_points
-
+from importlib.metadata import entry_points
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description
`importlib_metadata` is purely dead weight when on Python 3.10+ and we're on 3.11+

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Drop use of `importlib_metadata`

## Status
- [x] Ready to go