### PR TITLE
Forbid `ASH` residue name

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -8,6 +8,11 @@ Releases follow the ``major.minor.micro`` scheme recommended by
 * ``minor`` increments add features but do not break API compatibility
 * ``micro`` increments represent bugfix releases or improvements in documentation
 
+Current development
+-------------------
+
+* PR `#739 <https://github.com/openforcefield/openff-evaluator/pull/739>`_: Add ``ASH`` to list of forbidden residue names in Packmol wrapper
+
 0.5.2 - January 21, 2025
 ------------------------
 

--- a/openff/evaluator/_tests/test_utils/test_packmol.py
+++ b/openff/evaluator/_tests/test_utils/test_packmol.py
@@ -160,3 +160,24 @@ def test_amino_acids():
 
     for index, smiles in enumerate(smiles):
         assert trajectory.top.residue(index).name == amino_residues[smiles]
+
+
+def test_packmol_forbidden_residue_name_ash(monkeypatch):
+    import mdtraj
+
+    top = mdtraj.Topology()
+    chain = top.add_chain()
+    residue = top.add_residue("UNK", chain)
+    top.add_atom("C1", mdtraj.element.carbon, residue)
+    top.add_atom("C2", mdtraj.element.carbon, residue)
+
+    forced_choices = iter("ASHBCD")
+
+    def fake_choice(_):
+        return next(forced_choices)
+
+    monkeypatch.setattr(packmol.random, "choice", fake_choice)
+
+    packmol._generate_residue_name(residue, "CC")
+
+    assert residue.name == "BCD"

--- a/openff/evaluator/utils/packmol.py
+++ b/openff/evaluator/utils/packmol.py
@@ -207,6 +207,7 @@ def _generate_residue_name(residue, smiles):
         "NMA",
         "THY",
         "URA",
+        "ASH",
     ]
 
     amino_residue_mappings = {

--- a/openff/evaluator/utils/packmol.py
+++ b/openff/evaluator/utils/packmol.py
@@ -207,7 +207,6 @@ def _generate_residue_name(residue, smiles):
         "NMA",
         "THY",
         "URA",
-        "ASH",
     ]
 
     amino_residue_mappings = {


### PR DESCRIPTION
## Description
Fixes #691

See [this comment](https://github.com/openforcefield/openff-evaluator/issues/691#issuecomment-3255106788) and more in the same issue for context

This is a quick and dirty hack that is not guaranteed to fix the surface-level problem[^1] and is guaranteed to not fix the underlying problem[^2]

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Forbid `ASH` residue name

## Questions
- [ ] Is there any way to reliably[^1] test this? I think not

## Status
- [ ] Ready to go

[^1]: The failure case is basically a 1-in-a-large-number random occurrence and therefore I think impossible to reliably and reproducibly trigger
[^2]: A refactor of how intermediate Packmol PDB files are handled is necessary for this