### PR TITLE
Add option to finish calculating even if conditions not met

### DIFF
--- a/openff/evaluator/properties/density.py
+++ b/openff/evaluator/properties/density.py
@@ -160,7 +160,7 @@ class Density(PhysicalProperty):
                 equilibration_max_iterations=equilibration_max_iterations,
                 n_uncorrelated_samples=n_uncorrelated_samples,
                 max_iterations=max_iterations,
-                error_on_failure=error_on_failure
+                error_on_failure=error_on_failure,
             )
         )
         protocols.analysis_protocol.observable = ProtocolPath(

--- a/openff/evaluator/properties/density.py
+++ b/openff/evaluator/properties/density.py
@@ -123,7 +123,7 @@ class Density(PhysicalProperty):
         equilibration_max_iterations: int = 100,
         n_uncorrelated_samples: int = 200,
         max_iterations: int = 100,
-        error_on_failure: bool = False,
+        error_on_failure: bool = True,
     ) -> PreequilibratedSimulationSchema:
 
         assert absolute_tolerance == UNDEFINED or relative_tolerance == UNDEFINED

--- a/openff/evaluator/properties/density.py
+++ b/openff/evaluator/properties/density.py
@@ -123,6 +123,7 @@ class Density(PhysicalProperty):
         equilibration_max_iterations: int = 100,
         n_uncorrelated_samples: int = 200,
         max_iterations: int = 100,
+        error_on_failure: bool = False,
     ) -> PreequilibratedSimulationSchema:
 
         assert absolute_tolerance == UNDEFINED or relative_tolerance == UNDEFINED
@@ -159,6 +160,7 @@ class Density(PhysicalProperty):
                 equilibration_max_iterations=equilibration_max_iterations,
                 n_uncorrelated_samples=n_uncorrelated_samples,
                 max_iterations=max_iterations,
+                error_on_failure=error_on_failure
             )
         )
         protocols.analysis_protocol.observable = ProtocolPath(

--- a/openff/evaluator/properties/properties.py
+++ b/openff/evaluator/properties/properties.py
@@ -208,6 +208,7 @@ class EstimableExcessProperty(PhysicalProperty, abc.ABC):
         equilibration_max_iterations: int = 100,
         n_uncorrelated_samples: int = 200,
         max_iterations: int = 100,
+        error_on_failure: bool = False,
     ) -> PreequilibratedSimulationSchema:
         """Returns the default calculation schema to use when estimating
         this class of property from direct simulations.
@@ -248,6 +249,7 @@ class EstimableExcessProperty(PhysicalProperty, abc.ABC):
             equilibration_max_iterations=equilibration_max_iterations,
             n_uncorrelated_samples=n_uncorrelated_samples,
             max_iterations=max_iterations,
+            error_on_failure=error_on_failure
         )
         # mixture_data_replicator = mixture_data_replicators[0]
 
@@ -278,6 +280,7 @@ class EstimableExcessProperty(PhysicalProperty, abc.ABC):
                 equilibration_max_iterations=equilibration_max_iterations,
                 n_uncorrelated_samples=n_uncorrelated_samples,
                 max_iterations=max_iterations,
+                error_on_failure=error_on_failure
             )
         )
         # specify simulation data path

--- a/openff/evaluator/properties/properties.py
+++ b/openff/evaluator/properties/properties.py
@@ -208,7 +208,7 @@ class EstimableExcessProperty(PhysicalProperty, abc.ABC):
         equilibration_max_iterations: int = 100,
         n_uncorrelated_samples: int = 200,
         max_iterations: int = 100,
-        error_on_failure: bool = False,
+        error_on_failure: bool = True,
     ) -> PreequilibratedSimulationSchema:
         """Returns the default calculation schema to use when estimating
         this class of property from direct simulations.

--- a/openff/evaluator/properties/properties.py
+++ b/openff/evaluator/properties/properties.py
@@ -249,7 +249,7 @@ class EstimableExcessProperty(PhysicalProperty, abc.ABC):
             equilibration_max_iterations=equilibration_max_iterations,
             n_uncorrelated_samples=n_uncorrelated_samples,
             max_iterations=max_iterations,
-            error_on_failure=error_on_failure
+            error_on_failure=error_on_failure,
         )
         # mixture_data_replicator = mixture_data_replicators[0]
 
@@ -280,7 +280,7 @@ class EstimableExcessProperty(PhysicalProperty, abc.ABC):
                 equilibration_max_iterations=equilibration_max_iterations,
                 n_uncorrelated_samples=n_uncorrelated_samples,
                 max_iterations=max_iterations,
-                error_on_failure=error_on_failure
+                error_on_failure=error_on_failure,
             )
         )
         # specify simulation data path

--- a/openff/evaluator/protocols/utils.py
+++ b/openff/evaluator/protocols/utils.py
@@ -684,7 +684,7 @@ def generate_preequilibrated_simulation_protocols(
     equilibration_max_iterations: int = 100,
     n_uncorrelated_samples: int = 200,
     max_iterations: int = 100,
-    error_on_failure: bool = False,
+    error_on_failure: bool = True,
 ) -> Tuple[PreequilibratedSimulationProtocols[S], ProtocolPath, StoredSimulationData]:
 
     # Unpack all the of the stored data.

--- a/openff/evaluator/protocols/utils.py
+++ b/openff/evaluator/protocols/utils.py
@@ -684,6 +684,7 @@ def generate_preequilibrated_simulation_protocols(
     equilibration_max_iterations: int = 100,
     n_uncorrelated_samples: int = 200,
     max_iterations: int = 100,
+    error_on_failure: bool = False,
 ) -> Tuple[PreequilibratedSimulationProtocols[S], ProtocolPath, StoredSimulationData]:
 
     # Unpack all the of the stored data.
@@ -750,6 +751,7 @@ def generate_preequilibrated_simulation_protocols(
             ConditionAggregationBehavior.All
         )
         conditional_group.max_iterations = max_iterations
+        conditional_group.error_on_failure = error_on_failure
 
         has_conditions = False
 


### PR DESCRIPTION
## Description

It's sometimes useful to calculate a property even if the specified conditions aren't met. This passes through a kwarg to allow that. There's already an analogous one for equilibration.

## Todos
- adds kwarg


## Status
- [x] Ready to go