### PR TITLE
Bump Python versions used in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,8 @@ jobs:
           - macos-latest
         python-version:
           - "3.11"
+          - "3.12"
+          - "3.13"
         pymbar-version:
           - "3.1"
         pydantic-version:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,6 @@ jobs:
         python-version:
           - "3.11"
           - "3.12"
-          - "3.13"
         pymbar-version:
           - "3.1"
         pydantic-version:


### PR DESCRIPTION
## Description
After #662, we should be able to test on 3.12