### PR TITLE
Fix FilterBySmiles

### DIFF
--- a/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
@@ -721,6 +721,14 @@ def test_filter_ionic_liquid():
     assert len(filtered_frame) == 1
 
 
+def test_filter_by_smiles_via_workflow(data_frame):
+    schema = CurationWorkflowSchema(
+        component_schemas=[FilterBySmilesSchema(smiles_to_include=["C"])]
+    )
+    filtered_frame = CurationWorkflow.apply(data_frame, schema)
+    assert len(filtered_frame) == 16
+
+
 def test_validate_filter_by_smiles():
     # Ensure a valid schema passes
     FilterBySmilesSchema(smiles_to_include=["C"])

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -720,7 +720,7 @@ class FilterBySmilesSchema(CurationComponentSchema):
         assert data.smiles_to_include is not None or data.smiles_to_exclude is not None
         assert data.smiles_to_include is None or data.smiles_to_exclude is None
 
-        return cls
+        return data
 
 
 class FilterBySmiles(CurationComponent):


### PR DESCRIPTION
Fixes #722

I reproduced the failure in the first commit: https://github.com/openforcefield/openff-evaluator/actions/runs/23426363168/job/68142004946?pr=754

The issue was returning cls instead of data in the validator