### PR TITLE
Mlfs remove object

### DIFF
--- a/openff/evaluator/_tests/test_storage/test_mutable.py
+++ b/openff/evaluator/_tests/test_storage/test_mutable.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import uuid
 
 import pytest
 
@@ -553,14 +554,15 @@ def test_subset_force_field_excluded_when_include_substance_active(
         assert len(_data_keys(result)) == 1
 
 
-def test_remove_object_deletes_json_and_directory():
+@pytest.mark.parametrize("factory", DATA_FACTORIES)
+def test_remove_object_deletes_json_and_directory(factory):
     """remove_object() deletes both the JSON file and the ancillary directory."""
     substance = Substance.from_components("C")
     with tempfile.TemporaryDirectory() as base_dir:
         storage_dir = os.path.join(base_dir, "storage")
         data_dir = os.path.join(base_dir, "data")
 
-        obj = create_dummy_simulation_data(data_dir, substance)
+        obj = factory(data_dir, substance)
         storage = MutableLocalFileStorage(storage_dir)
         key = storage.store_object(obj, data_dir)
 
@@ -575,20 +577,22 @@ def test_remove_object_deletes_json_and_directory():
         assert not os.path.isdir(ancillary_path)
 
 
-def test_remove_object_removes_from_registry():
+@pytest.mark.parametrize("factory", DATA_FACTORIES)
+def test_remove_object_removes_from_registry(factory):
     """Key is absent from _stored_object_keys after removal."""
     substance = Substance.from_components("C")
     with tempfile.TemporaryDirectory() as base_dir:
         storage_dir = os.path.join(base_dir, "storage")
         data_dir = os.path.join(base_dir, "data")
 
-        obj = create_dummy_simulation_data(data_dir, substance)
+        obj = factory(data_dir, substance)
         storage = MutableLocalFileStorage(storage_dir)
         key = storage.store_object(obj, data_dir)
 
-        assert key in storage._stored_object_keys[StoredSimulationData.__name__]
+        type_name = type(obj).__name__
+        assert key in storage._stored_object_keys[type_name]
         storage.remove_object(key)
-        assert key not in storage._stored_object_keys.get(StoredSimulationData.__name__, [])
+        assert key not in storage._stored_object_keys.get(type_name, [])
 
 
 def test_remove_object_clears_hash_index():
@@ -604,14 +608,15 @@ def test_remove_object_clears_hash_index():
         assert not any(k == key for k in storage._object_hashes.values())
 
 
-def test_remove_object_clears_cache():
+@pytest.mark.parametrize("factory", DATA_FACTORIES)
+def test_remove_object_clears_cache(factory):
     """With cache_objects_in_memory=True, the cache entry is evicted."""
     substance = Substance.from_components("C")
     with tempfile.TemporaryDirectory() as base_dir:
         storage_dir = os.path.join(base_dir, "storage")
         data_dir = os.path.join(base_dir, "data")
 
-        obj = create_dummy_simulation_data(data_dir, substance)
+        obj = factory(data_dir, substance)
         storage = MutableLocalFileStorage(storage_dir, cache_objects_in_memory=True)
         key = storage.store_object(obj, data_dir)
 
@@ -631,7 +636,8 @@ def test_remove_object_key_not_found_raises():
             storage.remove_object("nonexistent_key")
 
 
-def test_remove_object_then_store_again():
+@pytest.mark.parametrize("factory", DATA_FACTORIES)
+def test_remove_object_then_store_again(factory):
     """After removal an object can be re-stored and retrieved correctly."""
     substance = Substance.from_components("C")
     with tempfile.TemporaryDirectory() as base_dir:
@@ -639,20 +645,14 @@ def test_remove_object_then_store_again():
         data_dir_1 = os.path.join(base_dir, "data1")
         data_dir_2 = os.path.join(base_dir, "data2")
 
-        import uuid as _uuid
-
-        obj1 = create_dummy_simulation_data(
-            data_dir_1, substance, calculation_id=str(_uuid.uuid4())
-        )
+        obj1 = factory(data_dir_1, substance, calculation_id=str(uuid.uuid4()))
         storage = MutableLocalFileStorage(storage_dir)
         key1 = storage.store_object(obj1, data_dir_1)
 
         storage.remove_object(key1)
 
         # Re-store with a fresh ancillary directory
-        obj2 = create_dummy_simulation_data(
-            data_dir_2, substance, calculation_id=str(_uuid.uuid4())
-        )
+        obj2 = factory(data_dir_2, substance, calculation_id=str(uuid.uuid4()))
         key2 = storage.store_object(obj2, data_dir_2)
 
         retrieved, _ = storage.retrieve_object(key2)
@@ -660,7 +660,8 @@ def test_remove_object_then_store_again():
         assert retrieved.substance == substance
 
 
-def test_remove_object_only_affects_target():
+@pytest.mark.parametrize("factory", DATA_FACTORIES)
+def test_remove_object_only_affects_target(factory):
     """Removing one object does not disturb other stored objects."""
     substance_c = Substance.from_components("C")
     substance_o = Substance.from_components("O")
@@ -670,8 +671,8 @@ def test_remove_object_only_affects_target():
         data_c = os.path.join(base_dir, "data_c")
         data_o = os.path.join(base_dir, "data_o")
 
-        obj_c = create_dummy_simulation_data(data_c, substance_c)
-        obj_o = create_dummy_simulation_data(data_o, substance_o)
+        obj_c = factory(data_c, substance_c)
+        obj_o = factory(data_o, substance_o)
 
         storage = MutableLocalFileStorage(storage_dir)
         key_c = storage.store_object(obj_c, data_c)

--- a/openff/evaluator/_tests/test_storage/test_mutable.py
+++ b/openff/evaluator/_tests/test_storage/test_mutable.py
@@ -551,3 +551,134 @@ def test_subset_force_field_excluded_when_include_substance_active(
         assert len(result._stored_object_keys.get(ForceFieldData.__name__, [])) == 0
         # But the data object is present
         assert len(_data_keys(result)) == 1
+
+
+def test_remove_object_deletes_json_and_directory():
+    """remove_object() deletes both the JSON file and the ancillary directory."""
+    substance = Substance.from_components("C")
+    with tempfile.TemporaryDirectory() as base_dir:
+        storage_dir = os.path.join(base_dir, "storage")
+        data_dir = os.path.join(base_dir, "data")
+
+        obj = create_dummy_simulation_data(data_dir, substance)
+        storage = MutableLocalFileStorage(storage_dir)
+        key = storage.store_object(obj, data_dir)
+
+        json_path = os.path.join(storage_dir, f"{key}.json")
+        ancillary_path = os.path.join(storage_dir, key)
+        assert os.path.isfile(json_path)
+        assert os.path.isdir(ancillary_path)
+
+        storage.remove_object(key)
+
+        assert not os.path.isfile(json_path)
+        assert not os.path.isdir(ancillary_path)
+
+
+def test_remove_object_removes_from_registry():
+    """Key is absent from _stored_object_keys after removal."""
+    substance = Substance.from_components("C")
+    with tempfile.TemporaryDirectory() as base_dir:
+        storage_dir = os.path.join(base_dir, "storage")
+        data_dir = os.path.join(base_dir, "data")
+
+        obj = create_dummy_simulation_data(data_dir, substance)
+        storage = MutableLocalFileStorage(storage_dir)
+        key = storage.store_object(obj, data_dir)
+
+        assert key in storage._stored_object_keys[StoredSimulationData.__name__]
+        storage.remove_object(key)
+        assert key not in storage._stored_object_keys.get(StoredSimulationData.__name__, [])
+
+
+def test_remove_object_clears_hash_index():
+    """For HashableStoredData, the corresponding hash entry is removed."""
+    ff = SmirnoffForceFieldSource.from_path("openff-2.2.1.offxml")
+    with tempfile.TemporaryDirectory() as base_dir:
+        storage_dir = os.path.join(base_dir, "storage")
+        storage = MutableLocalFileStorage(storage_dir)
+        key = storage.store_force_field(ff)
+
+        assert any(k == key for k in storage._object_hashes.values())
+        storage.remove_object(key)
+        assert not any(k == key for k in storage._object_hashes.values())
+
+
+def test_remove_object_clears_cache():
+    """With cache_objects_in_memory=True, the cache entry is evicted."""
+    substance = Substance.from_components("C")
+    with tempfile.TemporaryDirectory() as base_dir:
+        storage_dir = os.path.join(base_dir, "storage")
+        data_dir = os.path.join(base_dir, "data")
+
+        obj = create_dummy_simulation_data(data_dir, substance)
+        storage = MutableLocalFileStorage(storage_dir, cache_objects_in_memory=True)
+        key = storage.store_object(obj, data_dir)
+
+        # Warm the cache
+        storage.retrieve_object(key)
+        assert key in storage._cached_retrieved_objects
+
+        storage.remove_object(key)
+        assert key not in storage._cached_retrieved_objects
+
+
+def test_remove_object_key_not_found_raises():
+    """remove_object raises KeyError for an unregistered key."""
+    with tempfile.TemporaryDirectory() as base_dir:
+        storage = MutableLocalFileStorage(os.path.join(base_dir, "storage"))
+        with pytest.raises(KeyError):
+            storage.remove_object("nonexistent_key")
+
+
+def test_remove_object_then_store_again():
+    """After removal an object can be re-stored and retrieved correctly."""
+    substance = Substance.from_components("C")
+    with tempfile.TemporaryDirectory() as base_dir:
+        storage_dir = os.path.join(base_dir, "storage")
+        data_dir_1 = os.path.join(base_dir, "data1")
+        data_dir_2 = os.path.join(base_dir, "data2")
+
+        import uuid as _uuid
+
+        obj1 = create_dummy_simulation_data(
+            data_dir_1, substance, calculation_id=str(_uuid.uuid4())
+        )
+        storage = MutableLocalFileStorage(storage_dir)
+        key1 = storage.store_object(obj1, data_dir_1)
+
+        storage.remove_object(key1)
+
+        # Re-store with a fresh ancillary directory
+        obj2 = create_dummy_simulation_data(
+            data_dir_2, substance, calculation_id=str(_uuid.uuid4())
+        )
+        key2 = storage.store_object(obj2, data_dir_2)
+
+        retrieved, _ = storage.retrieve_object(key2)
+        assert retrieved is not None
+        assert retrieved.substance == substance
+
+
+def test_remove_object_only_affects_target():
+    """Removing one object does not disturb other stored objects."""
+    substance_c = Substance.from_components("C")
+    substance_o = Substance.from_components("O")
+
+    with tempfile.TemporaryDirectory() as base_dir:
+        storage_dir = os.path.join(base_dir, "storage")
+        data_c = os.path.join(base_dir, "data_c")
+        data_o = os.path.join(base_dir, "data_o")
+
+        obj_c = create_dummy_simulation_data(data_c, substance_c)
+        obj_o = create_dummy_simulation_data(data_o, substance_o)
+
+        storage = MutableLocalFileStorage(storage_dir)
+        key_c = storage.store_object(obj_c, data_c)
+        key_o = storage.store_object(obj_o, data_o)
+
+        storage.remove_object(key_c)
+
+        retrieved_o, _ = storage.retrieve_object(key_o)
+        assert retrieved_o is not None
+        assert retrieved_o.substance == substance_o

--- a/openff/evaluator/_tests/test_storage/test_mutable.py
+++ b/openff/evaluator/_tests/test_storage/test_mutable.py
@@ -596,7 +596,7 @@ def test_remove_object_removes_from_registry(factory):
 
 
 def test_remove_object_clears_hash_index():
-    """For HashableStoredData, the corresponding hash entry is removed."""
+    """For MutableLocalFileStorage, the corresponding hash entry is removed."""
     ff = SmirnoffForceFieldSource.from_path("openff-2.2.1.offxml")
     with tempfile.TemporaryDirectory() as base_dir:
         storage_dir = os.path.join(base_dir, "storage")

--- a/openff/evaluator/storage/mutable.py
+++ b/openff/evaluator/storage/mutable.py
@@ -3,6 +3,7 @@ A mutable, extensible local file storage backend.
 """
 
 import json
+import os
 import shutil
 from os import path
 from typing import TYPE_CHECKING, Iterable
@@ -58,6 +59,64 @@ class MutableLocalFileStorage(LocalFileStorage):
         """Merge *other* into this storage in-place (``self += other``)."""
         self.update(other)
         return self
+
+    def _remove_object(self, storage_key: str) -> None:
+        """Delete the JSON file and ancillary directory for *storage_key*."""
+        file_path = path.join(self._root_directory, f"{storage_key}.json")
+        directory_path = path.join(self._root_directory, f"{storage_key}")
+
+        if path.isfile(file_path):
+            os.remove(file_path)
+        if path.isdir(directory_path):
+            shutil.rmtree(directory_path)
+
+    def remove_object(self, storage_key: str) -> None:
+        """Remove a stored object by *storage_key*.
+
+        Removes the object from the key registry, hash index, and
+        in-memory cache, then deletes its files from disk.
+
+        Parameters
+        ----------
+        storage_key:
+            The storage key returned by :meth:`store_object`.
+
+        Raises
+        ------
+        KeyError
+            If *storage_key* is not registered in this storage.
+        """
+        # Find which type owns this key.
+        type_name_found = None
+        for type_name, keys in self._stored_object_keys.items():
+            if storage_key in keys:
+                type_name_found = type_name
+                break
+
+        if type_name_found is None:
+            raise KeyError(
+                f"No stored object with key {storage_key!r} found in this storage."
+            )
+
+        with self._lock:
+            # Remove from key registry.
+            self._stored_object_keys[type_name_found].remove(storage_key)
+
+            # Remove from hash index (any hash pointing to this key).
+            hashes_to_remove = [
+                h for h, k in self._object_hashes.items() if k == storage_key
+            ]
+            for h in hashes_to_remove:
+                del self._object_hashes[h]
+
+            # Remove from in-memory cache.
+            self._cached_retrieved_objects.pop(storage_key, None)
+
+            # Delete files from disk.
+            self._remove_object(storage_key)
+
+        # Persist the updated key registry.
+        self._save_stored_object_keys()
 
     def _store_object(
         self, object_to_store, storage_key=None, ancillary_data_path=None


### PR DESCRIPTION
## Description
Removes objects by storage keys. This may need to get expanded later (e.g. removing by substance or component...) but for now, storage key works.

Includes some copied code from other branches, should get reviewed after being rebased to reduce extraneous LOC.