### PR TITLE
Add tautomer filter

### DIFF
--- a/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
@@ -38,10 +38,10 @@ from openff.evaluator.datasets.curation.components.filtering import (
     FilterByStereochemistrySchema,
     FilterBySubstances,
     FilterBySubstancesSchema,
-    FilterByTemperature,
-    FilterByTemperatureSchema,
     FilterByTautomers,
     FilterByTautomersSchema,
+    FilterByTemperature,
+    FilterByTemperatureSchema,
     FilterDuplicates,
     FilterDuplicatesSchema,
 )
@@ -1258,7 +1258,10 @@ def test_filter_by_tautomers_via_workflow():
     data_frame = pandas.DataFrame(
         [
             {"N Components": 1, "Component 1": "C"},
-            {"N Components": 1, "Component 1": "CC(=O)CC(=O)C"},  # beta-diketone, not in whitelist
+            {
+                "N Components": 1,
+                "Component 1": "CC(=O)CC(=O)C",
+            },  # beta-diketone, not in whitelist
         ]
     )
 
@@ -1285,9 +1288,7 @@ def test_filter_by_tautomers_no_match_removed_default():
 
 def test_filter_by_tautomers_whitelist_keto_enol_aliphatic_kept():
     """Acetone (KETO_ENOL_ALIPHATIC) must survive the default filter."""
-    data_frame = pandas.DataFrame(
-        [{"N Components": 1, "Component 1": "CC(C)=O"}]
-    )
+    data_frame = pandas.DataFrame([{"N Components": 1, "Component 1": "CC(C)=O"}])
 
     filtered_frame = FilterByTautomers.apply(data_frame, FilterByTautomersSchema())
 
@@ -1298,9 +1299,12 @@ def test_filter_by_tautomers_default_whitelist_only():
     data_frame = pandas.DataFrame(
         [
             {"N Components": 1, "Component 1": "C"},
-            {"N Components": 1, "Component 1": "CC(=O)N"},       # amide → kept
-            {"N Components": 1, "Component 1": "CC(=O)CC(=O)C"}, # beta-diketone → removed
-            {"N Components": 1, "Component 1": "O=C1CCCCC1"},    # cyclic keto/enol → kept
+            {"N Components": 1, "Component 1": "CC(=O)N"},  # amide → kept
+            {
+                "N Components": 1,
+                "Component 1": "CC(=O)CC(=O)C",
+            },  # beta-diketone → removed
+            {"N Components": 1, "Component 1": "O=C1CCCCC1"},  # cyclic keto/enol → kept
         ]
     )
 
@@ -1338,7 +1342,9 @@ def test_filter_by_tautomers_explicit_exclude():
 
     filtered_frame = FilterByTautomers.apply(
         data_frame,
-        FilterByTautomersSchema(categories_to_include=None, categories_to_exclude=["AMIDE_IMIDIC_ACID"]),
+        FilterByTautomersSchema(
+            categories_to_include=None, categories_to_exclude=["AMIDE_IMIDIC_ACID"]
+        ),
     )
 
     assert len(filtered_frame) == 1
@@ -1349,9 +1355,7 @@ def test_filter_by_tautomers_exclude_suppression_canonical():
     """Acetylacetone is canonically BETA_DIKETONE (suppression hides KETO_ENOL_ALIPHATIC).
     Excluding KETO_ENOL_ALIPHATIC should therefore keep it; excluding BETA_DIKETONE
     should remove it."""
-    data_frame = pandas.DataFrame(
-        [{"N Components": 1, "Component 1": "CC(=O)CC(=O)C"}]
-    )
+    data_frame = pandas.DataFrame([{"N Components": 1, "Component 1": "CC(=O)CC(=O)C"}])
 
     # KETO_ENOL_ALIPHATIC is suppressed → molecule is kept
     kept = FilterByTautomers.apply(
@@ -1380,9 +1384,7 @@ def test_filter_by_tautomers_include_suppression_applied():
     latter, so specifying categories_to_include=["BETA_DIKETONE"] must keep it.
     The enol form CC(O)=CC(=O)C is used because BETA_DIKETONE's dominant form
     is the enol."""
-    data_frame = pandas.DataFrame(
-        [{"N Components": 1, "Component 1": "CC(O)=CC(=O)C"}]
-    )
+    data_frame = pandas.DataFrame([{"N Components": 1, "Component 1": "CC(O)=CC(=O)C"}])
 
     filtered_frame = FilterByTautomers.apply(
         data_frame,
@@ -1398,8 +1400,8 @@ def test_filter_by_tautomers_minor_form_rejected():
     passes; C=C(O)O (the enol/minor form) must be removed."""
     data_frame = pandas.DataFrame(
         [
-            {"N Components": 1, "Component 1": "CC(=O)O"},   # dominant — kept
-            {"N Components": 1, "Component 1": "C=C(O)O"},   # minor — removed
+            {"N Components": 1, "Component 1": "CC(=O)O"},  # dominant — kept
+            {"N Components": 1, "Component 1": "C=C(O)O"},  # minor — removed
         ]
     )
 

--- a/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
@@ -40,6 +40,8 @@ from openff.evaluator.datasets.curation.components.filtering import (
     FilterBySubstancesSchema,
     FilterByTemperature,
     FilterByTemperatureSchema,
+    FilterByTautomers,
+    FilterByTautomersSchema,
     FilterDuplicates,
     FilterDuplicatesSchema,
 )
@@ -1212,3 +1214,222 @@ def test_curation_does_not_alter_precision():
     )
 
     assert list(data_frame["Mole Fraction 1"]) == list(filtered["Mole Fraction 1"])
+
+
+def test_validate_filter_by_tautomers():
+    FilterByTautomersSchema()
+    FilterByTautomersSchema(categories_to_include=None, categories_to_exclude=[])
+    FilterByTautomersSchema(categories_to_include=["AMIDE_IMIDIC_ACID"])
+
+    with pytest.raises(ValidationError):
+        FilterByTautomersSchema(categories_to_include=None, categories_to_exclude=None)
+
+    with pytest.raises(ValidationError):
+        FilterByTautomersSchema(
+            categories_to_include=["AMIDE_IMIDIC_ACID"],
+            categories_to_exclude=["BETA_DIKETONE"],
+        )
+
+    with pytest.raises(ValidationError):
+        FilterByTautomersSchema(categories_to_include=["NOT_A_CATEGORY"])
+
+
+def test_filter_by_tautomers_schema_default_whitelist():
+    schema = FilterByTautomersSchema()
+
+    assert set(schema.categories_to_include) == {
+        "ALPHA_AMINO_ACID",
+        "AMIDE_ENOL",
+        "AMIDE_IMIDIC_ACID",
+        "CARBOXYLIC_ACID_ENOL",
+        "ESTER_ENOL",
+        "IMINE_ENAMINE_PRIMARY",
+        "IMINE_ENAMINE_SECONDARY",
+        "KETO_ENOL_ALIPHATIC",
+        "KETO_ENOL_CYCLIC",
+        "KETO_ENOL_AROMATIC",
+        "KETENE_YNOL",
+        "LACTAM_LACTIM",
+        "OXIME_NITROSO",
+    }
+
+
+def test_filter_by_tautomers_via_workflow():
+    data_frame = pandas.DataFrame(
+        [
+            {"N Components": 1, "Component 1": "C"},
+            {"N Components": 1, "Component 1": "CC(=O)CC(=O)C"},  # beta-diketone, not in whitelist
+        ]
+    )
+
+    schema = CurationWorkflowSchema(component_schemas=[FilterByTautomersSchema()])
+    filtered_frame = CurationWorkflow.apply(data_frame, schema)
+
+    assert len(filtered_frame) == 1
+    assert filtered_frame.iloc[0]["Component 1"] == "C"
+
+
+def test_filter_by_tautomers_no_match_removed_default():
+    data_frame = pandas.DataFrame(
+        # ensure we don't start picking anything up crazy like ethanol
+        [
+            {"N Components": 1, "Component 1": "C"},
+            {"N Components": 1, "Component 1": "CCO"},
+        ]
+    )
+
+    filtered_frame = FilterByTautomers.apply(data_frame, FilterByTautomersSchema())
+
+    assert len(filtered_frame) == len(data_frame)
+
+
+def test_filter_by_tautomers_whitelist_keto_enol_aliphatic_kept():
+    """Acetone (KETO_ENOL_ALIPHATIC) must survive the default filter."""
+    data_frame = pandas.DataFrame(
+        [{"N Components": 1, "Component 1": "CC(C)=O"}]
+    )
+
+    filtered_frame = FilterByTautomers.apply(data_frame, FilterByTautomersSchema())
+
+    assert len(filtered_frame) == 1
+
+
+def test_filter_by_tautomers_default_whitelist_only():
+    data_frame = pandas.DataFrame(
+        [
+            {"N Components": 1, "Component 1": "C"},
+            {"N Components": 1, "Component 1": "CC(=O)N"},       # amide → kept
+            {"N Components": 1, "Component 1": "CC(=O)CC(=O)C"}, # beta-diketone → removed
+            {"N Components": 1, "Component 1": "O=C1CCCCC1"},    # cyclic keto/enol → kept
+        ]
+    )
+
+    filtered_frame = FilterByTautomers.apply(data_frame, FilterByTautomersSchema())
+
+    assert len(filtered_frame) == 3
+    assert set(filtered_frame["Component 1"]) == {"C", "CC(=O)N", "O=C1CCCCC1"}
+
+
+def test_filter_by_tautomers_explicit_include():
+    data_frame = pandas.DataFrame(
+        [
+            {"N Components": 1, "Component 1": "C"},
+            {"N Components": 1, "Component 1": "CC(=O)N"},
+            {"N Components": 1, "Component 1": "CC(=O)CC(=O)C"},
+        ]
+    )
+
+    filtered_frame = FilterByTautomers.apply(
+        data_frame,
+        FilterByTautomersSchema(categories_to_include=["AMIDE_IMIDIC_ACID"]),
+    )
+
+    assert len(filtered_frame) == 2
+    assert set(filtered_frame["Component 1"]) == {"C", "CC(=O)N"}
+
+
+def test_filter_by_tautomers_explicit_exclude():
+    data_frame = pandas.DataFrame(
+        [
+            {"N Components": 1, "Component 1": "CC(=O)N"},
+            {"N Components": 1, "Component 1": "C[N+](=O)[O-]"},
+        ]
+    )
+
+    filtered_frame = FilterByTautomers.apply(
+        data_frame,
+        FilterByTautomersSchema(categories_to_include=None, categories_to_exclude=["AMIDE_IMIDIC_ACID"]),
+    )
+
+    assert len(filtered_frame) == 1
+    assert filtered_frame.iloc[0]["Component 1"] == "C[N+](=O)[O-]"
+
+
+def test_filter_by_tautomers_exclude_suppression_canonical():
+    """Acetylacetone is canonically BETA_DIKETONE (suppression hides KETO_ENOL_ALIPHATIC).
+    Excluding KETO_ENOL_ALIPHATIC should therefore keep it; excluding BETA_DIKETONE
+    should remove it."""
+    data_frame = pandas.DataFrame(
+        [{"N Components": 1, "Component 1": "CC(=O)CC(=O)C"}]
+    )
+
+    # KETO_ENOL_ALIPHATIC is suppressed → molecule is kept
+    kept = FilterByTautomers.apply(
+        data_frame,
+        FilterByTautomersSchema(
+            categories_to_include=None,
+            categories_to_exclude=["KETO_ENOL_ALIPHATIC"],
+        ),
+    )
+    assert len(kept) == 1
+
+    # BETA_DIKETONE is its canonical category → molecule is removed
+    removed = FilterByTautomers.apply(
+        data_frame,
+        FilterByTautomersSchema(
+            categories_to_include=None,
+            categories_to_exclude=["BETA_DIKETONE"],
+        ),
+    )
+    assert len(removed) == 0
+
+
+def test_filter_by_tautomers_include_suppression_applied():
+    """In include mode, suppression must apply: enol-acetylacetone matches both
+    BETA_DIKETONE and KETO_ENOL_ALIPHATIC, but BETA_DIKETONE suppresses the
+    latter, so specifying categories_to_include=["BETA_DIKETONE"] must keep it.
+    The enol form CC(O)=CC(=O)C is used because BETA_DIKETONE's dominant form
+    is the enol."""
+    data_frame = pandas.DataFrame(
+        [{"N Components": 1, "Component 1": "CC(O)=CC(=O)C"}]
+    )
+
+    filtered_frame = FilterByTautomers.apply(
+        data_frame,
+        FilterByTautomersSchema(categories_to_include=["BETA_DIKETONE"]),
+    )
+
+    assert len(filtered_frame) == 1
+
+
+def test_filter_by_tautomers_minor_form_rejected():
+    """A molecule in the minor tautomeric form must be rejected even if its
+    category is whitelisted. CC(=O)O (acetic acid) is the dominant form and
+    passes; C=C(O)O (the enol/minor form) must be removed."""
+    data_frame = pandas.DataFrame(
+        [
+            {"N Components": 1, "Component 1": "CC(=O)O"},   # dominant — kept
+            {"N Components": 1, "Component 1": "C=C(O)O"},   # minor — removed
+        ]
+    )
+
+    filtered_frame = FilterByTautomers.apply(data_frame, FilterByTautomersSchema())
+
+    assert len(filtered_frame) == 1
+    assert filtered_frame.iloc[0]["Component 1"] == "CC(=O)O"
+
+
+def test_filter_by_tautomers_multi_component_row_removed():
+    data_frame = pandas.DataFrame(
+        [
+            {"N Components": 2, "Component 1": "C", "Component 2": "CCO"},
+            {
+                "N Components": 2,
+                "Component 1": "C",
+                "Component 2": "CC(=O)CC(=O)C",
+            },
+        ]
+    )
+
+    filtered_frame = FilterByTautomers.apply(data_frame, FilterByTautomersSchema())
+
+    assert len(filtered_frame) == 1
+    assert filtered_frame.iloc[0]["Component 2"] == "CCO"
+
+
+def test_filter_by_tautomers_empty_frame_no_failure():
+    data_frame = pandas.DataFrame(columns=["N Components", "Component 1"])
+
+    filtered_frame = FilterByTautomers.apply(data_frame, FilterByTautomersSchema())
+
+    assert len(filtered_frame) == 0

--- a/openff/evaluator/_tests/test_datasets/test_curation/test_tautomers.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_tautomers.py
@@ -19,24 +19,24 @@ def test_tautomer_category_table():
         # Dominant and minor SMILES are known molecules that each SMARTS must
         # directly match (no tautomer enumeration needed).  This proves the
         # SMARTS are chemically meaningful, not merely syntactically valid.
-        (TautomerCategory.AMIDE_IMIDIC_ACID,          "CC(=O)N",       "CC(=N)O"),
-        (TautomerCategory.BETA_DIKETONE,               "CC(O)=CC(=O)C", "CC(=O)CC(=O)C"),
-        (TautomerCategory.KETO_ENOL_ALIPHATIC,         "CCC(C)=O",      "CCC(O)=C"),
-        (TautomerCategory.KETO_ENOL_CYCLIC,            "O=C1CCCCC1",    "OC1=CCCCC1"),
-        (TautomerCategory.THIOKETONE_THIOL_ALIPHATIC,  "CC(=S)C",       "CC(S)=C"),
-        (TautomerCategory.KETO_ENOL_AROMATIC,          "Oc1ccccc1",     "O=C1C=CC=CC1"),
-        (TautomerCategory.IMINE_ENAMINE_SECONDARY,     "CCNC=C",        "CCN=CC"),
-        (TautomerCategory.IMINE_ENAMINE_PRIMARY,       "CC=N",          "CC(N)=C"),
-        (TautomerCategory.ALPHA_AMINO_ACID,            "NCC(=O)O",      "N=CC(O)O"),
+        (TautomerCategory.AMIDE_IMIDIC_ACID, "CC(=O)N", "CC(=N)O"),
+        (TautomerCategory.BETA_DIKETONE, "CC(O)=CC(=O)C", "CC(=O)CC(=O)C"),
+        (TautomerCategory.KETO_ENOL_ALIPHATIC, "CCC(C)=O", "CCC(O)=C"),
+        (TautomerCategory.KETO_ENOL_CYCLIC, "O=C1CCCCC1", "OC1=CCCCC1"),
+        (TautomerCategory.THIOKETONE_THIOL_ALIPHATIC, "CC(=S)C", "CC(S)=C"),
+        (TautomerCategory.KETO_ENOL_AROMATIC, "Oc1ccccc1", "O=C1C=CC=CC1"),
+        (TautomerCategory.IMINE_ENAMINE_SECONDARY, "CCNC=C", "CCN=CC"),
+        (TautomerCategory.IMINE_ENAMINE_PRIMARY, "CC=N", "CC(N)=C"),
+        (TautomerCategory.ALPHA_AMINO_ACID, "NCC(=O)O", "N=CC(O)O"),
         # 4-methylimidazole: the two N-H tautomers have distinct SMILES, so each
         # SMARTS is tested against a different molecule and a swap bug is detectable.
-        (TautomerCategory.ANNULAR_AZOLE,               "Cc1c[nH]cn1",   "Cc1cnc[nH]1"),
-        (TautomerCategory.LACTAM_LACTIM,               "O=C1CCCCN1",    "OC1=NCCCC1"),
-        (TautomerCategory.OXIME_NITROSO,               "CC=NO",         "CC(N=O)"),
-        (TautomerCategory.KETENE_YNOL,                 "CC=C=O",        "CC#CO"),
-        (TautomerCategory.CARBOXYLIC_ACID_ENOL,        "CC(=O)O",       "C=C(O)O"),
-        (TautomerCategory.ESTER_ENOL,                  "CC(=O)OC",      "C=C(O)OC"),
-        (TautomerCategory.AMIDE_ENOL,                  "CC(=O)NC",      "C=C(O)NC"),
+        (TautomerCategory.ANNULAR_AZOLE, "Cc1c[nH]cn1", "Cc1cnc[nH]1"),
+        (TautomerCategory.LACTAM_LACTIM, "O=C1CCCCN1", "OC1=NCCCC1"),
+        (TautomerCategory.OXIME_NITROSO, "CC=NO", "CC(N=O)"),
+        (TautomerCategory.KETENE_YNOL, "CC=C=O", "CC#CO"),
+        (TautomerCategory.CARBOXYLIC_ACID_ENOL, "CC(=O)O", "C=C(O)O"),
+        (TautomerCategory.ESTER_ENOL, "CC(=O)OC", "C=C(O)OC"),
+        (TautomerCategory.AMIDE_ENOL, "CC(=O)NC", "C=C(O)NC"),
     ],
 )
 def test_smarts_match_known_forms(category, dominant_smiles, minor_smiles):
@@ -44,33 +44,36 @@ def test_smarts_match_known_forms(category, dominant_smiles, minor_smiles):
     rule = TAUTOMER_RULES[category]
     dom_mol = Molecule.from_smiles(dominant_smiles, allow_undefined_stereo=True)
     min_mol = Molecule.from_smiles(minor_smiles, allow_undefined_stereo=True)
-    assert dom_mol.chemical_environment_matches(rule.dominant_smarts), (
-        f"{category} dominant_smarts did not match {dominant_smiles!r}"
-    )
-    assert min_mol.chemical_environment_matches(rule.minor_smarts), (
-        f"{category} minor_smarts did not match {minor_smiles!r}"
-    )
+    assert dom_mol.chemical_environment_matches(
+        rule.dominant_smarts
+    ), f"{category} dominant_smarts did not match {dominant_smiles!r}"
+    assert min_mol.chemical_environment_matches(
+        rule.minor_smarts
+    ), f"{category} minor_smarts did not match {minor_smiles!r}"
 
 
 @pytest.mark.parametrize(
     "smiles,expected_category",
     [
-        ("CC(=O)N", TautomerCategory.AMIDE_IMIDIC_ACID),            # acetamide
-        ("CC(=O)CC(=O)C", TautomerCategory.BETA_DIKETONE),         # acetylacetone
-        ("O=C1CCCCC1", TautomerCategory.KETO_ENOL_CYCLIC),         # cyclohexanone
-        ("CC(C)=O", TautomerCategory.KETO_ENOL_ALIPHATIC),         # acetone
-        ("c1ccccc1O", TautomerCategory.KETO_ENOL_AROMATIC),        # phenol
-        ("Cc1ccc(O)cc1", TautomerCategory.KETO_ENOL_AROMATIC),     # para-cresol
-        ("c1cnc[nH]1", TautomerCategory.ANNULAR_AZOLE),            # imidazole
-        ("NCC(=O)O", TautomerCategory.ALPHA_AMINO_ACID),           # glycine
-        ("O=C1CCCCN1", TautomerCategory.LACTAM_LACTIM),            # 2-piperidinone
-        ("CC=NO", TautomerCategory.OXIME_NITROSO),                  # acetaldoxime
-        ("CC=N", TautomerCategory.IMINE_ENAMINE_PRIMARY),           # ethylideneamine (acetaldehyde primary imine)
-        ("CCNC=C", TautomerCategory.IMINE_ENAMINE_SECONDARY),       # secondary enamine
+        ("CC(=O)N", TautomerCategory.AMIDE_IMIDIC_ACID),  # acetamide
+        ("CC(=O)CC(=O)C", TautomerCategory.BETA_DIKETONE),  # acetylacetone
+        ("O=C1CCCCC1", TautomerCategory.KETO_ENOL_CYCLIC),  # cyclohexanone
+        ("CC(C)=O", TautomerCategory.KETO_ENOL_ALIPHATIC),  # acetone
+        ("c1ccccc1O", TautomerCategory.KETO_ENOL_AROMATIC),  # phenol
+        ("Cc1ccc(O)cc1", TautomerCategory.KETO_ENOL_AROMATIC),  # para-cresol
+        ("c1cnc[nH]1", TautomerCategory.ANNULAR_AZOLE),  # imidazole
+        ("NCC(=O)O", TautomerCategory.ALPHA_AMINO_ACID),  # glycine
+        ("O=C1CCCCN1", TautomerCategory.LACTAM_LACTIM),  # 2-piperidinone
+        ("CC=NO", TautomerCategory.OXIME_NITROSO),  # acetaldoxime
+        (
+            "CC=N",
+            TautomerCategory.IMINE_ENAMINE_PRIMARY,
+        ),  # ethylideneamine (acetaldehyde primary imine)
+        ("CCNC=C", TautomerCategory.IMINE_ENAMINE_SECONDARY),  # secondary enamine
         ("CC(=S)C", TautomerCategory.THIOKETONE_THIOL_ALIPHATIC),  # thioacetone
-        ("CC=C=O", TautomerCategory.KETENE_YNOL),                   # methylketene
-        ("CC(=O)O", TautomerCategory.CARBOXYLIC_ACID_ENOL),         # acetic acid
-        ("CC(=O)OC", TautomerCategory.ESTER_ENOL),                  # methyl acetate
+        ("CC=C=O", TautomerCategory.KETENE_YNOL),  # methylketene
+        ("CC(=O)O", TautomerCategory.CARBOXYLIC_ACID_ENOL),  # acetic acid
+        ("CC(=O)OC", TautomerCategory.ESTER_ENOL),  # methyl acetate
     ],
 )
 def test_match_tautomer_categories(smiles, expected_category):
@@ -81,12 +84,12 @@ def test_match_tautomer_categories(smiles, expected_category):
 @pytest.mark.parametrize(
     "smiles",
     [
-        "C",         # methane
-        "CC",        # ethane
-        "CCO",       # ethanol
+        "C",  # methane
+        "CC",  # ethane
+        "CCO",  # ethanol
         "c1ccccc1",  # benzene
         "C1CCCCC1",  # cyclohexane
-        "CCOCC",     # diethyl ether
+        "CCOCC",  # diethyl ether
     ],
 )
 def test_match_tautomer_categories_no_match(smiles):

--- a/openff/evaluator/_tests/test_datasets/test_curation/test_tautomers.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_tautomers.py
@@ -1,0 +1,137 @@
+import pytest
+from openff.toolkit.topology import Molecule
+
+from openff.evaluator.datasets.curation.components.tautomers import (
+    TAUTOMER_RULES,
+    TautomerCategory,
+    _enumerate_tautomers_cached,
+    match_tautomer_categories,
+)
+
+
+def test_tautomer_category_table():
+    assert set(TAUTOMER_RULES).issubset(set(TautomerCategory))
+
+
+@pytest.mark.parametrize(
+    "category,dominant_smiles,minor_smiles",
+    [
+        # Dominant and minor SMILES are known molecules that each SMARTS must
+        # directly match (no tautomer enumeration needed).  This proves the
+        # SMARTS are chemically meaningful, not merely syntactically valid.
+        (TautomerCategory.AMIDE_IMIDIC_ACID,          "CC(=O)N",       "CC(=N)O"),
+        (TautomerCategory.BETA_DIKETONE,               "CC(O)=CC(=O)C", "CC(=O)CC(=O)C"),
+        (TautomerCategory.KETO_ENOL_ALIPHATIC,         "CCC(C)=O",      "CCC(O)=C"),
+        (TautomerCategory.KETO_ENOL_CYCLIC,            "O=C1CCCCC1",    "OC1=CCCCC1"),
+        (TautomerCategory.THIOKETONE_THIOL_ALIPHATIC,  "CC(=S)C",       "CC(S)=C"),
+        (TautomerCategory.KETO_ENOL_AROMATIC,          "Oc1ccccc1",     "O=C1C=CC=CC1"),
+        (TautomerCategory.IMINE_ENAMINE_SECONDARY,     "CCNC=C",        "CCN=CC"),
+        (TautomerCategory.IMINE_ENAMINE_PRIMARY,       "CC=N",          "CC(N)=C"),
+        (TautomerCategory.ALPHA_AMINO_ACID,            "NCC(=O)O",      "N=CC(O)O"),
+        # 4-methylimidazole: the two N-H tautomers have distinct SMILES, so each
+        # SMARTS is tested against a different molecule and a swap bug is detectable.
+        (TautomerCategory.ANNULAR_AZOLE,               "Cc1c[nH]cn1",   "Cc1cnc[nH]1"),
+        (TautomerCategory.LACTAM_LACTIM,               "O=C1CCCCN1",    "OC1=NCCCC1"),
+        (TautomerCategory.OXIME_NITROSO,               "CC=NO",         "CC(N=O)"),
+        (TautomerCategory.KETENE_YNOL,                 "CC=C=O",        "CC#CO"),
+        (TautomerCategory.CARBOXYLIC_ACID_ENOL,        "CC(=O)O",       "C=C(O)O"),
+        (TautomerCategory.ESTER_ENOL,                  "CC(=O)OC",      "C=C(O)OC"),
+        (TautomerCategory.AMIDE_ENOL,                  "CC(=O)NC",      "C=C(O)NC"),
+    ],
+)
+def test_smarts_match_known_forms(category, dominant_smiles, minor_smiles):
+    """Each SMARTS must match a known molecule, not merely parse without error."""
+    rule = TAUTOMER_RULES[category]
+    dom_mol = Molecule.from_smiles(dominant_smiles, allow_undefined_stereo=True)
+    min_mol = Molecule.from_smiles(minor_smiles, allow_undefined_stereo=True)
+    assert dom_mol.chemical_environment_matches(rule.dominant_smarts), (
+        f"{category} dominant_smarts did not match {dominant_smiles!r}"
+    )
+    assert min_mol.chemical_environment_matches(rule.minor_smarts), (
+        f"{category} minor_smarts did not match {minor_smiles!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "smiles,expected_category",
+    [
+        ("CC(=O)N", TautomerCategory.AMIDE_IMIDIC_ACID),            # acetamide
+        ("CC(=O)CC(=O)C", TautomerCategory.BETA_DIKETONE),         # acetylacetone
+        ("O=C1CCCCC1", TautomerCategory.KETO_ENOL_CYCLIC),         # cyclohexanone
+        ("CC(C)=O", TautomerCategory.KETO_ENOL_ALIPHATIC),         # acetone
+        ("c1ccccc1O", TautomerCategory.KETO_ENOL_AROMATIC),        # phenol
+        ("Cc1ccc(O)cc1", TautomerCategory.KETO_ENOL_AROMATIC),     # para-cresol
+        ("c1cnc[nH]1", TautomerCategory.ANNULAR_AZOLE),            # imidazole
+        ("NCC(=O)O", TautomerCategory.ALPHA_AMINO_ACID),           # glycine
+        ("O=C1CCCCN1", TautomerCategory.LACTAM_LACTIM),            # 2-piperidinone
+        ("CC=NO", TautomerCategory.OXIME_NITROSO),                  # acetaldoxime
+        ("CC=N", TautomerCategory.IMINE_ENAMINE_PRIMARY),           # ethylideneamine (acetaldehyde primary imine)
+        ("CCNC=C", TautomerCategory.IMINE_ENAMINE_SECONDARY),       # secondary enamine
+        ("CC(=S)C", TautomerCategory.THIOKETONE_THIOL_ALIPHATIC),  # thioacetone
+        ("CC=C=O", TautomerCategory.KETENE_YNOL),                   # methylketene
+        ("CC(=O)O", TautomerCategory.CARBOXYLIC_ACID_ENOL),         # acetic acid
+        ("CC(=O)OC", TautomerCategory.ESTER_ENOL),                  # methyl acetate
+    ],
+)
+def test_match_tautomer_categories(smiles, expected_category):
+    categories = match_tautomer_categories(smiles)
+    assert expected_category in categories
+
+
+@pytest.mark.parametrize(
+    "smiles",
+    [
+        "C",         # methane
+        "CC",        # ethane
+        "CCO",       # ethanol
+        "c1ccccc1",  # benzene
+        "C1CCCCC1",  # cyclohexane
+        "CCOCC",     # diethyl ether
+    ],
+)
+def test_match_tautomer_categories_no_match(smiles):
+    assert match_tautomer_categories(smiles) == frozenset()
+
+
+def test_amide_enol_secondary_amide():
+    """N-methyl acetamide (CC(=O)NC) triggers AMIDE_ENOL in raw SMARTS but is
+    suppressed because AMIDE_IMIDIC_ACID co-fires and takes priority for amides."""
+    raw = match_tautomer_categories("CC(=O)NC", suppress=False)
+    assert TautomerCategory.AMIDE_ENOL in raw
+    suppressed = match_tautomer_categories("CC(=O)NC")
+    assert TautomerCategory.AMIDE_IMIDIC_ACID in suppressed
+    assert TautomerCategory.AMIDE_ENOL not in suppressed
+
+
+@pytest.mark.parametrize(
+    "category,smiles,expect_dominant,expect_minor",
+    [
+        # AMIDE_ENOL: both dominant and minor are reachable from a single seed.
+        (TautomerCategory.AMIDE_ENOL, "CC(=O)NC", True, True),
+        # Plot uses an alternate lactam seed to make the lactam/lactim pair
+        # visually distinct while still matching both sides.
+        (TautomerCategory.LACTAM_LACTIM, "O=C1NCCC=C1", True, True),
+    ],
+)
+def test_plot_example_tautomer_coverage(
+    category,
+    smiles,
+    expect_dominant,
+    expect_minor,
+):
+    Molecule.from_smiles(smiles, allow_undefined_stereo=True)
+
+    rule = TAUTOMER_RULES[category]
+    tautomers = _enumerate_tautomers_cached(smiles)
+
+    has_dominant = any(
+        tautomer.chemical_environment_matches(rule.dominant_smarts)
+        for tautomer in tautomers
+    )
+    has_minor = any(
+        tautomer.chemical_environment_matches(rule.minor_smarts)
+        for tautomer in tautomers
+    )
+
+    assert has_dominant is expect_dominant
+    assert has_minor is expect_minor

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -1225,8 +1225,8 @@ class FilterByTautomersSchema(CurationComponentSchema):
     **Suppression**
 
     Category matching always uses suppression: if a molecule matches both a
-    parent category and a subordinate category, the subordinate is hidden and
-    only the parent is reported. The complete suppression table is defined in
+    parent category and a subordinate category, its match with the subordinate is hidden and
+    only its match with the parent is reported. The complete suppression table is defined in
     ``tautomers._SUPPRESSED_CATEGORY_MATCHES``; the most important cases are:
 
     * ``BETA_DIKETONE`` suppresses ``KETO_ENOL_ALIPHATIC``,

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -24,6 +24,11 @@ from openff.evaluator.datasets.curation.components import (
     CurationComponent,
     CurationComponentSchema,
 )
+from openff.evaluator.datasets.curation.components.tautomers import (
+    TAUTOMER_RULES,
+    TautomerCategory,
+    match_tautomer_categories,
+)
 from openff.evaluator.datasets.utilities import (
     data_frame_to_substances,
     reorder_data_frame,
@@ -1207,6 +1212,199 @@ class FilterByEnvironments(CurationComponent):
         return data_frame[data_frame.apply(filter_function, axis=1)]
 
 
+class FilterByTautomersSchema(CurationComponentSchema):
+    """Configure tautomer-family filtering for curated data.
+
+    By default, only tautomer categories in `categories_to_include` are retained;
+    components with no recognized tautomer family are always kept. Set exactly one
+    of `categories_to_include` or `categories_to_exclude` to control which families
+    are allowed.
+
+    Notes
+    -----
+    **Suppression**
+
+    Category matching always uses suppression: if a molecule matches both a
+    parent category and a subordinate category, the subordinate is hidden and
+    only the parent is reported. The complete suppression table is defined in
+    ``tautomers._SUPPRESSED_CATEGORY_MATCHES``; the most important cases are:
+
+    * ``BETA_DIKETONE`` suppresses ``KETO_ENOL_ALIPHATIC``,
+      ``CARBOXYLIC_ACID_ENOL``, and ``ESTER_ENOL``. Acetylacetone is
+      therefore classified only as ``BETA_DIKETONE`` — excluding
+      ``KETO_ENOL_ALIPHATIC`` alone does *not* remove it.
+    * ``AMIDE_IMIDIC_ACID`` suppresses ``AMIDE_ENOL`` (and several imine/enamine
+      categories). Specifying ``categories_to_include=["AMIDE_ENOL"]`` alone
+      will therefore remove most amide molecules, which are reclassified as
+      ``AMIDE_IMIDIC_ACID``. Always pair ``AMIDE_ENOL`` with
+      ``AMIDE_IMIDIC_ACID`` — the default whitelist already does this.
+
+    **Dominant-form check (include mode only)**
+
+    In include mode, every matched whitelisted category also requires the
+    stored SMILES to be in the *dominant* tautomeric form. This rejects
+    records where the SMILES encodes a minor tautomer (e.g. storing acetic
+    acid as ``C=C(O)O`` instead of ``CC(=O)O``). Dominant form is defined by
+    the SMARTS in ``tautomers.TAUTOMER_RULES[category].dominant_smarts``.
+    Exclude mode skips this check entirely; it only tests canonical category
+    membership.
+
+    A notable consequence: ``BETA_DIKETONE``'s dominant SMARTS matches the
+    *enol* form (e.g. ``CC(O)=CC(=O)C``) because in non-polar solvents the
+    enol predominates (Hansen 2023, doi:10.3390/encyclopedia3010013). Keto-form
+    records (``CC(=O)CC(=O)C``) are therefore rejected when ``BETA_DIKETONE``
+    is whitelisted. Recommend not whitelisting this category until
+    solvent-aware dominant-form detection is implemented.
+
+    Examples
+    --------
+    Override the default to keep only keto/enol families:
+
+    >>> FilterByTautomersSchema(categories_to_include=["KETO_ENOL_ALIPHATIC", "KETO_ENOL_CYCLIC"])
+
+    Exclude only beta-diketone families while keeping everything else:
+
+    >>> FilterByTautomersSchema(
+    ...     categories_to_include=None,
+    ...     categories_to_exclude=["BETA_DIKETONE"],
+    ... )
+    """
+
+    type: Literal["FilterByTautomers"] = "FilterByTautomers"
+
+    categories_to_include: Optional[List[str]] = Field(
+        [
+            "ALPHA_AMINO_ACID",
+            "AMIDE_IMIDIC_ACID",
+            "IMINE_ENAMINE_PRIMARY",
+            "IMINE_ENAMINE_SECONDARY",
+            "KETO_ENOL_ALIPHATIC",
+            "KETO_ENOL_CYCLIC",
+            "KETO_ENOL_AROMATIC",
+            "KETENE_YNOL",
+            "LACTAM_LACTIM",
+            "OXIME_NITROSO",
+            "CARBOXYLIC_ACID_ENOL",
+            "ESTER_ENOL",
+            "AMIDE_ENOL",
+        ],
+        description="The tautomer categories which are allowed to remain in the data "
+        "set. This option is mutually exclusive with `categories_to_exclude`.",
+    )
+    categories_to_exclude: Optional[List[str]] = Field(
+        None,
+        description="The tautomer categories which should be removed from the data "
+        "set. This option is mutually exclusive with `categories_to_include`.",
+    )
+
+    @model_validator(mode="after")
+    def _validate(self):
+        if (
+            self.categories_to_include is None
+            and self.categories_to_exclude is None
+        ):
+            raise ValueError(
+                "Exactly one of 'categories_to_include' or 'categories_to_exclude' "
+                "must be set; both cannot be None."
+            )
+        if (
+            self.categories_to_include is not None
+            and self.categories_to_exclude is not None
+        ):
+            raise ValueError(
+                "'categories_to_include' and 'categories_to_exclude' are mutually "
+                "exclusive; set exactly one."
+            )
+
+        valid_category_names = set(TautomerCategory.__members__)
+
+        if self.categories_to_include is not None:
+            if len(self.categories_to_include) == 0:
+                raise ValueError("'categories_to_include' must not be empty.")
+            unknown = [
+                c for c in self.categories_to_include
+                if c not in valid_category_names
+            ]
+            if unknown:
+                raise ValueError(
+                    f"Unknown tautomer categories in 'categories_to_include': {unknown}"
+                )
+
+        if self.categories_to_exclude is not None:
+            unknown = [
+                c for c in self.categories_to_exclude
+                if c not in valid_category_names
+            ]
+            if unknown:
+                raise ValueError(
+                    f"Unknown tautomer categories in 'categories_to_exclude': {unknown}"
+                )
+
+        return self
+
+
+class FilterByTautomers(CurationComponent):
+    """A component which filters out measurements for components whose enumerated
+    tautomer families fall outside an allowed category set.
+
+    Notes
+    -----
+    This filter uses pair-based RDKit tautomer enumeration and only considers a
+    category matched when both the dominant and minor SMARTS are found across the
+    enumerated tautomer set. Categories that depend on ring-closure tautomerism may
+    therefore remain unmatched if RDKit does not enumerate the corresponding forms.
+    """
+
+    @classmethod
+    def _apply(
+        cls,
+        data_frame: pandas.DataFrame,
+        schema: FilterByTautomersSchema,
+        n_processes,
+    ) -> pandas.DataFrame:
+        if len(data_frame) == 0:
+            return data_frame
+
+        from openff.toolkit.topology import Molecule
+
+        if schema.categories_to_exclude is not None:
+            excluded = {TautomerCategory[c] for c in schema.categories_to_exclude}
+            allowed_categories = set(TautomerCategory) - excluded
+        else:
+            allowed_categories = {
+                TautomerCategory[c] for c in schema.categories_to_include
+            }
+
+        def filter_function(data_row):
+            n_components = data_row["N Components"]
+
+            for index in range(n_components):
+                smiles = data_row[f"Component {index + 1}"]
+                matched_categories = match_tautomer_categories(smiles)
+
+                if matched_categories - allowed_categories:
+                    return False
+
+                # In include mode only: require the input SMILES to be in
+                # the dominant tautomeric form for each matched category.
+                # This check does not apply in exclude mode — the goal there
+                # is purely to discard disallowed canonical categories.
+                if schema.categories_to_include is not None:
+                    whitelisted_matches = matched_categories & allowed_categories
+                    if whitelisted_matches:
+                        mol = Molecule.from_smiles(smiles, allow_undefined_stereo=True)
+                        for category in whitelisted_matches:
+                            if not mol.chemical_environment_matches(
+                                TAUTOMER_RULES[category].dominant_smarts
+                            ):
+                                return False
+
+            return True
+
+        # noinspection PyTypeChecker
+        return data_frame[data_frame.apply(filter_function, axis=1)]
+
+
 FilterComponentSchema = Union[
     FilterDuplicatesSchema,
     FilterByTemperatureSchema,
@@ -1223,4 +1421,5 @@ FilterComponentSchema = Union[
     FilterByNComponentsSchema,
     FilterBySubstancesSchema,
     FilterByEnvironmentsSchema,
+    FilterByTautomersSchema,
 ]

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -1299,10 +1299,7 @@ class FilterByTautomersSchema(CurationComponentSchema):
 
     @model_validator(mode="after")
     def _validate(self):
-        if (
-            self.categories_to_include is None
-            and self.categories_to_exclude is None
-        ):
+        if self.categories_to_include is None and self.categories_to_exclude is None:
             raise ValueError(
                 "Exactly one of 'categories_to_include' or 'categories_to_exclude' "
                 "must be set; both cannot be None."
@@ -1322,8 +1319,7 @@ class FilterByTautomersSchema(CurationComponentSchema):
             if len(self.categories_to_include) == 0:
                 raise ValueError("'categories_to_include' must not be empty.")
             unknown = [
-                c for c in self.categories_to_include
-                if c not in valid_category_names
+                c for c in self.categories_to_include if c not in valid_category_names
             ]
             if unknown:
                 raise ValueError(
@@ -1332,8 +1328,7 @@ class FilterByTautomersSchema(CurationComponentSchema):
 
         if self.categories_to_exclude is not None:
             unknown = [
-                c for c in self.categories_to_exclude
-                if c not in valid_category_names
+                c for c in self.categories_to_exclude if c not in valid_category_names
             ]
             if unknown:
                 raise ValueError(

--- a/openff/evaluator/datasets/curation/components/tautomers.py
+++ b/openff/evaluator/datasets/curation/components/tautomers.py
@@ -166,10 +166,7 @@ def _to_category_tuple(
     categories: Optional[Iterable[TautomerCategory]],
 ) -> Tuple[str, ...]:
     if categories is None:
-        return tuple(
-            category.value
-            for category in TautomerCategory
-        )
+        return tuple(category.value for category in TautomerCategory)
 
     return tuple(sorted(category.value for category in categories))
 

--- a/openff/evaluator/datasets/curation/components/tautomers.py
+++ b/openff/evaluator/datasets/curation/components/tautomers.py
@@ -1,0 +1,245 @@
+import functools
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, FrozenSet, Iterable, Optional, Tuple
+
+from rdkit import Chem
+from rdkit.Chem.MolStandardize import rdMolStandardize
+
+
+class TautomerCategory(str, Enum):
+    BETA_DIKETONE = "BETA_DIKETONE"
+    KETO_ENOL_ALIPHATIC = "KETO_ENOL_ALIPHATIC"
+    KETO_ENOL_CYCLIC = "KETO_ENOL_CYCLIC"
+    THIOKETONE_THIOL_ALIPHATIC = "THIOKETONE_THIOL_ALIPHATIC"
+    KETO_ENOL_AROMATIC = "KETO_ENOL_AROMATIC"
+    IMINE_ENAMINE_SECONDARY = "IMINE_ENAMINE_SECONDARY"
+    IMINE_ENAMINE_PRIMARY = "IMINE_ENAMINE_PRIMARY"
+    ALPHA_AMINO_ACID = "ALPHA_AMINO_ACID"
+    ANNULAR_AZOLE = "ANNULAR_AZOLE"
+    LACTAM_LACTIM = "LACTAM_LACTIM"
+    AMIDE_IMIDIC_ACID = "AMIDE_IMIDIC_ACID"
+    OXIME_NITROSO = "OXIME_NITROSO"
+    KETENE_YNOL = "KETENE_YNOL"
+    CARBOXYLIC_ACID_ENOL = "CARBOXYLIC_ACID_ENOL"
+    ESTER_ENOL = "ESTER_ENOL"
+    AMIDE_ENOL = "AMIDE_ENOL"
+
+
+@dataclass(frozen=True)
+class TautomerRule:
+    dominant_smarts: str
+    minor_smarts: str
+
+
+TAUTOMER_RULES: Dict[TautomerCategory, TautomerRule] = {
+    # Hansen 2023, doi: 10.3390/encyclopedia3010013
+    # ratio of keto/enol forms depends on polarity of solvent and character of substituents.
+    # recommend not whitelisting this category, but it is included here for completeness
+    # and potential future work.
+    TautomerCategory.BETA_DIKETONE: TautomerRule(
+        dominant_smarts="[#1:5]-[#8X2:1]-[#6X3:2]=[#6X3:3]-[#6X3:4]=[#8X1:6]",
+        minor_smarts="[#8X1:1]=[#6X3:2]-[#6AX4:3](-[#1:5])-[#6X3:4]=[#8X1:6]",
+    ),
+    # classic example of keto/enol tautomerism,
+    # keto form dominates; stabilized by carbonyl,
+    # see Clayden, Greeves and Warren, Organic Chemistry, 2nd Ed., section 21 (p. 471)
+    TautomerCategory.KETO_ENOL_ALIPHATIC: TautomerRule(
+        dominant_smarts="[#8;X1;!r:1]=[#6X3;!r;!$([#6X3]-[#8X2]);!$([#6X3]-[#7]):2]-[#6AX4;!r;!$([#6AX4]~[#7,#16,#15]);!$([#6AX4]~[c]):3]-[#1:4]",
+        minor_smarts="[#1:4]-[#8;X2H1;!r:1]-[#6X3;!r;!$([#6X3]-[#7]):2]=[#6AX3;!$([#6AX3]~[#7,#16,#15]);!$([#6AX3]-[#6X3]=[#8,#16]);!$([#6AX3]~[c]):3]",
+    ),
+    # separate out this category to avoid confusion with aromatic enols
+    # ketone still dominant
+    TautomerCategory.KETO_ENOL_CYCLIC: TautomerRule(
+        dominant_smarts="[#8;X1:1]=[#6X3;R;A;!$([#6X3;R;A]~[#6X3;R]=[#8X1]);!$([#6X3;R;A]~[#8;R]):2]-[#6X4;A;R;!$([#6X4;R]~[#7,#16,#15]);!$([#6X4;R]~[#8;R]):3]-[#1:4]",
+        minor_smarts="[#1:4]-[#8;X2H1:1]-[#6X3;A;R;!$([#6X3;R]~[#7;R]):2]=[#6X3;A;R;!$([#6X3;R]~[#7,#16,#15]);!$([#6X3;R]~[#6X3]=[#16]):3]",
+    ),
+    # need this because RDKit finds tautomers for acids
+    TautomerCategory.CARBOXYLIC_ACID_ENOL: TautomerRule(
+        dominant_smarts="[#1:1]-[#8X2H1:2]-[#6X3:3](-[#6;!$([*](-[#6X3]=[#8X1])~[#6X3]~[#8]):5]-[#1:6])=[#8X1:4]",
+        minor_smarts="[#1:1]-[#8X2H1:2]-[#6X3:3](=[#6;!$([*]-[#6X3]=[#8X1]):5])-[#8X2:4]-[#1:6]",
+    ),
+    # ester enol; ester strongly dominates. analogous to CARBOXYLIC_ACID_ENOL
+    # but the alcohol oxygen bears a carbon substituent rather than H.
+    TautomerCategory.ESTER_ENOL: TautomerRule(
+        dominant_smarts="[#6:1]-[#8X2H0:2]-[#6X3:3](-[#6;!$([*](-[#6X3]=[#8X1])~[#6X3]~[#8]):5]-[#1:6])=[#8X1:4]",
+        minor_smarts="[#6:1]-[#8X2H0:2]-[#6X3:3](=[#6;!$([*]-[#6X3]=[#8X1]):5])-[#8X2:4]-[#1:6]",
+    ),
+    TautomerCategory.AMIDE_ENOL: TautomerRule(
+        dominant_smarts="[#1:6]-[#7X3;!r;!$([#7X3]-[#6X3]=[#7]):1]-[#6X3:2](=[#8X1:3])-[#6X4:4]-[#1:5]",
+        minor_smarts="[#1:6]-[#7X3;!r;!$([#7X3]-[#6X3]=[#7]):1]-[#6X3:2](-[#8X2:3]-[#1:5])=[#6X3:4]",
+    ),
+    # aka thione/thiol.
+    # likely low-populated, as thioketones and enethiols are inherently unstable (Bruno, Steer and Mezey, 1982).
+    # in general tautomers interconvert and both forms can be present at equilibrium
+    # (see Bruno, Steer and Mezey, 1982; Selzer and Rappoport 1996) although the thione may be more stable
+    # (see Ashry et al 2017, Journal of Molecular Structure).
+    # recommend not whitelisting this category, but it is included here for completeness and potential future work.
+    TautomerCategory.THIOKETONE_THIOL_ALIPHATIC: TautomerRule(
+        dominant_smarts="[#16;X1;!r:1]=[#6X3;!r:2]-[#6AX4;!r:3]-[#1:4]",
+        minor_smarts="[#1:4]-[#16;X2H1;!r:1]-[#6X3;!r:2]=[#6AX3;!r:3]",
+    ),
+    # other classic example of keto/enol tautomerism, but stabilized by aromaticity
+    # see Clayden again, same page. Enol is dominant.
+    TautomerCategory.KETO_ENOL_AROMATIC: TautomerRule(
+        dominant_smarts="[#1:4]-[#8,#16;X2H1:1]-[#6aX3:2]~[#6aX3:3]~[#6a:5]",
+        minor_smarts="[#8,#16;X1:1]=[#6X3R;r5,r6:2]-[#6X4R;r5,r6:3](-[#1:4])",
+    ),
+    # see Clayden 2nd edition p. 456, for secondary, enamine is dominant
+    TautomerCategory.IMINE_ENAMINE_SECONDARY: TautomerRule(
+        dominant_smarts="[#1,#6:4][#7X3;!r:1]([#1,#6:5])[#6X3:2]=[#6X3:3]",
+        minor_smarts="[#1,#6:5][#7X2;H0;!r:1]=[#6X3:2][#6AX4:3][#1:4]",
+    ),
+    # Clayden 2nd edition p. 455, for primary, imine is dominant
+    TautomerCategory.IMINE_ENAMINE_PRIMARY: TautomerRule(
+        dominant_smarts="[#7X2;H1:1]=[#6X3:2][#6AX4;!$([#6AX4]~[#6X3]=[#8,#16]);!$([#6AX4]~[#7X3;+1]):3][#1:4]",
+        minor_smarts="[#7X3;H2:1][#6X3:2]=[#6X3:3]",
+    ),
+    # amino acid form (NH2-CαH-C=O) dominates; the imino-diol minor tautomer
+    # is chemically exotic and mostly arises as a spurious RDKit enumeration product.
+    # recommend whitelist!
+    TautomerCategory.ALPHA_AMINO_ACID: TautomerRule(
+        dominant_smarts="[#7X3;H2:1]-[#6AX4:2](-[#1:5])-[#6X3:3]=[#8X1:4]",
+        minor_smarts="[#1:5]-[#7X2:1]=[#6X3:2]-[#6X4:3](-[#8X2H1:4])-[#8X2H1:6]",
+    ),
+    # no universally dominant form; ratio depends on substitution and solvent.
+    # generally quite complicated and varies by solvent and substituent,
+    # only listed here for completeness sake and future work.
+    # see Katritzsky 1970: the prototropic tautomerism of heteroaromatic compounds
+    # (probably newer sources too)
+    TautomerCategory.ANNULAR_AZOLE: TautomerRule(
+        dominant_smarts="[#1:3]-[#7X3R:1]@[#6R:2]@[#7X2R:4]",
+        minor_smarts="[#7X2R:1]@[#6R:2]@[#7X3R:4]-[#1:3]",
+    ),
+    # lactam usually dominates in 5-membered rings (Pilgram 1984 4.36.3.1.2)
+    # and in saturated lactams (Jose and De 2025, J Comp Chem)
+    TautomerCategory.LACTAM_LACTIM: TautomerRule(
+        dominant_smarts="[#1:4]-[#7X3R;A;!$([#7;r5]@[#8R,#7R]):1]@[#6R;A:2]=[#8X1!R:3]",
+        minor_smarts="[#7RH0;A;!$([#7;r5]@[#8R,#7R]):1]@[#6R;A:2]-[#8X2H1!R:3]-[#1:4]",
+    ),
+    # amide dominates
+    TautomerCategory.AMIDE_IMIDIC_ACID: TautomerRule(
+        dominant_smarts="[#1:4]-[#7X3;!r;!$([#7X3]-[#6X3]=[#7]):1]-[#6X3:2]=[#8X1:3]",
+        minor_smarts="[#7X2;!r:1]=[#6X3:2]-[#8X2H1:3]-[#1:4]",
+    ),
+    # oxime is stable -- Clayden
+    TautomerCategory.OXIME_NITROSO: TautomerRule(
+        dominant_smarts="[#1:4]-[#8X2:1]-[#7X2:2]=[#6X3:3]",
+        minor_smarts="[#8X1:1]=[#7X2:2]-[#6X4:3]-[#1:4]",
+    ),
+    # ketenes more stable
+    # Zhdankin 2005, Comprehensive Organic Functional Group Transformations II, 2.21.2.1.1
+    TautomerCategory.KETENE_YNOL: TautomerRule(
+        dominant_smarts="[#1:4]-[#6X3:1]=[#6X2:2]=[#8X1:3]",
+        minor_smarts="[#6X2:1]#[#6X2:2]-[#8X2:3]-[#1:4]",
+    ),
+}
+
+
+_TAUTOMER_ENUMERATOR = rdMolStandardize.TautomerEnumerator()
+
+_SUPPRESSED_CATEGORY_MATCHES = {
+    TautomerCategory.BETA_DIKETONE: frozenset(
+        {
+            TautomerCategory.KETO_ENOL_ALIPHATIC,
+            # beta-keto acids and beta-keto esters should be classified as
+            # BETA_DIKETONE, not as CARBOXYLIC_ACID_ENOL / ESTER_ENOL.
+            # LW: I tried for some time and could not generalize exclusive SMARTS,
+            # nor could Claude, so this seemed easier
+            TautomerCategory.CARBOXYLIC_ACID_ENOL,
+            TautomerCategory.ESTER_ENOL,
+        }
+    ),
+    TautomerCategory.AMIDE_IMIDIC_ACID: frozenset(
+        {
+            TautomerCategory.IMINE_ENAMINE_PRIMARY,
+            TautomerCategory.KETO_ENOL_ALIPHATIC,
+            TautomerCategory.IMINE_ENAMINE_SECONDARY,
+            TautomerCategory.AMIDE_ENOL,
+            # quite a few things matching the elementary amide pattern
+        }
+    ),
+}
+
+
+def _to_category_tuple(
+    categories: Optional[Iterable[TautomerCategory]],
+) -> Tuple[str, ...]:
+    if categories is None:
+        return tuple(
+            category.value
+            for category in TautomerCategory
+        )
+
+    return tuple(sorted(category.value for category in categories))
+
+
+@functools.lru_cache(maxsize=4096)
+def _enumerate_tautomers_cached(smiles: str) -> tuple:
+    from openff.toolkit.topology import Molecule
+
+    rdmol = Chem.MolFromSmiles(smiles)
+    if rdmol is None:
+        return tuple()
+
+    tautomers = []
+    seen = set()
+    # Enumerate always includes the input molecule, so no need to pre-seed `seen`.
+    for t in _TAUTOMER_ENUMERATOR.Enumerate(rdmol):
+        smi = Chem.MolToSmiles(t, isomericSmiles=True)
+        if smi not in seen:
+            seen.add(smi)
+            try:
+                tautomers.append(Molecule.from_smiles(smi, allow_undefined_stereo=True))
+            except Exception:
+                pass
+
+    return tuple(tautomers)
+
+
+@functools.lru_cache(maxsize=4096)
+def _match_tautomer_categories_cached(
+    smiles: str, category_names: Tuple[str, ...]
+) -> FrozenSet[TautomerCategory]:
+    """Return the raw (unsuppressed) set of matched categories."""
+    tautomers = _enumerate_tautomers_cached(smiles)
+
+    if not tautomers:
+        return frozenset()
+
+    matched_categories = set()
+
+    for category_name in category_names:
+        category = TautomerCategory(category_name)
+        rule = TAUTOMER_RULES[category]
+
+        has_dominant = any(
+            t.chemical_environment_matches(rule.dominant_smarts) for t in tautomers
+        )
+        has_minor = any(
+            t.chemical_environment_matches(rule.minor_smarts) for t in tautomers
+        )
+
+        if has_dominant and has_minor:
+            matched_categories.add(category)
+
+    return frozenset(matched_categories)
+
+
+def _apply_suppression(
+    matched: FrozenSet[TautomerCategory],
+) -> FrozenSet[TautomerCategory]:
+    result = set(matched)
+    for category, suppressed in _SUPPRESSED_CATEGORY_MATCHES.items():
+        if category in result:
+            result.difference_update(suppressed)
+    return frozenset(result)
+
+
+def match_tautomer_categories(
+    smiles: str,
+    categories: Optional[Iterable[TautomerCategory]] = None,
+    suppress: bool = True,
+) -> FrozenSet[TautomerCategory]:
+    raw = _match_tautomer_categories_cached(smiles, _to_category_tuple(categories))
+    return _apply_suppression(raw) if suppress else raw

--- a/openff/evaluator/datasets/curation/components/tautomers.py
+++ b/openff/evaluator/datasets/curation/components/tautomers.py
@@ -186,10 +186,7 @@ def _enumerate_tautomers_cached(smiles: str) -> tuple:
         smi = Chem.MolToSmiles(t, isomericSmiles=True)
         if smi not in seen:
             seen.add(smi)
-            try:
-                tautomers.append(Molecule.from_smiles(smi, allow_undefined_stereo=True))
-            except Exception:
-                pass
+            tautomers.append(Molecule.from_smiles(smi, allow_undefined_stereo=True))
 
     return tuple(tautomers)
 


### PR DESCRIPTION
## Description

Adds functions for classifying, and filtering out, molecules that may be tautomers. The rules and examples are plotted below. There are a lot of considerations as to which and how much a form is dominant, so I don't recommend whitelisting some categories. Others, of course, are very common, like keto/enol tautomerism. 

I initially considered simply removing any molecule that had possible tautomers generaetd by RDKit's EnumerateTautomers function, but that would flag very simple molecules like acetone -- hence the need to overcomplicate and classify.

As mentioned very quickly in the FF fitting meeting today, this only would really apply to a small subset of ThermoML (~400 unique molecules), and the classified molecules largley did not raise red flags, save perhaps the ANNULAR_AZOLE category. This unfortunately was me throwing my hands up at the multitude of considerations of ring nitrogen tautomers and dumping them all into the one category. 


<img width="3594" height="3516" alt="tautomer_rules" src="https://github.com/user-attachments/assets/2a9d2821-c207-4d55-9a04-f42ca2437dc9" />


<img width="1500" height="945" alt="tautomers-summary" src="https://github.com/user-attachments/assets/73ce19b8-1eda-497b-a649-5d6d7045c781" />
