### PR TITLE
Avoid `xmltodict` 1.0.3

### DIFF
--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -34,5 +34,8 @@ dependencies:
     - pandoc
     - ipython
 
+    # Shim
+    - xmltodict !=1.0.3
+
     - pip:
       - git+https://github.com/openforcefield/openff-sphinx-theme.git@main

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -35,3 +35,6 @@ dependencies:
   - taproom
   - dataclasses
   - pandas =2
+
+  # Shim
+  - xmltodict !=1.0.3


### PR DESCRIPTION
## Description
Closes #735

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Do not install problematic `xmltodict` version

## Status
- [ ] Ready to go