### PR TITLE
Add soft propertytype filter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,13 @@ ci:
 files: (^pyproject.toml|openff|^utilities|^integration-tests|^docs)
 repos:
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 26.3.1
+  rev: 26.5.1
   hooks:
   - id: black
   - id: black-jupyter
     files: ^docs/tutorials
 - repo: https://github.com/PyCQA/isort
-  rev: 9.0.0a3
+  rev: 9.0.0b1
   hooks:
   - id: isort
 - repo: https://github.com/PyCQA/flake8
@@ -31,6 +31,6 @@ repos:
     - id: nbstripout
       files: ^docs/tutorial
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: v2.21.1
+  rev: v2.27.0
   hooks:
     - id: pyproject-fmt

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -175,6 +175,8 @@ Data Set API
     FilterBySubstances
     FilterByEnvironmentsSchema
     FilterByEnvironments
+    FilterByCoreAndAdditionalPropertyTypesSchema
+    FilterByCoreAndAdditionalPropertyTypes
 
 *FreeSolv*
 

--- a/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
@@ -1225,15 +1225,18 @@ def _substances_for_property(data_frame: pandas.DataFrame, property_type: str) -
 
 class TestFilterByCoreAndAdditionalPropertyTypes:
 
+    property_types = ["Density", "EnthalpyOfMixing"]
+
     def test_validate_filter_by_core_and_additional(self):
+        """Generally test valid arguments for schema and set expectations"""
         # Valid schema
         FilterByCoreAndAdditionalPropertyTypesSchema(
             core_property_types={"Density": None},
-            additional_property_types={"SurfaceTension": None},
+            additional_property_types={"EnthalpyOfMixing": None},
         )
         FilterByCoreAndAdditionalPropertyTypesSchema(
             core_property_types={"Density": [1]},
-            additional_property_types={"SurfaceTension": None},
+            additional_property_types={"EnthalpyOfMixing": None},
             scale_factor=0.0,
         )
 
@@ -1248,7 +1251,7 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         with pytest.raises(ValidationError):
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"Density": None},
-                additional_property_types={"SurfaceTension": None},
+                additional_property_types={"EnthalpyOfMixing": None},
                 scale_factor=-1.0,
             )
 
@@ -1256,7 +1259,7 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         with pytest.raises(ValidationError):
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={},
-                additional_property_types={"SurfaceTension": None},
+                additional_property_types={"EnthalpyOfMixing": None},
             )
         with pytest.raises(ValidationError):
             FilterByCoreAndAdditionalPropertyTypesSchema(
@@ -1268,95 +1271,110 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         with pytest.raises(ValidationError):
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"Density": None},
-                additional_property_types={"SurfaceTension": None},
+                additional_property_types={"EnthalpyOfMixing": None},
                 select_by="random",
             )
 
-    def test_filter_by_core_and_additional(self):
+    def test_filter_by_core_and_additional_truncates_correctly(self):
         # Core substances = intersection of all core property type substance sets.
         # Additional substances = overlap (always) + gap-fill up to
         # int(scale_factor * core_count) per additional type.
-        property_types = ["Density", "SurfaceTension"]
         substance_entries = [
-            (("CC",),    (True, True)),
-            (("CCC",),   (True, True)),
-            (("CCCC",),  (True, True)),
-            (("CCCCC",), (False, True)),  # additional-only, excluded at target=3
+            (("CC",),       (True, False)),
+            (("CC", "O"),   (True, True)),
+            (("CCC",),      (True, False)),
+            (("CCC", "O"),  (False, True)),
+            (("CCCC",),     (True, False)),
+            (("CCCC", "O"), (True, True)),
+            (("CCCCC", "O"), (False, True)),  # no density -- not in core
         ]
-        data_frame = _build_data_frame(property_types, substance_entries)
+        data_frame = _build_data_frame(self.property_types, substance_entries)
 
         filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None},
-                additional_property_types={"SurfaceTension": None},
+                core_property_types={"EnthalpyOfMixing": None},
+                additional_property_types={"Density": None},
                 scale_factor=1.0,
             ),
         )
-
         assert _substances_for_property(filtered, "Density") == {
-            ("CC",), ("CCC",), ("CCCC",)
+            ("CC",), ("CCC",), ("CCCC",),
+            ("CC", "O"), ("CCC", "O"), ("CCCC", "O")
         }
-        assert _substances_for_property(filtered, "SurfaceTension") == {
-            ("CC",), ("CCC",), ("CCCC",)
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
+            ("CC", "O"), ("CCC", "O"), ("CCCC", "O")
         }
-        assert ("CCCCC",) not in data_frame_to_substances(filtered)
+        assert ("CCCCC", "O") not in data_frame_to_substances(filtered)
 
+    def test_filter_by_core_and_additional_full_overlap_ignore_scale_factor(self):
         # Overlap > target: full overlap is retained without truncation.
         substance_entries = [
-            (("CC",),    (True, True)),
-            (("CCC",),   (True, True)),
-            (("CCCC",),  (True, True)),
-            (("CCCCC",), (True, True)),
+            (("CC",),       (True, False)),
+            (("CC", "O"),   (True, True)),
+            (("CCC",),      (True, False)),
+            (("CCC", "O"),  (True, True)),
+            (("CCCC",),     (True, False)),
+            (("CCCC", "O"), (True, True)),
+            (("CCCCC",),    (True, False)),
+            (("CCCCC", "O"), (True, True)),
         ]
-        data_frame = _build_data_frame(property_types, substance_entries)
+        data_frame = _build_data_frame(self.property_types, substance_entries)
 
         filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None},
-                additional_property_types={"SurfaceTension": None},
+                core_property_types={"EnthalpyOfMixing": None},
+                additional_property_types={"Density": None},
                 scale_factor=0.5,  # target=2 but overlap=4 → keep all 4
             ),
         )
 
-        assert _substances_for_property(filtered, "SurfaceTension") == {
-            ("CC",), ("CCC",), ("CCCC",), ("CCCCC",)
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
+            ("CC", "O"), ("CCC", "O"), ("CCCC", "O"), ("CCCCC", "O")
         }
 
+    def test_filter_by_core_and_additional_no_overlap(self):
         # scale_factor=0: no additional rows selected.
         substance_entries = [
-            (("CC",),   (True, True)),
-            (("CCC",),  (True, True)),
-            (("CCCC",), (False, True)),
+            (("CC",),       (True, False)),
+            (("CC", "O"),   (True, True)),
+            (("CCC",),      (True, False)),
+            (("CCC", "O"),  (True, False)),
+            (("CCCC",),     (True, False)),
+            (("CCCC", "O"), (True, False)),
         ]
-        data_frame = _build_data_frame(property_types, substance_entries)
+        data_frame = _build_data_frame(self.property_types, substance_entries)
 
         filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None},
-                additional_property_types={"SurfaceTension": None},
+                core_property_types={"EnthalpyOfMixing": None},
+                additional_property_types={"Density": None},
                 scale_factor=0.0,
             ),
         )
 
         assert _substances_for_property(filtered, "Density") == {("CC",), ("CCC",)}
-        assert _substances_for_property(filtered, "SurfaceTension") == set()
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == set()
 
+    def test_filter_by_core_and_additional_fewer_candidates_than_target(self):
         # Fewer candidates than target: return all available.
         substance_entries = [
-            (("CC",),   (True, True)),
-            (("CCC",),  (True, False)),
-            (("CCCC",), (True, False)),
+            (("CC",),       (True, False)),
+            (("CC", "O"),   (False, True)),
+            (("CCC",),      (True, False)),
+            (("CCC", "O"),  (False, True)),
+            (("CCCC",),     (True, False)),
+            (("CCCC", "O"), (False, False)),
         ]
-        data_frame = _build_data_frame(property_types, substance_entries)
+        data_frame = _build_data_frame(self.property_types, substance_entries)
 
         filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"Density": None},
-                additional_property_types={"SurfaceTension": None},
+                additional_property_types={"EnthalpyOfMixing": None},
                 scale_factor=1.0,
             ),
         )
@@ -1364,16 +1382,19 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         assert _substances_for_property(filtered, "Density") == {
             ("CC",), ("CCC",), ("CCCC",)
         }
-        assert _substances_for_property(filtered, "SurfaceTension") == {("CC",)}
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CC", "O")}
 
     def test_filter_by_core_and_additional_empty_core(self):
-        # Empty core intersection → empty result.
-        property_types = ["Density", "Viscosity", "SurfaceTension"]
+        # Empty core intersection of density and enthalpy of vaporization --> empty result.
+        property_types = ["Density", "EnthalpyOfVaporization", "EnthalpyOfMixing"]
         substance_entries = [
-            (("CC",),    (True, False, True)),
-            (("CCC",),   (True, False, True)),
-            (("CCCC",),  (False, True, True)),
-            (("CCCCC",), (False, True, False)),
+            (("CC",),       (True, False, False)),
+            (("CCC",),      (True, False, False)),
+            (("CCCC",),     (False, True, False)),
+            (("CCCCC",),    (False, True, False)),
+            (("CC", "O"),   (False, False, True)),
+            (("CCC", "O"),  (False, False, True)),
+            (("CCCC", "O"), (False, False, True)),
         ]
         data_frame = _build_data_frame(property_types, substance_entries)
 
@@ -1381,7 +1402,7 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"Density": None, "Viscosity": None},
-                additional_property_types={"SurfaceTension": None},
+                additional_property_types={"EnthalpyOfMixing": None},
                 scale_factor=1.0,
             ),
         )
@@ -1390,37 +1411,42 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
 
     def test_filter_by_core_and_additional_multiple_core_types(self):
         """Strict intersection across multiple core types."""
-        property_types = ["Density", "Viscosity", "SurfaceTension"]
+        property_types = ["Density", "EnthalpyOfVaporization", "EnthalpyOfMixing"]
         substance_entries = [
-            (("CC",),    (True, True, True)),
-            (("CCC",),   (True, True, True)),
-            (("CCCC",),  (True, False, True)),   # Density + ST, not Viscosity
-            (("CCCCC",), (False, True, False)),  # Viscosity only
+            (("CC",),       (True, True, False)),
+            (("CC", "O"),   (False, False, True)),
+            (("CCC",),      (True, True, False)),
+            (("CCC", "O"),  (False, False, True)),
+            (("CCCC",),     (True, False, False)),   # Density only, not EnthalpyOfVaporization
+            (("CCCC", "O"), (False, False, True)),   # EOM only
+            (("CCCCC",),    (False, True, False)),   # EnthalpyOfVaporization only
         ]
         data_frame = _build_data_frame(property_types, substance_entries)
 
         filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None, "Viscosity": None},
-                additional_property_types={"SurfaceTension": None},
+                core_property_types={"Density": None, "EnthalpyOfVaporization": None},
+                additional_property_types={"EnthalpyOfMixing": None},
                 scale_factor=1.0,
             ),
         )
 
         assert _substances_for_property(filtered, "Density") == {("CC",), ("CCC",)}
-        assert _substances_for_property(filtered, "Viscosity") == {("CC",), ("CCC",)}
-        assert _substances_for_property(filtered, "SurfaceTension") == {("CC",), ("CCC",)}
+        assert _substances_for_property(filtered, "EnthalpyOfVaporization") == {("CC",), ("CCC",)}
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CC", "O"), ("CCC", "O")}
         assert ("CCCC",) not in data_frame_to_substances(filtered)
 
     def test_filter_by_core_and_additional_n_components(self):
         """n_components constrains which rows qualify for each type."""
-        property_types = ["Density", "SurfaceTension"]
+        property_types = ["Density", "EnthalpyOfMixing"]
 
         # n_components on core: binary Density rows excluded from core set.
         substance_entries = [
-            (("CC",),       (True, True)),
-            (("CCC",),      (True, True)),
+            (("CC",),       (True, False)),
+            (("CC", "O"),   (False, True)),
+            (("CCC",),      (True, False)),
+            (("CCC", "O"),  (False, True)),
             (("CC", "CCC"), (True, False)),
         ]
         data_frame = _build_data_frame(property_types, substance_entries)
@@ -1429,7 +1455,7 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"Density": [1]},
-                additional_property_types={"SurfaceTension": None},
+                additional_property_types={"EnthalpyOfMixing": None},
                 scale_factor=1.0,
             ),
         )
@@ -1437,36 +1463,17 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         assert _substances_for_property(filtered, "Density") == {("CC",), ("CCC",)}
         assert ("CC", "CCC") not in data_frame_to_substances(filtered)
 
-        # n_components on additional: binary ST rows excluded from candidates.
-        substance_entries = [
-            (("CC",),       (True, True)),
-            (("CCC",),      (True, False)),
-            (("CC", "CCC"), (False, True)),
-        ]
-        data_frame = _build_data_frame(property_types, substance_entries)
-
-        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
-            data_frame,
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None},
-                additional_property_types={"SurfaceTension": [1]},
-                scale_factor=1.0,
-            ),
-        )
-
-        assert ("CC", "CCC") not in data_frame_to_substances(filtered)
-        assert _substances_for_property(filtered, "SurfaceTension") == {("CC",)}
 
     def test_filter_by_core_and_additional_gap_fill_similarity(self):
         """Gap-fill by similarity: substance most similar to core is selected.
 
-        Tanimoto(CC, CCC) > Tanimoto(CC, c1ccccc1) → CCC selected.
+        Tanimoto(CC, CCC) > Tanimoto(CC, c1ccccc1) → CCC+O selected.
         """
-        property_types = ["Density", "SurfaceTension"]
+        property_types = ["Density", "EnthalpyOfMixing"]
         substance_entries = [
-            (("CC",),       (True, False)),
-            (("CCC",),      (False, True)),
-            (("c1ccccc1",), (False, True)),
+            (("CC",),          (True, False)),
+            (("CCC", "O"),     (False, True)),
+            (("c1ccccc1", "O"), (False, True)),
         ]
         data_frame = _build_data_frame(property_types, substance_entries)
 
@@ -1474,24 +1481,24 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"Density": None},
-                additional_property_types={"SurfaceTension": None},
+                additional_property_types={"EnthalpyOfMixing": None},
                 scale_factor=1.0,
                 select_by="similarity",
             ),
         )
 
-        assert _substances_for_property(filtered, "SurfaceTension") == {("CCC",)}
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CCC", "O")}
 
     def test_filter_by_core_and_additional_gap_fill_diversity(self):
         """Gap-fill by diversity: substance most dissimilar to core is selected.
 
-        MaxMin from {CC} → c1ccccc1 selected.
+        MaxMin from {CC} → c1ccccc1+O selected.
         """
-        property_types = ["Density", "SurfaceTension"]
+        property_types = ["Density", "EnthalpyOfMixing"]
         substance_entries = [
-            (("CC",),       (True, False)),
-            (("CCC",),      (False, True)),
-            (("c1ccccc1",), (False, True)),
+            (("CC",),          (True, False)),
+            (("CCC", "O"),     (False, True)),
+            (("c1ccccc1", "O"), (False, True)),
         ]
         data_frame = _build_data_frame(property_types, substance_entries)
 
@@ -1499,74 +1506,87 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"Density": None},
-                additional_property_types={"SurfaceTension": None},
+                additional_property_types={"EnthalpyOfMixing": None},
                 scale_factor=1.0,
                 select_by="diversity",
             ),
         )
 
-        assert _substances_for_property(filtered, "SurfaceTension") == {("c1ccccc1",)}
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("c1ccccc1", "O")}
 
     def test_filter_by_core_and_additional_multi_type_coverage(self):
         """Gap-fill prefers substances covering multiple additional types."""
-        property_types = ["Density", "SurfaceTension", "DielectricConstant"]
+        property_types = ["Density", "EnthalpyOfMixing", "DielectricConstant"]
 
-        # CCC covers both ST and DC; CCCC/CCCCC cover only one each.
-        # gap = 1 per type → CCC fills both rather than picking CCCC + CCCCC.
+        # Core: {CC+O, CCC+O, CCCC+O} with EOM data
+        # Additional types: Density (pure) and DielectricConstant (mixed/pure)
+        # CCC+O candidates fill both DC and nothing else (DC=T, Density=F);
+        # CCCC covers only DC; CCCCC covers only Density.
+        # Greedy prefers candidates covering multiple types.
         substance_entries = [
-            (("CC",),    (True, True, True)),
-            (("CCC",),   (False, True, True)),
-            (("CCCC",),  (False, True, False)),
-            (("CCCCC",), (False, False, True)),
+            (("CC",),       (True, False, False)),
+            (("CC", "O"),   (True, True, True)),
+            (("CCC",),      (True, False, False)),
+            (("CCC", "O"),  (False, True, True)),
+            (("CCCC",),     (True, False, False)),
+            (("CCCC", "O"), (False, True, False)),
+            (("CCCCC",),    (True, False, False)),
+            (("CCCCC", "O"), (False, False, True)),
         ]
         data_frame = _build_data_frame(property_types, substance_entries)
 
         filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None},
+                core_property_types={"EnthalpyOfMixing": None},
                 additional_property_types={
-                    "SurfaceTension": None,
+                    "Density": None,
                     "DielectricConstant": None,
                 },
                 scale_factor=2.0,
             ),
         )
 
-        assert _substances_for_property(filtered, "SurfaceTension") == {("CC",), ("CCC",)}
-        assert _substances_for_property(filtered, "DielectricConstant") == {
-            ("CC",), ("CCC",)
-        }
-        assert ("CCCC",) not in data_frame_to_substances(filtered)
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CC", "O"), ("CCC", "O"), ("CCCC", "O")}
+        assert _substances_for_property(filtered, "Density") == {("CC",), ("CCC",), ("CCCC",), ("CCCCC",)}
+        assert _substances_for_property(filtered, "DielectricConstant") == {("CC", "O"), ("CCC", "O"), ("CCCCC", "O")}
         assert ("CCCCC",) not in data_frame_to_substances(filtered)
 
-        # When multi-type candidates are exhausted, fall through to single-type.
-        # ST gap=2, DC gap=2. CCC fills 1 each; then CCCCCC fills DC, ST gets one more.
+        # When candidates exhausted: core-only substances may be retained for core property.
+        # Core: {CC+O, CCC+O, CCCC+O, CCCCC+O}; scale_factor=3.0 → target=12 per additional type.
+        # Density candidates: {CC, CCC, CCCC, CCCCC, CCCCCC} (5 available, need 12 → take all)
+        # DC candidates: {CCCCCC+O} overlap + any non-core substances
         substance_entries = [
-            (("CC",),     (True,  True,  True)),
-            (("CCC",),    (False, True,  True)),
-            (("CCCC",),   (False, True,  False)),
-            (("CCCCC",),  (False, True,  False)),
-            (("CCCCCC",), (False, False, True)),
+            (("CC",),        (True,  False, False)),
+            (("CC", "O"),     (False, True,  True)),
+            (("CCC",),       (True,  False, False)),
+            (("CCC", "O"),    (False, True,  True)),
+            (("CCCC",),      (True,  False, False)),
+            (("CCCC", "O"),   (False, True,  False)),
+            (("CCCCC",),     (True,  False, False)),
+            (("CCCCC", "O"),  (False, True,  False)),
+            (("CCCCCC",),    (True,  False, False)),
+            (("CCCCCC", "O"), (False, False, True)),
         ]
         data_frame = _build_data_frame(property_types, substance_entries)
 
         filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None},
+                core_property_types={"EnthalpyOfMixing": None},
                 additional_property_types={
-                    "SurfaceTension": None,
+                    "Density": None,
                     "DielectricConstant": None,
                 },
                 scale_factor=3.0,
             ),
         )
 
-        st_substances = _substances_for_property(filtered, "SurfaceTension")
+        eom_substances = _substances_for_property(filtered, "EnthalpyOfMixing")
+        density_substances = _substances_for_property(filtered, "Density")
         dc_substances = _substances_for_property(filtered, "DielectricConstant")
 
-        assert ("CCC",) in st_substances and ("CCC",) in dc_substances
-        assert ("CCCCCC",) in dc_substances
-        assert len(st_substances) == 3
-        assert len(dc_substances) == 3
+        assert ("CC", "O") in eom_substances and ("CCC", "O") in eom_substances
+        assert len(density_substances) == 5  # all pure candidates selected
+        assert ("CCCCCC", "O") in dc_substances
+        assert len(eom_substances) == 4  # core set

--- a/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
@@ -1301,6 +1301,15 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             )
 
     def test_filter_by_core_and_additional_truncates_correctly(self):
+        """Headline happy path: the gap-fill count truncates to
+        int(scale_factor * core_count) when more candidates are available.
+
+        This focuses on the count arithmetic (4 core, scale_factor=0.5 -> 2)
+        with three candidates competing for two slots. The complementary
+        ``gap_fill_similarity`` / ``gap_fill_diversity`` tests instead isolate
+        *which* candidate wins under each ``select_by`` strategy, using a
+        minimal two-candidate set where the count is not the point.
+        """
         # Core substances = intersection of all core property type substance sets.
         # Additional substances = overlap (always) + gap-fill up to
         # int(scale_factor * core_count) per additional type.
@@ -1395,36 +1404,6 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CC", "O")}
         assert _substances_for_property(filtered, "Density") == {("CC", "O")}
         assert ("CC",) not in data_frame_to_substances(filtered)
-
-    def test_filter_by_core_and_additional_fewer_candidates_than_target(self):
-        # Fewer candidates than target: return all available.
-        substance_entries = [
-            (("CC",),       (True, False)),
-            (("CC", "O"),   (False, True)),
-            (("CCC",),      (True, False)),
-            (("CCC", "O"),  (False, True)),
-            (("CCCC",),     (True, False)),
-            (("CCCC", "O"), (False, False)),
-        ]
-        data_frame = _build_data_frame(self.property_types, substance_entries)
-
-        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
-            data_frame,
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None},
-                additional_property_types={
-                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig(scale_factor=1.0)
-                },
-            ),
-        )
-
-        assert _substances_for_property(filtered, "Density") == {
-            ("CC",), ("CCC",), ("CCCC",)
-        }
-        # target = 3 but only 2 candidates have data → both are taken.
-        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
-            ("CC", "O"), ("CCC", "O")
-        }
 
     def test_filter_by_core_and_additional_empty_core(self):
         # Empty core intersection of density and enthalpy of vaporization --> empty result.
@@ -1521,6 +1500,11 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         """Gap-fill by similarity: substance most similar to core is selected.
 
         Tanimoto(CC, CCC) > Tanimoto(CC, c1ccccc1) → CCC+O selected.
+
+        Unlike ``truncates_correctly`` (which exercises the gap-fill *count*),
+        this isolates the ``select_by`` ranking: a minimal two-candidate set
+        where the count is irrelevant and only the similarity ordering decides
+        the winner. It is the counterpart to ``gap_fill_diversity``.
         """
         property_types = ["Density", "EnthalpyOfMixing"]
         substance_entries = [

--- a/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
@@ -1237,9 +1237,13 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         additional_property_types,
         *,
         property_types=None,
-        select_by="similarity",
+        **kwargs,
     ):
-        """Build a data frame from *substance_entries* and apply the filter."""
+        """Build a data frame from *substance_entries* and apply the filter.
+
+        Any extra keyword arguments (e.g. ``select_by``) are forwarded to
+        :class:`FilterByCoreAndAdditionalPropertyTypesSchema`.
+        """
         data_frame = _build_data_frame(
             property_types or self.property_types, substance_entries
         )
@@ -1248,7 +1252,7 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types=core_property_types,
                 additional_property_types=additional_property_types,
-                select_by=select_by,
+                **kwargs,
             ),
         )
 
@@ -1445,7 +1449,7 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             (("CCC",),      (True, True, False)),
             (("CCC", "O"),  (False, False, True)),
             (("CCCC",),     (True, False, False)),   # Density only, not EnthalpyOfVaporization
-            (("CCCC", "O"), (False, False, True)),   # EOM only
+            (("CCCC", "O"), (False, False, True)),   # dHmix only
             (("CCCCC",),    (False, True, False)),   # EnthalpyOfVaporization only
         ]
 
@@ -1514,38 +1518,9 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             select_by=select_by,
         )
 
-        # Both candidates carry only EOM data, so an exact match on the EOM set
+        # Both candidates carry only dHmix data, so an exact match on the dHmix set
         # also confirms the loser was dropped entirely.
         assert _substances_for_property(filtered, "EnthalpyOfMixing") == {expected}
-
-    def test_filter_by_core_and_additional_gap_fill_diversity_skips_invalid_smiles(
-        self,
-    ):
-        """A candidate whose SMILES cannot be parsed is not treated as maximally
-        diverse.
-
-        Diversity ranks by dissimilarity to the core. A candidate with no
-        fingerprint must score as *least* diverse (0.0), not most (1.0), so the
-        parseable benzene candidate is chosen over the unparseable one. Guards a
-        regression in the diversity branch of ``_gap_fill``.
-        """
-        substance_entries = [
-            (("CC",), (True, False)),  # core
-            (("c1ccccc1",), (False, True)),  # valid candidate
-            (("not_a_valid_smiles",), (False, True)),  # unparseable candidate
-        ]
-
-        filtered = self._filter(
-            substance_entries,
-            {"Density": None},
-            {"EnthalpyOfMixing": {}},
-            select_by="diversity",
-        )
-
-        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
-            ("c1ccccc1",)
-        }
-        assert ("not_a_valid_smiles",) not in data_frame_to_substances(filtered)
 
     def test_filter_by_core_and_additional_gap_fill_targets_under_represented_core(
         self,
@@ -1557,9 +1532,7 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         (represented); benzene does not (under-represented). The two candidates sit
         one in each region: heptane (Morgan-r2 Tanimoto 1.0 to octane, 0.0 to
         benzene) and toluene (0.273 to benzene). With one gap to fill, anchoring on
-        the under-represented core {benzene} selects toluene. The previous
-        whole-core behaviour would instead have picked heptane (similarity 1.0 to
-        the *already-covered* octane), so this guards that regression.
+        the under-represented core {benzene} selects toluene.
         """
         substance_entries = [
             (("CCCCCCCC",), (True, True)),  # core, already represented
@@ -1623,10 +1596,10 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
     ):
         """A multi-type pick advances the spread of *every* type it covers.
 
-        Core (Density) = {octane, benzene}, both lacking EnthalpyOfMixing (EOM) and
-        DielectricConstant (DC). Heptane (near octane) is the only EOM candidate and
+        Core (Density) = {octane, benzene}, both lacking EnthalpyOfMixing (dHmix) and
+        DielectricConstant (DC). Heptane (near octane) is the only dHmix candidate and
         also carries DC; the remaining DC candidates are hexane (near octane) and
-        toluene (near benzene). EOM is filled first and selects heptane, which also
+        toluene (near benzene). dHmix is filled first and selects heptane, which also
         covers one DC slot. Because the references are shared, heptane marks the
         octane region covered for DC too, so the second DC pick goes to toluene
         (benzene region). With per-type-independent references, DC would still see
@@ -1636,7 +1609,7 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         substance_entries = [
             (("CCCCCCCC",), (True, False, False)),  # core, under-represented
             (("c1ccccc1",), (True, False, False)),  # core, under-represented
-            (("CCCCCCC",), (False, True, True)),  # EOM+DC candidate, near octane
+            (("CCCCCCC",), (False, True, True)),  # dHmix+DC candidate, near octane
             (("CCCCCC",), (False, False, True)),  # DC candidate, near octane
             (("Cc1ccccc1",), (False, False, True)),  # DC candidate, near benzene
         ]
@@ -1656,7 +1629,7 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             ("CCCCCCC",)
         }
         assert _substances_for_property(filtered, "DielectricConstant") == {
-            ("CCCCCCC",),  # the shared EOM+DC pick covers the octane region
+            ("CCCCCCC",),  # the shared dHmix+DC pick covers the octane region
             ("Cc1ccccc1",),  # so the next DC pick spreads to the benzene region
         }
         # The redundant octane-region DC candidate is not taken.
@@ -1667,13 +1640,13 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
 
         Core (Density) = {CC+O}. EnthalpyOfMixing has a gap (scale_factor=1.0);
         DielectricConstant is overlap-only (scale_factor=0.0). The single candidate
-        CCC carries both EOM and DC data and is taken to fill EOM. Its DC row must be
+        CCC carries both dHmix and DC data and is taken to fill dHmix. Its DC row must be
         dropped — DC's target is 0 and CCC is not core overlap — rather than leaking
         in because CCC was selected for another type.
         """
         substance_entries = [
             (("CC", "O"), (True, False, False)),  # core
-            (("CCC",), (False, True, True)),  # EOM+DC candidate
+            (("CCC",), (False, True, True)),  # dHmix+DC candidate
         ]
 
         filtered = self._filter(
@@ -1694,9 +1667,9 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         """A multi-type pick is charged to every type it still has budget for, even
         one it is dissimilar to — pinning the count semantics.
 
-        Core (Density) = {benzene}, lacking both EOM and DC. Heptane (aliphatic,
-        Tanimoto 0 to benzene) carries EOM and DC; toluene carries DC and is similar
-        to benzene. EOM has only heptane, so heptane is taken and — covering DC's
+        Core (Density) = {benzene}, lacking both dHmix and DC. Heptane (aliphatic,
+        Tanimoto 0 to benzene) carries dHmix and DC; toluene carries DC and is similar
+        to benzene. dHmix has only heptane, so heptane is taken and — covering DC's
         single slot too — consumes DC's budget, so toluene is not added. Multi-type
         coverage is deliberately preferred over reserving DC's budget for a closer
         match; ``credit`` simply does not advance DC's spread for the dissimilar
@@ -1704,7 +1677,7 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         """
         substance_entries = [
             (("c1ccccc1",), (True, False, False)),  # core, under-represented
-            (("CCCCCCC",), (False, True, True)),  # EOM+DC, dissimilar to benzene
+            (("CCCCCCC",), (False, True, True)),  # dHmix+DC, dissimilar to benzene
             (("Cc1ccccc1",), (False, False, True)),  # DC only, similar to benzene
         ]
 
@@ -1761,7 +1734,7 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
 
     def test_filter_by_core_and_additional_candidates_exhausted(self):
         """When candidates run out, the full candidate set is taken."""
-        # Core: {CC+O, CCC+O, CCCC+O, CCCCC+O} with EOM data.
+        # Core: {CC+O, CCC+O, CCCC+O, CCCCC+O} with dHmix data.
         # Density scale_factor=3.0 → target=12, but only 5 pure candidates
         # exist → all are taken.
         # DielectricConstant target=4 with overlap {CC+O, CCC+O} → gap-fill
@@ -1789,11 +1762,11 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             property_types=["Density", "EnthalpyOfMixing", "DielectricConstant"],
         )
 
-        eom_substances = _substances_for_property(filtered, "EnthalpyOfMixing")
+        dhmix_substances = _substances_for_property(filtered, "EnthalpyOfMixing")
         density_substances = _substances_for_property(filtered, "Density")
         dc_substances = _substances_for_property(filtered, "DielectricConstant")
 
-        assert eom_substances == {
+        assert dhmix_substances == {
             ("CC", "O"),
             ("CCC", "O"),
             ("CCCC", "O"),

--- a/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
@@ -14,6 +14,8 @@ from openff.evaluator.datasets import (
 from openff.evaluator.datasets.curation.components.filtering import (
     FilterByCharged,
     FilterByChargedSchema,
+    FilterByCoreAndAdditionalPropertyTypes,
+    FilterByCoreAndAdditionalPropertyTypesSchema,
     FilterByElements,
     FilterByElementsSchema,
     FilterByEnvironments,
@@ -1212,3 +1214,359 @@ def test_curation_does_not_alter_precision():
     )
 
     assert list(data_frame["Mole Fraction 1"]) == list(filtered["Mole Fraction 1"])
+
+
+def _substances_for_property(data_frame: pandas.DataFrame, property_type: str) -> set:
+    col = f"{property_type} Value (unit)"
+    if col not in data_frame.columns:
+        return set()
+    return data_frame_to_substances(data_frame[data_frame[col].notna()])
+
+
+class TestFilterByCoreAndAdditionalPropertyTypes:
+
+    def test_validate_filter_by_core_and_additional(self):
+        # Valid schema
+        FilterByCoreAndAdditionalPropertyTypesSchema(
+            core_property_types={"Density": None},
+            additional_property_types={"SurfaceTension": None},
+        )
+        FilterByCoreAndAdditionalPropertyTypesSchema(
+            core_property_types={"Density": [1]},
+            additional_property_types={"SurfaceTension": None},
+            scale_factor=0.0,
+        )
+
+        # Types must be disjoint
+        with pytest.raises(ValidationError):
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": None},
+                additional_property_types={"Density": None},
+            )
+
+        # scale_factor must be non-negative
+        with pytest.raises(ValidationError):
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": None},
+                additional_property_types={"SurfaceTension": None},
+                scale_factor=-1.0,
+            )
+
+        # Both dicts must be non-empty
+        with pytest.raises(ValidationError):
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={},
+                additional_property_types={"SurfaceTension": None},
+            )
+        with pytest.raises(ValidationError):
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": None},
+                additional_property_types={},
+            )
+
+        # select_by must be 'similarity' or 'diversity'
+        with pytest.raises(ValidationError):
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": None},
+                additional_property_types={"SurfaceTension": None},
+                select_by="random",
+            )
+
+    def test_filter_by_core_and_additional(self):
+        # Core substances = intersection of all core property type substance sets.
+        # Additional substances = overlap (always) + gap-fill up to
+        # int(scale_factor * core_count) per additional type.
+        property_types = ["Density", "SurfaceTension"]
+        substance_entries = [
+            (("CC",),    (True, True)),
+            (("CCC",),   (True, True)),
+            (("CCCC",),  (True, True)),
+            (("CCCCC",), (False, True)),  # additional-only, excluded at target=3
+        ]
+        data_frame = _build_data_frame(property_types, substance_entries)
+
+        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
+            data_frame,
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": None},
+                additional_property_types={"SurfaceTension": None},
+                scale_factor=1.0,
+            ),
+        )
+
+        assert _substances_for_property(filtered, "Density") == {
+            ("CC",), ("CCC",), ("CCCC",)
+        }
+        assert _substances_for_property(filtered, "SurfaceTension") == {
+            ("CC",), ("CCC",), ("CCCC",)
+        }
+        assert ("CCCCC",) not in data_frame_to_substances(filtered)
+
+        # Overlap > target: full overlap is retained without truncation.
+        substance_entries = [
+            (("CC",),    (True, True)),
+            (("CCC",),   (True, True)),
+            (("CCCC",),  (True, True)),
+            (("CCCCC",), (True, True)),
+        ]
+        data_frame = _build_data_frame(property_types, substance_entries)
+
+        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
+            data_frame,
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": None},
+                additional_property_types={"SurfaceTension": None},
+                scale_factor=0.5,  # target=2 but overlap=4 → keep all 4
+            ),
+        )
+
+        assert _substances_for_property(filtered, "SurfaceTension") == {
+            ("CC",), ("CCC",), ("CCCC",), ("CCCCC",)
+        }
+
+        # scale_factor=0: no additional rows selected.
+        substance_entries = [
+            (("CC",),   (True, True)),
+            (("CCC",),  (True, True)),
+            (("CCCC",), (False, True)),
+        ]
+        data_frame = _build_data_frame(property_types, substance_entries)
+
+        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
+            data_frame,
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": None},
+                additional_property_types={"SurfaceTension": None},
+                scale_factor=0.0,
+            ),
+        )
+
+        assert _substances_for_property(filtered, "Density") == {("CC",), ("CCC",)}
+        assert _substances_for_property(filtered, "SurfaceTension") == set()
+
+        # Fewer candidates than target: return all available.
+        substance_entries = [
+            (("CC",),   (True, True)),
+            (("CCC",),  (True, False)),
+            (("CCCC",), (True, False)),
+        ]
+        data_frame = _build_data_frame(property_types, substance_entries)
+
+        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
+            data_frame,
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": None},
+                additional_property_types={"SurfaceTension": None},
+                scale_factor=1.0,
+            ),
+        )
+
+        assert _substances_for_property(filtered, "Density") == {
+            ("CC",), ("CCC",), ("CCCC",)
+        }
+        assert _substances_for_property(filtered, "SurfaceTension") == {("CC",)}
+
+    def test_filter_by_core_and_additional_empty_core(self):
+        # Empty core intersection → empty result.
+        property_types = ["Density", "Viscosity", "SurfaceTension"]
+        substance_entries = [
+            (("CC",),    (True, False, True)),
+            (("CCC",),   (True, False, True)),
+            (("CCCC",),  (False, True, True)),
+            (("CCCCC",), (False, True, False)),
+        ]
+        data_frame = _build_data_frame(property_types, substance_entries)
+
+        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
+            data_frame,
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": None, "Viscosity": None},
+                additional_property_types={"SurfaceTension": None},
+                scale_factor=1.0,
+            ),
+        )
+
+        assert len(filtered) == 0
+
+    def test_filter_by_core_and_additional_multiple_core_types(self):
+        """Strict intersection across multiple core types."""
+        property_types = ["Density", "Viscosity", "SurfaceTension"]
+        substance_entries = [
+            (("CC",),    (True, True, True)),
+            (("CCC",),   (True, True, True)),
+            (("CCCC",),  (True, False, True)),   # Density + ST, not Viscosity
+            (("CCCCC",), (False, True, False)),  # Viscosity only
+        ]
+        data_frame = _build_data_frame(property_types, substance_entries)
+
+        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
+            data_frame,
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": None, "Viscosity": None},
+                additional_property_types={"SurfaceTension": None},
+                scale_factor=1.0,
+            ),
+        )
+
+        assert _substances_for_property(filtered, "Density") == {("CC",), ("CCC",)}
+        assert _substances_for_property(filtered, "Viscosity") == {("CC",), ("CCC",)}
+        assert _substances_for_property(filtered, "SurfaceTension") == {("CC",), ("CCC",)}
+        assert ("CCCC",) not in data_frame_to_substances(filtered)
+
+    def test_filter_by_core_and_additional_n_components(self):
+        """n_components constrains which rows qualify for each type."""
+        property_types = ["Density", "SurfaceTension"]
+
+        # n_components on core: binary Density rows excluded from core set.
+        substance_entries = [
+            (("CC",),       (True, True)),
+            (("CCC",),      (True, True)),
+            (("CC", "CCC"), (True, False)),
+        ]
+        data_frame = _build_data_frame(property_types, substance_entries)
+
+        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
+            data_frame,
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": [1]},
+                additional_property_types={"SurfaceTension": None},
+                scale_factor=1.0,
+            ),
+        )
+
+        assert _substances_for_property(filtered, "Density") == {("CC",), ("CCC",)}
+        assert ("CC", "CCC") not in data_frame_to_substances(filtered)
+
+        # n_components on additional: binary ST rows excluded from candidates.
+        substance_entries = [
+            (("CC",),       (True, True)),
+            (("CCC",),      (True, False)),
+            (("CC", "CCC"), (False, True)),
+        ]
+        data_frame = _build_data_frame(property_types, substance_entries)
+
+        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
+            data_frame,
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": None},
+                additional_property_types={"SurfaceTension": [1]},
+                scale_factor=1.0,
+            ),
+        )
+
+        assert ("CC", "CCC") not in data_frame_to_substances(filtered)
+        assert _substances_for_property(filtered, "SurfaceTension") == {("CC",)}
+
+    def test_filter_by_core_and_additional_gap_fill_similarity(self):
+        """Gap-fill by similarity: substance most similar to core is selected.
+
+        Tanimoto(CC, CCC) > Tanimoto(CC, c1ccccc1) → CCC selected.
+        """
+        property_types = ["Density", "SurfaceTension"]
+        substance_entries = [
+            (("CC",),       (True, False)),
+            (("CCC",),      (False, True)),
+            (("c1ccccc1",), (False, True)),
+        ]
+        data_frame = _build_data_frame(property_types, substance_entries)
+
+        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
+            data_frame,
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": None},
+                additional_property_types={"SurfaceTension": None},
+                scale_factor=1.0,
+                select_by="similarity",
+            ),
+        )
+
+        assert _substances_for_property(filtered, "SurfaceTension") == {("CCC",)}
+
+    def test_filter_by_core_and_additional_gap_fill_diversity(self):
+        """Gap-fill by diversity: substance most dissimilar to core is selected.
+
+        MaxMin from {CC} → c1ccccc1 selected.
+        """
+        property_types = ["Density", "SurfaceTension"]
+        substance_entries = [
+            (("CC",),       (True, False)),
+            (("CCC",),      (False, True)),
+            (("c1ccccc1",), (False, True)),
+        ]
+        data_frame = _build_data_frame(property_types, substance_entries)
+
+        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
+            data_frame,
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": None},
+                additional_property_types={"SurfaceTension": None},
+                scale_factor=1.0,
+                select_by="diversity",
+            ),
+        )
+
+        assert _substances_for_property(filtered, "SurfaceTension") == {("c1ccccc1",)}
+
+    def test_filter_by_core_and_additional_multi_type_coverage(self):
+        """Gap-fill prefers substances covering multiple additional types."""
+        property_types = ["Density", "SurfaceTension", "DielectricConstant"]
+
+        # CCC covers both ST and DC; CCCC/CCCCC cover only one each.
+        # gap = 1 per type → CCC fills both rather than picking CCCC + CCCCC.
+        substance_entries = [
+            (("CC",),    (True, True, True)),
+            (("CCC",),   (False, True, True)),
+            (("CCCC",),  (False, True, False)),
+            (("CCCCC",), (False, False, True)),
+        ]
+        data_frame = _build_data_frame(property_types, substance_entries)
+
+        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
+            data_frame,
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": None},
+                additional_property_types={
+                    "SurfaceTension": None,
+                    "DielectricConstant": None,
+                },
+                scale_factor=2.0,
+            ),
+        )
+
+        assert _substances_for_property(filtered, "SurfaceTension") == {("CC",), ("CCC",)}
+        assert _substances_for_property(filtered, "DielectricConstant") == {
+            ("CC",), ("CCC",)
+        }
+        assert ("CCCC",) not in data_frame_to_substances(filtered)
+        assert ("CCCCC",) not in data_frame_to_substances(filtered)
+
+        # When multi-type candidates are exhausted, fall through to single-type.
+        # ST gap=2, DC gap=2. CCC fills 1 each; then CCCCCC fills DC, ST gets one more.
+        substance_entries = [
+            (("CC",),     (True,  True,  True)),
+            (("CCC",),    (False, True,  True)),
+            (("CCCC",),   (False, True,  False)),
+            (("CCCCC",),  (False, True,  False)),
+            (("CCCCCC",), (False, False, True)),
+        ]
+        data_frame = _build_data_frame(property_types, substance_entries)
+
+        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
+            data_frame,
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": None},
+                additional_property_types={
+                    "SurfaceTension": None,
+                    "DielectricConstant": None,
+                },
+                scale_factor=3.0,
+            ),
+        )
+
+        st_substances = _substances_for_property(filtered, "SurfaceTension")
+        dc_substances = _substances_for_property(filtered, "DielectricConstant")
+
+        assert ("CCC",) in st_substances and ("CCC",) in dc_substances
+        assert ("CCCCCC",) in dc_substances
+        assert len(st_substances) == 3
+        assert len(dc_substances) == 3

--- a/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
@@ -1230,6 +1230,28 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
 
     property_types = ["Density", "EnthalpyOfMixing"]
 
+    def _filter(
+        self,
+        substance_entries,
+        core_property_types,
+        additional_property_types,
+        *,
+        property_types=None,
+        select_by="similarity",
+    ):
+        """Build a data frame from *substance_entries* and apply the filter."""
+        data_frame = _build_data_frame(
+            property_types or self.property_types, substance_entries
+        )
+        return FilterByCoreAndAdditionalPropertyTypes.apply(
+            data_frame,
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types=core_property_types,
+                additional_property_types=additional_property_types,
+                select_by=select_by,
+            ),
+        )
+
     def test_validate_filter_by_core_and_additional(self):
         """Generally test valid arguments for schema and set expectations"""
         # Valid schema
@@ -1308,9 +1330,9 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
 
         This focuses on the count arithmetic (4 core, scale_factor=0.5 -> 2)
         with three candidates competing for two slots. The complementary
-        ``gap_fill_similarity`` / ``gap_fill_diversity`` tests instead isolate
-        *which* candidate wins under each ``select_by`` strategy, using a
-        minimal two-candidate set where the count is not the point.
+        ``gap_fill_select_by`` test instead isolates *which* candidate wins under
+        each ``select_by`` strategy, using a minimal two-candidate set where the
+        count is not the point.
         """
         # Core substances = intersection of all core property type substance sets.
         # Additional substances = overlap (always) + gap-fill up to
@@ -1324,18 +1346,13 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             (("CCC", "O"),  (False, True)),
             (("c1ccccc1", "O"), (False, True)),
         ]
-        data_frame = _build_data_frame(self.property_types, substance_entries)
 
         # 4 core substances, scale_factor=0.5 -> target of 2 EnthalpyOfMixing
         # substances; the alkane mixtures outrank the dissimilar aromatic one.
-        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
-            data_frame,
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None},
-                additional_property_types={
-                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig(scale_factor=0.5)
-                },
-            ),
+        filtered = self._filter(
+            substance_entries,
+            {"Density": None},
+            {"EnthalpyOfMixing": {"scale_factor": 0.5}},
         )
         assert _substances_for_property(filtered, "Density") == {
             ("CC",), ("CCC",), ("CCCC",), ("CCCCC",)
@@ -1357,17 +1374,14 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             (("CCCCC",),    (True, False)),
             (("CCCCC", "O"), (True, True)),
         ]
-        data_frame = _build_data_frame(self.property_types, substance_entries)
 
-        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
-            data_frame,
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"EnthalpyOfMixing": None},
-                additional_property_types={
-                    # target=2 but overlap=4 → keep all 4
-                    "Density": AdditionalPropertyTypeConfig(scale_factor=0.5)
-                },
-            ),
+        filtered = self._filter(
+            substance_entries,
+            {"EnthalpyOfMixing": None},
+            {
+                # target=2 but overlap=4 → keep all 4
+                "Density": {"scale_factor": 0.5}
+            },
         )
 
         assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
@@ -1389,16 +1403,11 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             (("CCCC",),     (True, False)),
             (("CCCC", "O"), (True, False)),
         ]
-        data_frame = _build_data_frame(self.property_types, substance_entries)
 
-        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
-            data_frame,
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"EnthalpyOfMixing": None},
-                additional_property_types={
-                    "Density": AdditionalPropertyTypeConfig(scale_factor=0.0)
-                },
-            ),
+        filtered = self._filter(
+            substance_entries,
+            {"EnthalpyOfMixing": None},
+            {"Density": {"scale_factor": 0.0}},
         )
 
         # Core = {CC+O}; its density data are overlap and survive, but no
@@ -1409,7 +1418,6 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
 
     def test_filter_by_core_and_additional_empty_core(self):
         # Empty core intersection of density and enthalpy of vaporization --> empty result.
-        property_types = ["Density", "EnthalpyOfVaporization", "EnthalpyOfMixing"]
         substance_entries = [
             (("CC",),       (True, False, False)),
             (("CCC",),      (True, False, False)),
@@ -1419,23 +1427,18 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             (("CCC", "O"),  (False, False, True)),
             (("CCCC", "O"), (False, False, True)),
         ]
-        data_frame = _build_data_frame(property_types, substance_entries)
 
-        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
-            data_frame,
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None, "Viscosity": None},
-                additional_property_types={
-                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig()
-                },
-            ),
+        filtered = self._filter(
+            substance_entries,
+            {"Density": None, "Viscosity": None},
+            {"EnthalpyOfMixing": {}},
+            property_types=["Density", "EnthalpyOfVaporization", "EnthalpyOfMixing"],
         )
 
         assert len(filtered) == 0
 
     def test_filter_by_core_and_additional_multiple_core_types(self):
         """Strict intersection across multiple core types."""
-        property_types = ["Density", "EnthalpyOfVaporization", "EnthalpyOfMixing"]
         substance_entries = [
             (("CC",),       (True, True, False)),
             (("CC", "O"),   (False, False, True)),
@@ -1445,16 +1448,12 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             (("CCCC", "O"), (False, False, True)),   # EOM only
             (("CCCCC",),    (False, True, False)),   # EnthalpyOfVaporization only
         ]
-        data_frame = _build_data_frame(property_types, substance_entries)
 
-        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
-            data_frame,
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None, "EnthalpyOfVaporization": None},
-                additional_property_types={
-                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig()
-                },
-            ),
+        filtered = self._filter(
+            substance_entries,
+            {"Density": None, "EnthalpyOfVaporization": None},
+            {"EnthalpyOfMixing": {}},
+            property_types=["Density", "EnthalpyOfVaporization", "EnthalpyOfMixing"],
         )
 
         assert _substances_for_property(filtered, "Density") == {("CC",), ("CCC",)}
@@ -1464,8 +1463,6 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
 
     def test_filter_by_core_and_additional_n_components(self):
         """n_components constrains which rows qualify for each type."""
-        property_types = ["Density", "EnthalpyOfMixing"]
-
         # Restrict core to pure Density only; the binary mixture is excluded.
         # Restrict the additional type to binary mixtures; the (unphysical)
         # pure-substance enthalpy of mixing entry is excluded.
@@ -1477,18 +1474,11 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             (("CC", "CCC"), (True, False)),
             (("CCCCC",),    (False, True)),
         ]
-        data_frame = _build_data_frame(property_types, substance_entries)
 
-        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
-            data_frame,
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": [1]},
-                additional_property_types={
-                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig(
-                        n_components=[2]
-                    )
-                },
-            ),
+        filtered = self._filter(
+            substance_entries,
+            {"Density": [1]},
+            {"EnthalpyOfMixing": {"n_components": [2]}},
         )
 
         assert _substances_for_property(filtered, "Density") == {("CC",), ("CCC",)}
@@ -1498,71 +1488,249 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         assert ("CC", "CCC") not in data_frame_to_substances(filtered)
         assert ("CCCCC",) not in data_frame_to_substances(filtered)
 
-    def test_filter_by_core_and_additional_gap_fill_similarity(self):
-        """Gap-fill by similarity: substance most similar to core is selected.
-
-        Tanimoto(CC, CCC) > Tanimoto(CC, c1ccccc1) → CCC+O selected.
-
-        Unlike ``truncates_correctly`` (which exercises the gap-fill *count*),
-        this isolates the ``select_by`` ranking: a minimal two-candidate set
-        where the count is irrelevant and only the similarity ordering decides
-        the winner. It is the counterpart to ``gap_fill_diversity``.
+    @pytest.mark.parametrize(
+        "select_by, expected",
+        [("similarity", ("CCC", "O")), ("diversity", ("O", "c1ccccc1"))],
+    )
+    def test_filter_by_core_and_additional_gap_fill_select_by(
+        self, select_by, expected
+    ):
+        """``select_by`` picks the right gap-fill candidate from {CCC+O, benzene+O}
+        against core {CC}: 'similarity' takes the nearer CCC+O
+        (Tanimoto(CC, CCC) > Tanimoto(CC, c1ccccc1)); 'diversity' takes the farther
+        benzene+O (MaxMin). A minimal two-candidate set where only the ranking, not
+        the count, decides the winner.
         """
-        property_types = ["Density", "EnthalpyOfMixing"]
         substance_entries = [
-            (("CC",),          (True, False)),
-            (("CCC", "O"),     (False, True)),
+            (("CC",), (True, False)),
+            (("CCC", "O"), (False, True)),
             (("c1ccccc1", "O"), (False, True)),
         ]
-        data_frame = _build_data_frame(property_types, substance_entries)
 
-        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
-            data_frame,
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None},
-                additional_property_types={
-                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig()
-                },
-                select_by="similarity",
-            ),
+        filtered = self._filter(
+            substance_entries,
+            {"Density": None},
+            {"EnthalpyOfMixing": {}},
+            select_by=select_by,
         )
 
-        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CCC", "O")}
-        assert ("O", "c1ccccc1") not in data_frame_to_substances(filtered)
+        # Both candidates carry only EOM data, so an exact match on the EOM set
+        # also confirms the loser was dropped entirely.
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {expected}
 
-    def test_filter_by_core_and_additional_gap_fill_diversity(self):
-        """Gap-fill by diversity: substance most dissimilar to core is selected.
+    def test_filter_by_core_and_additional_gap_fill_diversity_skips_invalid_smiles(
+        self,
+    ):
+        """A candidate whose SMILES cannot be parsed is not treated as maximally
+        diverse.
 
-        MaxMin from {CC} → c1ccccc1+O selected.
+        Diversity ranks by dissimilarity to the core. A candidate with no
+        fingerprint must score as *least* diverse (0.0), not most (1.0), so the
+        parseable benzene candidate is chosen over the unparseable one. Guards a
+        regression in the diversity branch of ``_gap_fill``.
         """
-        property_types = ["Density", "EnthalpyOfMixing"]
         substance_entries = [
-            (("CC",),          (True, False)),
-            (("CCC", "O"),     (False, True)),
-            (("c1ccccc1", "O"), (False, True)),
+            (("CC",), (True, False)),  # core
+            (("c1ccccc1",), (False, True)),  # valid candidate
+            (("not_a_valid_smiles",), (False, True)),  # unparseable candidate
         ]
-        data_frame = _build_data_frame(property_types, substance_entries)
 
-        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
-            data_frame,
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None},
-                additional_property_types={
-                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig()
-                },
-                select_by="diversity",
-            ),
+        filtered = self._filter(
+            substance_entries,
+            {"Density": None},
+            {"EnthalpyOfMixing": {}},
+            select_by="diversity",
         )
+
         assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
-            ("O", "c1ccccc1")
+            ("c1ccccc1",)
         }
-        assert ("CCC", "O") not in data_frame_to_substances(filtered)
+        assert ("not_a_valid_smiles",) not in data_frame_to_substances(filtered)
+
+    def test_filter_by_core_and_additional_gap_fill_targets_under_represented_core(
+        self,
+    ):
+        """Similarity gap-fill anchors on the core substances that *lack* the
+        additional type, not the whole core.
+
+        Core (Density) = {octane, benzene}. Octane already has EnthalpyOfMixing
+        (represented); benzene does not (under-represented). The two candidates sit
+        one in each region: heptane (Morgan-r2 Tanimoto 1.0 to octane, 0.0 to
+        benzene) and toluene (0.273 to benzene). With one gap to fill, anchoring on
+        the under-represented core {benzene} selects toluene. The previous
+        whole-core behaviour would instead have picked heptane (similarity 1.0 to
+        the *already-covered* octane), so this guards that regression.
+        """
+        substance_entries = [
+            (("CCCCCCCC",), (True, True)),  # core, already represented
+            (("c1ccccc1",), (True, False)),  # core, under-represented
+            (("CCCCCCC",), (False, True)),  # candidate near octane
+            (("Cc1ccccc1",), (False, True)),  # candidate near benzene
+        ]
+
+        filtered = self._filter(
+            substance_entries,
+            {"Density": None},
+            {"EnthalpyOfMixing": {}},
+            select_by="similarity",
+        )
+
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
+            ("CCCCCCCC",),  # core overlap (always kept)
+            ("Cc1ccccc1",),  # gap-fill near the under-represented benzene
+        }
+        # The candidate near the already-covered octane is not pulled in.
+        assert ("CCCCCCC",) not in data_frame_to_substances(filtered)
+
+    def test_filter_by_core_and_additional_gap_fill_spreads_across_under_represented_core(
+        self,
+    ):
+        """Similarity gap-fill spreads picks across the under-represented core
+        rather than piling into its densest region.
+
+        Core (Density) = {octane, benzene}, both lacking EnthalpyOfMixing. Two
+        candidates sit near octane (heptane @1.0, hexane @0.875) and one near
+        benzene (toluene @0.273). With two gaps, the dynamic strategy picks one
+        aliphatic and then — having marked octane covered — switches to toluene for
+        the benzene region, giving {heptane, toluene}. A static reference would take
+        the two highest-scoring aliphatics {heptane, hexane} and leave benzene
+        uncovered, so this pins the spreading behaviour.
+        """
+        substance_entries = [
+            (("CCCCCCCC",), (True, False)),  # core, under-represented
+            (("c1ccccc1",), (True, False)),  # core, under-represented
+            (("CCCCCCC",), (False, True)),  # aliphatic candidate (near octane)
+            (("CCCCCC",), (False, True)),  # aliphatic candidate (near octane)
+            (("Cc1ccccc1",), (False, True)),  # aromatic candidate (near benzene)
+        ]
+
+        filtered = self._filter(
+            substance_entries,
+            {"Density": None},
+            {"EnthalpyOfMixing": {}},
+            select_by="similarity",
+        )
+
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
+            ("CCCCCCC",),  # one aliphatic, covering the octane region
+            ("Cc1ccccc1",),  # one aromatic, covering the benzene region
+        }
+        # The second aliphatic is not taken — a static reference would have.
+        assert ("CCCCCC",) not in data_frame_to_substances(filtered)
+
+    def test_filter_by_core_and_additional_gap_fill_spread_is_shared_across_types(
+        self,
+    ):
+        """A multi-type pick advances the spread of *every* type it covers.
+
+        Core (Density) = {octane, benzene}, both lacking EnthalpyOfMixing (EOM) and
+        DielectricConstant (DC). Heptane (near octane) is the only EOM candidate and
+        also carries DC; the remaining DC candidates are hexane (near octane) and
+        toluene (near benzene). EOM is filled first and selects heptane, which also
+        covers one DC slot. Because the references are shared, heptane marks the
+        octane region covered for DC too, so the second DC pick goes to toluene
+        (benzene region). With per-type-independent references, DC would still see
+        octane as uncovered and pick hexane, leaving benzene unrepresented — so this
+        guards the shared-reference behaviour.
+        """
+        substance_entries = [
+            (("CCCCCCCC",), (True, False, False)),  # core, under-represented
+            (("c1ccccc1",), (True, False, False)),  # core, under-represented
+            (("CCCCCCC",), (False, True, True)),  # EOM+DC candidate, near octane
+            (("CCCCCC",), (False, False, True)),  # DC candidate, near octane
+            (("Cc1ccccc1",), (False, False, True)),  # DC candidate, near benzene
+        ]
+
+        filtered = self._filter(
+            substance_entries,
+            {"Density": None},
+            {
+                "EnthalpyOfMixing": {"scale_factor": 0.5},
+                "DielectricConstant": {"scale_factor": 1.0},
+            },
+            property_types=["Density", "EnthalpyOfMixing", "DielectricConstant"],
+            select_by="similarity",
+        )
+
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
+            ("CCCCCCC",)
+        }
+        assert _substances_for_property(filtered, "DielectricConstant") == {
+            ("CCCCCCC",),  # the shared EOM+DC pick covers the octane region
+            ("Cc1ccccc1",),  # so the next DC pick spreads to the benzene region
+        }
+        # The redundant octane-region DC candidate is not taken.
+        assert ("CCCCCC",) not in data_frame_to_substances(filtered)
+
+    def test_filter_by_core_and_additional_zero_gap_type_not_pulled_in(self):
+        """A multi-type pick does not retain rows for a type whose gap is zero.
+
+        Core (Density) = {CC+O}. EnthalpyOfMixing has a gap (scale_factor=1.0);
+        DielectricConstant is overlap-only (scale_factor=0.0). The single candidate
+        CCC carries both EOM and DC data and is taken to fill EOM. Its DC row must be
+        dropped — DC's target is 0 and CCC is not core overlap — rather than leaking
+        in because CCC was selected for another type.
+        """
+        substance_entries = [
+            (("CC", "O"), (True, False, False)),  # core
+            (("CCC",), (False, True, True)),  # EOM+DC candidate
+        ]
+
+        filtered = self._filter(
+            substance_entries,
+            {"Density": None},
+            {
+                "EnthalpyOfMixing": {"scale_factor": 1.0},
+                "DielectricConstant": {"scale_factor": 0.0},
+            },
+            property_types=["Density", "EnthalpyOfMixing", "DielectricConstant"],
+        )
+
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CCC",)}
+        # DC target is 0 and CCC is not overlap → no DC rows retained.
+        assert _substances_for_property(filtered, "DielectricConstant") == set()
+
+    def test_filter_by_core_and_additional_cross_fill_consumes_dissimilar_budget(self):
+        """A multi-type pick is charged to every type it still has budget for, even
+        one it is dissimilar to — pinning the count semantics.
+
+        Core (Density) = {benzene}, lacking both EOM and DC. Heptane (aliphatic,
+        Tanimoto 0 to benzene) carries EOM and DC; toluene carries DC and is similar
+        to benzene. EOM has only heptane, so heptane is taken and — covering DC's
+        single slot too — consumes DC's budget, so toluene is not added. Multi-type
+        coverage is deliberately preferred over reserving DC's budget for a closer
+        match; ``credit`` simply does not advance DC's spread for the dissimilar
+        pick.
+        """
+        substance_entries = [
+            (("c1ccccc1",), (True, False, False)),  # core, under-represented
+            (("CCCCCCC",), (False, True, True)),  # EOM+DC, dissimilar to benzene
+            (("Cc1ccccc1",), (False, False, True)),  # DC only, similar to benzene
+        ]
+
+        filtered = self._filter(
+            substance_entries,
+            {"Density": None},
+            {
+                "EnthalpyOfMixing": {"scale_factor": 1.0},
+                "DielectricConstant": {"scale_factor": 1.0},
+            },
+            property_types=["Density", "EnthalpyOfMixing", "DielectricConstant"],
+            select_by="similarity",
+        )
+
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
+            ("CCCCCCC",)
+        }
+        # Heptane fills DC's single slot too; the closer toluene is not added.
+        assert _substances_for_property(filtered, "DielectricConstant") == {
+            ("CCCCCCC",)
+        }
+        assert ("Cc1ccccc1",) not in data_frame_to_substances(filtered)
 
     @pytest.mark.parametrize("select_by", ["similarity", "diversity"])
     def test_filter_by_core_and_additional_multi_type_coverage(self, select_by):
         """Gap-fill prefers substances covering multiple additional types."""
-        property_types = ["Density", "EnthalpyOfMixing", "DielectricConstant"]
-
         # Core: {CC+O} (EnthalpyOfMixing). Targets: 1 Density + 1
         # DielectricConstant substance. CCC covers both additional types and
         # fills both gaps at once, so it is preferred over CCCC (Density only)
@@ -1573,18 +1741,16 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             (("CCCC",),      (True, False, False)),
             (("CCCCC", "O"), (False, False, True)),
         ]
-        data_frame = _build_data_frame(property_types, substance_entries)
 
-        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
-            data_frame,
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"EnthalpyOfMixing": None},
-                additional_property_types={
-                    "Density": AdditionalPropertyTypeConfig(),
-                    "DielectricConstant": AdditionalPropertyTypeConfig(),
-                },
-                select_by=select_by,
-            ),
+        filtered = self._filter(
+            substance_entries,
+            {"EnthalpyOfMixing": None},
+            {
+                "Density": {},
+                "DielectricConstant": {},
+            },
+            property_types=["Density", "EnthalpyOfMixing", "DielectricConstant"],
+            select_by=select_by,
         )
 
         assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CC", "O")}
@@ -1595,8 +1761,6 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
 
     def test_filter_by_core_and_additional_candidates_exhausted(self):
         """When candidates run out, the full candidate set is taken."""
-        property_types = ["Density", "EnthalpyOfMixing", "DielectricConstant"]
-
         # Core: {CC+O, CCC+O, CCCC+O, CCCCC+O} with EOM data.
         # Density scale_factor=3.0 → target=12, but only 5 pure candidates
         # exist → all are taken.
@@ -1614,17 +1778,15 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             (("CCCCCC",),    (True,  False, False)),
             (("CCCCCC", "O"), (False, False, True)),
         ]
-        data_frame = _build_data_frame(property_types, substance_entries)
 
-        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
-            data_frame,
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"EnthalpyOfMixing": None},
-                additional_property_types={
-                    "Density": AdditionalPropertyTypeConfig(scale_factor=3.0),
-                    "DielectricConstant": AdditionalPropertyTypeConfig(),
-                },
-            ),
+        filtered = self._filter(
+            substance_entries,
+            {"EnthalpyOfMixing": None},
+            {
+                "Density": {"scale_factor": 3.0},
+                "DielectricConstant": {},
+            },
+            property_types=["Density", "EnthalpyOfMixing", "DielectricConstant"],
         )
 
         eom_substances = _substances_for_property(filtered, "EnthalpyOfMixing")
@@ -1644,7 +1806,6 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         """A substance kept for one additional type must not drag along its
         rows for another additional type whose n_components filter excludes it.
         """
-        property_types = ["EnthalpyOfMixing", "Density", "DielectricConstant"]
         substance_entries = [
             # Core substance (binary): also carries binary Density data, which
             # the Density n_components=[1] filter must exclude, and
@@ -1653,17 +1814,15 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             # Legitimate pure Density gap-fill candidate.
             (("CCC",), (False, True, False)),
         ]
-        data_frame = _build_data_frame(property_types, substance_entries)
 
-        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
-            data_frame,
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"EnthalpyOfMixing": None},
-                additional_property_types={
-                    "Density": AdditionalPropertyTypeConfig(n_components=[1]),
-                    "DielectricConstant": AdditionalPropertyTypeConfig(),
-                },
-            ),
+        filtered = self._filter(
+            substance_entries,
+            {"EnthalpyOfMixing": None},
+            {
+                "Density": {"n_components": [1]},
+                "DielectricConstant": {},
+            },
+            property_types=["EnthalpyOfMixing", "Density", "DielectricConstant"],
         )
 
         assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CC", "O")}
@@ -1677,16 +1836,11 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             (("CC", "O"), (False, True)),
             (("CCC",), (True, False)),
         ]
-        data_frame = _build_data_frame(self.property_types, substance_entries)
 
-        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
-            data_frame,
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"EnthalpyOfMixing": []},
-                additional_property_types={
-                    "Density": AdditionalPropertyTypeConfig(n_components=[])
-                },
-            ),
+        filtered = self._filter(
+            substance_entries,
+            {"EnthalpyOfMixing": []},
+            {"Density": {"n_components": []}},
         )
 
         assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CC", "O")}

--- a/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
@@ -1303,8 +1303,8 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             )
 
     def test_filter_by_core_and_additional_truncates_correctly(self):
-        """Headline happy path: the gap-fill count truncates to
-        int(scale_factor * core_count) when more candidates are available.
+        """gap-fill count truncates to int(scale_factor * core_count)
+        when more candidates are available.
 
         This focuses on the count arithmetic (4 core, scale_factor=0.5 -> 2)
         with three candidates competing for two slots. The complementary

--- a/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
@@ -12,6 +12,7 @@ from openff.evaluator.datasets import (
     PropertyPhase,
 )
 from openff.evaluator.datasets.curation.components.filtering import (
+    AdditionalPropertyTypeConfig,
     FilterByCharged,
     FilterByChargedSchema,
     FilterByCoreAndAdditionalPropertyTypes,
@@ -1244,7 +1245,7 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         with pytest.raises(ValidationError):
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"Density": None},
-                additional_property_types={"Density": None},
+                additional_property_types={"Density": AdditionalPropertyTypeConfig()},
             )
 
         # scale_factor must be non-negative
@@ -1441,7 +1442,7 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         """n_components constrains which rows qualify for each type."""
         property_types = ["Density", "EnthalpyOfMixing"]
 
-        # n_components on core: binary Density rows excluded from core set.
+        # Restrict core to pure Density only; the binary mixture is excluded.
         substance_entries = [
             (("CC",),       (True, False)),
             (("CC", "O"),   (False, True)),
@@ -1511,6 +1512,7 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
                 select_by="diversity",
             ),
         )
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CCC", "O")}
 
         assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("c1ccccc1", "O")}
 
@@ -1543,7 +1545,6 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
                     "Density": None,
                     "DielectricConstant": None,
                 },
-                scale_factor=2.0,
             ),
         )
 
@@ -1578,7 +1579,6 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
                     "Density": None,
                     "DielectricConstant": None,
                 },
-                scale_factor=3.0,
             ),
         )
 

--- a/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
@@ -1233,12 +1233,15 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         # Valid schema
         FilterByCoreAndAdditionalPropertyTypesSchema(
             core_property_types={"Density": None},
-            additional_property_types={"EnthalpyOfMixing": None},
+            additional_property_types={
+                "EnthalpyOfMixing": AdditionalPropertyTypeConfig()
+            },
         )
         FilterByCoreAndAdditionalPropertyTypesSchema(
             core_property_types={"Density": [1]},
-            additional_property_types={"EnthalpyOfMixing": None},
-            scale_factor=0.0,
+            additional_property_types={
+                "EnthalpyOfMixing": AdditionalPropertyTypeConfig(scale_factor=0.0)
+            },
         )
 
         # Types must be disjoint
@@ -1248,19 +1251,29 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
                 additional_property_types={"Density": AdditionalPropertyTypeConfig()},
             )
 
-        # scale_factor must be non-negative
+        # Additional types require a config value, not None
         with pytest.raises(ValidationError):
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"Density": None},
                 additional_property_types={"EnthalpyOfMixing": None},
-                scale_factor=-1.0,
+            )
+
+        # scale_factor must be non-negative
+        with pytest.raises(ValidationError):
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": None},
+                additional_property_types={
+                    "EnthalpyOfMixing": {"scale_factor": -1.0}
+                },
             )
 
         # Both dicts must be non-empty
         with pytest.raises(ValidationError):
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={},
-                additional_property_types={"EnthalpyOfMixing": None},
+                additional_property_types={
+                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig()
+                },
             )
         with pytest.raises(ValidationError):
             FilterByCoreAndAdditionalPropertyTypesSchema(
@@ -1272,7 +1285,9 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         with pytest.raises(ValidationError):
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"Density": None},
-                additional_property_types={"EnthalpyOfMixing": None},
+                additional_property_types={
+                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig()
+                },
                 select_by="random",
             )
 
@@ -1282,31 +1297,33 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         # int(scale_factor * core_count) per additional type.
         substance_entries = [
             (("CC",),       (True, False)),
-            (("CC", "O"),   (True, True)),
             (("CCC",),      (True, False)),
-            (("CCC", "O"),  (False, True)),
             (("CCCC",),     (True, False)),
-            (("CCCC", "O"), (True, True)),
-            (("CCCCC", "O"), (False, True)),  # no density -- not in core
+            (("CCCCC",),    (True, False)),
+            (("CC", "O"),   (False, True)),
+            (("CCC", "O"),  (False, True)),
+            (("c1ccccc1", "O"), (False, True)),
         ]
         data_frame = _build_data_frame(self.property_types, substance_entries)
 
+        # 4 core substances, scale_factor=0.5 -> target of 2 EnthalpyOfMixing
+        # substances; the alkane mixtures outrank the dissimilar aromatic one.
         filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"EnthalpyOfMixing": None},
-                additional_property_types={"Density": None},
-                scale_factor=1.0,
+                core_property_types={"Density": None},
+                additional_property_types={
+                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig(scale_factor=0.5)
+                },
             ),
         )
         assert _substances_for_property(filtered, "Density") == {
-            ("CC",), ("CCC",), ("CCCC",),
-            ("CC", "O"), ("CCC", "O"), ("CCCC", "O")
+            ("CC",), ("CCC",), ("CCCC",), ("CCCCC",)
         }
         assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
-            ("CC", "O"), ("CCC", "O"), ("CCCC", "O")
+            ("CC", "O"), ("CCC", "O")
         }
-        assert ("CCCCC", "O") not in data_frame_to_substances(filtered)
+        assert ("O", "c1ccccc1") not in data_frame_to_substances(filtered)
 
     def test_filter_by_core_and_additional_full_overlap_ignore_scale_factor(self):
         # Overlap > target: full overlap is retained without truncation.
@@ -1326,17 +1343,24 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"EnthalpyOfMixing": None},
-                additional_property_types={"Density": None},
-                scale_factor=0.5,  # target=2 but overlap=4 → keep all 4
+                additional_property_types={
+                    # target=2 but overlap=4 → keep all 4
+                    "Density": AdditionalPropertyTypeConfig(scale_factor=0.5)
+                },
             ),
         )
 
         assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
             ("CC", "O"), ("CCC", "O"), ("CCCC", "O"), ("CCCCC", "O")
         }
+        assert _substances_for_property(filtered, "Density") == {
+            ("CC", "O"), ("CCC", "O"), ("CCCC", "O"), ("CCCCC", "O")
+        }
+        # No gap-fill: the pure-substance density data are not selected.
+        assert ("CC",) not in data_frame_to_substances(filtered)
 
-    def test_filter_by_core_and_additional_no_overlap(self):
-        # scale_factor=0: no additional rows selected.
+    def test_filter_by_core_and_additional_zero_scale_factor(self):
+        # scale_factor=0: no gap-fill, but the core overlap is still retained.
         substance_entries = [
             (("CC",),       (True, False)),
             (("CC", "O"),   (True, True)),
@@ -1351,13 +1375,17 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"EnthalpyOfMixing": None},
-                additional_property_types={"Density": None},
-                scale_factor=0.0,
+                additional_property_types={
+                    "Density": AdditionalPropertyTypeConfig(scale_factor=0.0)
+                },
             ),
         )
 
-        assert _substances_for_property(filtered, "Density") == {("CC",), ("CCC",)}
-        assert _substances_for_property(filtered, "EnthalpyOfMixing") == set()
+        # Core = {CC+O}; its density data are overlap and survive, but no
+        # further density substances are gap-filled.
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CC", "O")}
+        assert _substances_for_property(filtered, "Density") == {("CC", "O")}
+        assert ("CC",) not in data_frame_to_substances(filtered)
 
     def test_filter_by_core_and_additional_fewer_candidates_than_target(self):
         # Fewer candidates than target: return all available.
@@ -1375,15 +1403,19 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"Density": None},
-                additional_property_types={"EnthalpyOfMixing": None},
-                scale_factor=1.0,
+                additional_property_types={
+                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig(scale_factor=1.0)
+                },
             ),
         )
 
         assert _substances_for_property(filtered, "Density") == {
             ("CC",), ("CCC",), ("CCCC",)
         }
-        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CC", "O")}
+        # target = 3 but only 2 candidates have data → both are taken.
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
+            ("CC", "O"), ("CCC", "O")
+        }
 
     def test_filter_by_core_and_additional_empty_core(self):
         # Empty core intersection of density and enthalpy of vaporization --> empty result.
@@ -1403,8 +1435,9 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"Density": None, "Viscosity": None},
-                additional_property_types={"EnthalpyOfMixing": None},
-                scale_factor=1.0,
+                additional_property_types={
+                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig()
+                },
             ),
         )
 
@@ -1428,8 +1461,9 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"Density": None, "EnthalpyOfVaporization": None},
-                additional_property_types={"EnthalpyOfMixing": None},
-                scale_factor=1.0,
+                additional_property_types={
+                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig()
+                },
             ),
         )
 
@@ -1443,12 +1477,15 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         property_types = ["Density", "EnthalpyOfMixing"]
 
         # Restrict core to pure Density only; the binary mixture is excluded.
+        # Restrict the additional type to binary mixtures; the (unphysical)
+        # pure-substance enthalpy of mixing entry is excluded.
         substance_entries = [
             (("CC",),       (True, False)),
             (("CC", "O"),   (False, True)),
             (("CCC",),      (True, False)),
             (("CCC", "O"),  (False, True)),
             (("CC", "CCC"), (True, False)),
+            (("CCCCC",),    (False, True)),
         ]
         data_frame = _build_data_frame(property_types, substance_entries)
 
@@ -1456,13 +1493,20 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"Density": [1]},
-                additional_property_types={"EnthalpyOfMixing": None},
-                scale_factor=1.0,
+                additional_property_types={
+                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig(
+                        n_components=[2]
+                    )
+                },
             ),
         )
 
         assert _substances_for_property(filtered, "Density") == {("CC",), ("CCC",)}
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
+            ("CC", "O"), ("CCC", "O")
+        }
         assert ("CC", "CCC") not in data_frame_to_substances(filtered)
+        assert ("CCCCC",) not in data_frame_to_substances(filtered)
 
 
     def test_filter_by_core_and_additional_gap_fill_similarity(self):
@@ -1482,13 +1526,15 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"Density": None},
-                additional_property_types={"EnthalpyOfMixing": None},
-                scale_factor=1.0,
+                additional_property_types={
+                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig()
+                },
                 select_by="similarity",
             ),
         )
 
         assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CCC", "O")}
+        assert ("O", "c1ccccc1") not in data_frame_to_substances(filtered)
 
     def test_filter_by_core_and_additional_gap_fill_diversity(self):
         """Gap-fill by diversity: substance most dissimilar to core is selected.
@@ -1507,32 +1553,30 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             data_frame,
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"Density": None},
-                additional_property_types={"EnthalpyOfMixing": None},
-                scale_factor=1.0,
+                additional_property_types={
+                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig()
+                },
                 select_by="diversity",
             ),
         )
-        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CCC", "O")}
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
+            ("O", "c1ccccc1")
+        }
+        assert ("CCC", "O") not in data_frame_to_substances(filtered)
 
-        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("c1ccccc1", "O")}
-
-    def test_filter_by_core_and_additional_multi_type_coverage(self):
+    @pytest.mark.parametrize("select_by", ["similarity", "diversity"])
+    def test_filter_by_core_and_additional_multi_type_coverage(self, select_by):
         """Gap-fill prefers substances covering multiple additional types."""
         property_types = ["Density", "EnthalpyOfMixing", "DielectricConstant"]
 
-        # Core: {CC+O, CCC+O, CCCC+O} with EOM data
-        # Additional types: Density (pure) and DielectricConstant (mixed/pure)
-        # CCC+O candidates fill both DC and nothing else (DC=T, Density=F);
-        # CCCC covers only DC; CCCCC covers only Density.
-        # Greedy prefers candidates covering multiple types.
+        # Core: {CC+O} (EnthalpyOfMixing). Targets: 1 Density + 1
+        # DielectricConstant substance. CCC covers both additional types and
+        # fills both gaps at once, so it is preferred over CCCC (Density only)
+        # and CCCCC+O (DielectricConstant only) under either strategy.
         substance_entries = [
-            (("CC",),       (True, False, False)),
-            (("CC", "O"),   (True, True, True)),
-            (("CCC",),      (True, False, False)),
-            (("CCC", "O"),  (False, True, True)),
-            (("CCCC",),     (True, False, False)),
-            (("CCCC", "O"), (False, True, False)),
-            (("CCCCC",),    (True, False, False)),
+            (("CC", "O"),    (False, True, False)),
+            (("CCC",),       (True, False, True)),
+            (("CCCC",),      (True, False, False)),
             (("CCCCC", "O"), (False, False, True)),
         ]
         data_frame = _build_data_frame(property_types, substance_entries)
@@ -1542,21 +1586,28 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"EnthalpyOfMixing": None},
                 additional_property_types={
-                    "Density": None,
-                    "DielectricConstant": None,
+                    "Density": AdditionalPropertyTypeConfig(),
+                    "DielectricConstant": AdditionalPropertyTypeConfig(),
                 },
+                select_by=select_by,
             ),
         )
 
-        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CC", "O"), ("CCC", "O"), ("CCCC", "O")}
-        assert _substances_for_property(filtered, "Density") == {("CC",), ("CCC",), ("CCCC",), ("CCCCC",)}
-        assert _substances_for_property(filtered, "DielectricConstant") == {("CC", "O"), ("CCC", "O"), ("CCCCC", "O")}
-        assert ("CCCCC",) not in data_frame_to_substances(filtered)
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CC", "O")}
+        assert _substances_for_property(filtered, "Density") == {("CCC",)}
+        assert _substances_for_property(filtered, "DielectricConstant") == {("CCC",)}
+        assert ("CCCC",) not in data_frame_to_substances(filtered)
+        assert ("CCCCC", "O") not in data_frame_to_substances(filtered)
 
-        # When candidates exhausted: core-only substances may be retained for core property.
-        # Core: {CC+O, CCC+O, CCCC+O, CCCCC+O}; scale_factor=3.0 → target=12 per additional type.
-        # Density candidates: {CC, CCC, CCCC, CCCCC, CCCCCC} (5 available, need 12 → take all)
-        # DC candidates: {CCCCCC+O} overlap + any non-core substances
+    def test_filter_by_core_and_additional_candidates_exhausted(self):
+        """When candidates run out, the full candidate set is taken."""
+        property_types = ["Density", "EnthalpyOfMixing", "DielectricConstant"]
+
+        # Core: {CC+O, CCC+O, CCCC+O, CCCCC+O} with EOM data.
+        # Density scale_factor=3.0 → target=12, but only 5 pure candidates
+        # exist → all are taken.
+        # DielectricConstant target=4 with overlap {CC+O, CCC+O} → gap-fill
+        # the only candidate, CCCCCC+O.
         substance_entries = [
             (("CC",),        (True,  False, False)),
             (("CC", "O"),     (False, True,  True)),
@@ -1576,8 +1627,8 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"EnthalpyOfMixing": None},
                 additional_property_types={
-                    "Density": None,
-                    "DielectricConstant": None,
+                    "Density": AdditionalPropertyTypeConfig(scale_factor=3.0),
+                    "DielectricConstant": AdditionalPropertyTypeConfig(),
                 },
             ),
         )
@@ -1586,7 +1637,8 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         density_substances = _substances_for_property(filtered, "Density")
         dc_substances = _substances_for_property(filtered, "DielectricConstant")
 
-        assert ("CC", "O") in eom_substances and ("CCC", "O") in eom_substances
+        assert eom_substances == {
+            ("CC", "O"), ("CCC", "O"), ("CCCC", "O"), ("CCCCC", "O")
+        }
         assert len(density_substances) == 5  # all pure candidates selected
-        assert ("CCCCCC", "O") in dc_substances
-        assert len(eom_substances) == 4  # core set
+        assert dc_substances == {("CC", "O"), ("CCC", "O"), ("CCCCCC", "O")}

--- a/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
@@ -1291,6 +1291,15 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
                 select_by="random",
             )
 
+        # Unknown config keys (e.g. typos) are rejected
+        with pytest.raises(ValidationError):
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"Density": None},
+                additional_property_types={
+                    "EnthalpyOfMixing": {"scale_facto": 0.5}
+                },
+            )
+
     def test_filter_by_core_and_additional_truncates_correctly(self):
         # Core substances = intersection of all core property type substance sets.
         # Additional substances = overlap (always) + gap-fill up to
@@ -1508,7 +1517,6 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         assert ("CC", "CCC") not in data_frame_to_substances(filtered)
         assert ("CCCCC",) not in data_frame_to_substances(filtered)
 
-
     def test_filter_by_core_and_additional_gap_fill_similarity(self):
         """Gap-fill by similarity: substance most similar to core is selected.
 
@@ -1638,7 +1646,62 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         dc_substances = _substances_for_property(filtered, "DielectricConstant")
 
         assert eom_substances == {
-            ("CC", "O"), ("CCC", "O"), ("CCCC", "O"), ("CCCCC", "O")
+            ("CC", "O"),
+            ("CCC", "O"),
+            ("CCCC", "O"),
+            ("CCCCC", "O"),
         }
         assert len(density_substances) == 5  # all pure candidates selected
         assert dc_substances == {("CC", "O"), ("CCC", "O"), ("CCCCCC", "O")}
+
+    def test_filter_by_core_and_additional_no_cross_type_leak(self):
+        """A substance kept for one additional type must not drag along its
+        rows for another additional type whose n_components filter excludes it.
+        """
+        property_types = ["EnthalpyOfMixing", "Density", "DielectricConstant"]
+        substance_entries = [
+            # Core substance (binary): also carries binary Density data, which
+            # the Density n_components=[1] filter must exclude, and
+            # DielectricConstant data, which is kept as overlap.
+            (("CC", "O"), (True, True, True)),
+            # Legitimate pure Density gap-fill candidate.
+            (("CCC",), (False, True, False)),
+        ]
+        data_frame = _build_data_frame(property_types, substance_entries)
+
+        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
+            data_frame,
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"EnthalpyOfMixing": None},
+                additional_property_types={
+                    "Density": AdditionalPropertyTypeConfig(n_components=[1]),
+                    "DielectricConstant": AdditionalPropertyTypeConfig(),
+                },
+            ),
+        )
+
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CC", "O")}
+        # The binary core substance's Density row is excluded by n_components=[1].
+        assert _substances_for_property(filtered, "Density") == {("CCC",)}
+        assert _substances_for_property(filtered, "DielectricConstant") == {("CC", "O")}
+
+    def test_filter_by_core_and_additional_empty_n_components(self):
+        """An empty n_components list means no restriction, same as None."""
+        substance_entries = [
+            (("CC", "O"), (False, True)),
+            (("CCC",), (True, False)),
+        ]
+        data_frame = _build_data_frame(self.property_types, substance_entries)
+
+        filtered = FilterByCoreAndAdditionalPropertyTypes.apply(
+            data_frame,
+            FilterByCoreAndAdditionalPropertyTypesSchema(
+                core_property_types={"EnthalpyOfMixing": []},
+                additional_property_types={
+                    "Density": AdditionalPropertyTypeConfig(n_components=[])
+                },
+            ),
+        )
+
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CC", "O")}
+        assert _substances_for_property(filtered, "Density") == {("CCC",)}

--- a/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
@@ -1256,76 +1256,12 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             ),
         )
 
-    def test_validate_filter_by_core_and_additional(self):
-        """Generally test valid arguments for schema and set expectations"""
-        # Valid schema
-        FilterByCoreAndAdditionalPropertyTypesSchema(
-            core_property_types={"Density": None},
-            additional_property_types={
-                "EnthalpyOfMixing": AdditionalPropertyTypeConfig()
-            },
-        )
-        FilterByCoreAndAdditionalPropertyTypesSchema(
-            core_property_types={"Density": [1]},
-            additional_property_types={
-                "EnthalpyOfMixing": AdditionalPropertyTypeConfig(scale_factor=0.0)
-            },
-        )
-
-        # Types must be disjoint
+    def test_validate_filter_by_core_and_additional_disjoint(self):
+        """Core and additional property types must be disjoint."""
         with pytest.raises(ValidationError):
             FilterByCoreAndAdditionalPropertyTypesSchema(
                 core_property_types={"Density": None},
                 additional_property_types={"Density": AdditionalPropertyTypeConfig()},
-            )
-
-        # Additional types require a config value, not None
-        with pytest.raises(ValidationError):
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None},
-                additional_property_types={"EnthalpyOfMixing": None},
-            )
-
-        # scale_factor must be non-negative
-        with pytest.raises(ValidationError):
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None},
-                additional_property_types={
-                    "EnthalpyOfMixing": {"scale_factor": -1.0}
-                },
-            )
-
-        # Both dicts must be non-empty
-        with pytest.raises(ValidationError):
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={},
-                additional_property_types={
-                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig()
-                },
-            )
-        with pytest.raises(ValidationError):
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None},
-                additional_property_types={},
-            )
-
-        # select_by must be 'similarity' or 'diversity'
-        with pytest.raises(ValidationError):
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None},
-                additional_property_types={
-                    "EnthalpyOfMixing": AdditionalPropertyTypeConfig()
-                },
-                select_by="random",
-            )
-
-        # Unknown config keys (e.g. typos) are rejected
-        with pytest.raises(ValidationError):
-            FilterByCoreAndAdditionalPropertyTypesSchema(
-                core_property_types={"Density": None},
-                additional_property_types={
-                    "EnthalpyOfMixing": {"scale_facto": 0.5}
-                },
             )
 
     def test_filter_by_core_and_additional_truncates_correctly(self):
@@ -1366,62 +1302,57 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         }
         assert ("O", "c1ccccc1") not in data_frame_to_substances(filtered)
 
-    def test_filter_by_core_and_additional_full_overlap_ignore_scale_factor(self):
-        # Overlap > target: full overlap is retained without truncation.
-        substance_entries = [
-            (("CC",),       (True, False)),
-            (("CC", "O"),   (True, True)),
-            (("CCC",),      (True, False)),
-            (("CCC", "O"),  (True, True)),
-            (("CCCC",),     (True, False)),
-            (("CCCC", "O"), (True, True)),
-            (("CCCCC",),    (True, False)),
-            (("CCCCC", "O"), (True, True)),
-        ]
-
+    @pytest.mark.parametrize(
+        "scale_factor, substance_entries, expected_dhmix, expected_density",
+        [
+            pytest.param(
+                0.5,
+                [
+                    (("CC",),       (True, False)),
+                    (("CC", "O"),   (True, True)),
+                    (("CCC",),      (True, False)),
+                    (("CCC", "O"),  (True, True)),
+                    (("CCCC",),     (True, False)),
+                    (("CCCC", "O"), (True, True)),
+                    (("CCCCC",),    (True, False)),
+                    (("CCCCC", "O"), (True, True)),
+                ],
+                {("CC", "O"), ("CCC", "O"), ("CCCC", "O"), ("CCCCC", "O")},
+                {("CC", "O"), ("CCC", "O"), ("CCCC", "O"), ("CCCCC", "O")},
+                id="overlap_exceeds_target",
+            ),
+            pytest.param(
+                0.0,
+                [
+                    (("CC",),       (True, False)),
+                    (("CC", "O"),   (True, True)),
+                    (("CCC",),      (True, False)),
+                    (("CCC", "O"),  (True, False)),
+                    (("CCCC",),     (True, False)),
+                    (("CCCC", "O"), (True, False)),
+                ],
+                {("CC", "O")},
+                {("CC", "O")},
+                id="zero_scale_factor",
+            ),
+        ],
+    )
+    def test_filter_by_core_and_additional_no_gap_fill(
+        self, scale_factor, substance_entries, expected_dhmix, expected_density
+    ):
+        """No gap-fill when overlap meets target or scale_factor is 0."""
         filtered = self._filter(
             substance_entries,
             {"EnthalpyOfMixing": None},
-            {
-                # target=2 but overlap=4 → keep all 4
-                "Density": {"scale_factor": 0.5}
-            },
+            {"Density": {"scale_factor": scale_factor}},
         )
 
-        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
-            ("CC", "O"), ("CCC", "O"), ("CCCC", "O"), ("CCCCC", "O")
-        }
-        assert _substances_for_property(filtered, "Density") == {
-            ("CC", "O"), ("CCC", "O"), ("CCCC", "O"), ("CCCCC", "O")
-        }
-        # No gap-fill: the pure-substance density data are not selected.
-        assert ("CC",) not in data_frame_to_substances(filtered)
-
-    def test_filter_by_core_and_additional_zero_scale_factor(self):
-        # scale_factor=0: no gap-fill, but the core overlap is still retained.
-        substance_entries = [
-            (("CC",),       (True, False)),
-            (("CC", "O"),   (True, True)),
-            (("CCC",),      (True, False)),
-            (("CCC", "O"),  (True, False)),
-            (("CCCC",),     (True, False)),
-            (("CCCC", "O"), (True, False)),
-        ]
-
-        filtered = self._filter(
-            substance_entries,
-            {"EnthalpyOfMixing": None},
-            {"Density": {"scale_factor": 0.0}},
-        )
-
-        # Core = {CC+O}; its density data are overlap and survive, but no
-        # further density substances are gap-filled.
-        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CC", "O")}
-        assert _substances_for_property(filtered, "Density") == {("CC", "O")}
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == expected_dhmix
+        assert _substances_for_property(filtered, "Density") == expected_density
         assert ("CC",) not in data_frame_to_substances(filtered)
 
     def test_filter_by_core_and_additional_empty_core(self):
-        # Empty core intersection of density and enthalpy of vaporization --> empty result.
+        # Viscosity has no column in the data frame, so core intersection is empty.
         substance_entries = [
             (("CC",),       (True, False, False)),
             (("CCC",),      (True, False, False)),
@@ -1634,34 +1565,6 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         }
         # The redundant octane-region DC candidate is not taken.
         assert ("CCCCCC",) not in data_frame_to_substances(filtered)
-
-    def test_filter_by_core_and_additional_zero_gap_type_not_pulled_in(self):
-        """A multi-type pick does not retain rows for a type whose gap is zero.
-
-        Core (Density) = {CC+O}. EnthalpyOfMixing has a gap (scale_factor=1.0);
-        DielectricConstant is overlap-only (scale_factor=0.0). The single candidate
-        CCC carries both dHmix and DC data and is taken to fill dHmix. Its DC row must be
-        dropped — DC's target is 0 and CCC is not core overlap — rather than leaking
-        in because CCC was selected for another type.
-        """
-        substance_entries = [
-            (("CC", "O"), (True, False, False)),  # core
-            (("CCC",), (False, True, True)),  # dHmix+DC candidate
-        ]
-
-        filtered = self._filter(
-            substance_entries,
-            {"Density": None},
-            {
-                "EnthalpyOfMixing": {"scale_factor": 1.0},
-                "DielectricConstant": {"scale_factor": 0.0},
-            },
-            property_types=["Density", "EnthalpyOfMixing", "DielectricConstant"],
-        )
-
-        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CCC",)}
-        # DC target is 0 and CCC is not overlap → no DC rows retained.
-        assert _substances_for_property(filtered, "DielectricConstant") == set()
 
     def test_filter_by_core_and_additional_cross_fill_consumes_dissimilar_budget(self):
         """A multi-type pick is charged to every type it still has budget for, even

--- a/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
@@ -1278,12 +1278,12 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         # Additional substances = overlap (always) + gap-fill up to
         # int(scale_factor * core_count) per additional type.
         substance_entries = [
-            (("CC",),       (True, False)),
-            (("CCC",),      (True, False)),
-            (("CCCC",),     (True, False)),
-            (("CCCCC",),    (True, False)),
-            (("CC", "O"),   (False, True)),
-            (("CCC", "O"),  (False, True)),
+            (("CC",), (True, False)),
+            (("CCC",), (True, False)),
+            (("CCCC",), (True, False)),
+            (("CCCCC",), (True, False)),
+            (("CC", "O"), (False, True)),
+            (("CCC", "O"), (False, True)),
             (("c1ccccc1", "O"), (False, True)),
         ]
 
@@ -1295,10 +1295,14 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             {"EnthalpyOfMixing": {"scale_factor": 0.5}},
         )
         assert _substances_for_property(filtered, "Density") == {
-            ("CC",), ("CCC",), ("CCCC",), ("CCCCC",)
+            ("CC",),
+            ("CCC",),
+            ("CCCC",),
+            ("CCCCC",),
         }
         assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
-            ("CC", "O"), ("CCC", "O")
+            ("CC", "O"),
+            ("CCC", "O"),
         }
         assert ("O", "c1ccccc1") not in data_frame_to_substances(filtered)
 
@@ -1308,13 +1312,13 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             pytest.param(
                 0.5,
                 [
-                    (("CC",),       (True, False)),
-                    (("CC", "O"),   (True, True)),
-                    (("CCC",),      (True, False)),
-                    (("CCC", "O"),  (True, True)),
-                    (("CCCC",),     (True, False)),
+                    (("CC",), (True, False)),
+                    (("CC", "O"), (True, True)),
+                    (("CCC",), (True, False)),
+                    (("CCC", "O"), (True, True)),
+                    (("CCCC",), (True, False)),
                     (("CCCC", "O"), (True, True)),
-                    (("CCCCC",),    (True, False)),
+                    (("CCCCC",), (True, False)),
                     (("CCCCC", "O"), (True, True)),
                 ],
                 {("CC", "O"), ("CCC", "O"), ("CCCC", "O"), ("CCCCC", "O")},
@@ -1324,11 +1328,11 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             pytest.param(
                 0.0,
                 [
-                    (("CC",),       (True, False)),
-                    (("CC", "O"),   (True, True)),
-                    (("CCC",),      (True, False)),
-                    (("CCC", "O"),  (True, False)),
-                    (("CCCC",),     (True, False)),
+                    (("CC",), (True, False)),
+                    (("CC", "O"), (True, True)),
+                    (("CCC",), (True, False)),
+                    (("CCC", "O"), (True, False)),
+                    (("CCCC",), (True, False)),
                     (("CCCC", "O"), (True, False)),
                 ],
                 {("CC", "O")},
@@ -1354,12 +1358,12 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
     def test_filter_by_core_and_additional_empty_core(self):
         # Viscosity has no column in the data frame, so core intersection is empty.
         substance_entries = [
-            (("CC",),       (True, False, False)),
-            (("CCC",),      (True, False, False)),
-            (("CCCC",),     (False, True, False)),
-            (("CCCCC",),    (False, True, False)),
-            (("CC", "O"),   (False, False, True)),
-            (("CCC", "O"),  (False, False, True)),
+            (("CC",), (True, False, False)),
+            (("CCC",), (True, False, False)),
+            (("CCCC",), (False, True, False)),
+            (("CCCCC",), (False, True, False)),
+            (("CC", "O"), (False, False, True)),
+            (("CCC", "O"), (False, False, True)),
             (("CCCC", "O"), (False, False, True)),
         ]
 
@@ -1375,13 +1379,16 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
     def test_filter_by_core_and_additional_multiple_core_types(self):
         """Strict intersection across multiple core types."""
         substance_entries = [
-            (("CC",),       (True, True, False)),
-            (("CC", "O"),   (False, False, True)),
-            (("CCC",),      (True, True, False)),
-            (("CCC", "O"),  (False, False, True)),
-            (("CCCC",),     (True, False, False)),   # Density only, not EnthalpyOfVaporization
-            (("CCCC", "O"), (False, False, True)),   # dHmix only
-            (("CCCCC",),    (False, True, False)),   # EnthalpyOfVaporization only
+            (("CC",), (True, True, False)),
+            (("CC", "O"), (False, False, True)),
+            (("CCC",), (True, True, False)),
+            (("CCC", "O"), (False, False, True)),
+            (
+                ("CCCC",),
+                (True, False, False),
+            ),  # Density only, not EnthalpyOfVaporization
+            (("CCCC", "O"), (False, False, True)),  # dHmix only
+            (("CCCCC",), (False, True, False)),  # EnthalpyOfVaporization only
         ]
 
         filtered = self._filter(
@@ -1392,8 +1399,14 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         )
 
         assert _substances_for_property(filtered, "Density") == {("CC",), ("CCC",)}
-        assert _substances_for_property(filtered, "EnthalpyOfVaporization") == {("CC",), ("CCC",)}
-        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CC", "O"), ("CCC", "O")}
+        assert _substances_for_property(filtered, "EnthalpyOfVaporization") == {
+            ("CC",),
+            ("CCC",),
+        }
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
+            ("CC", "O"),
+            ("CCC", "O"),
+        }
         assert ("CCCC",) not in data_frame_to_substances(filtered)
 
     def test_filter_by_core_and_additional_n_components(self):
@@ -1402,12 +1415,12 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         # Restrict the additional type to binary mixtures; the (unphysical)
         # pure-substance enthalpy of mixing entry is excluded.
         substance_entries = [
-            (("CC",),       (True, False)),
-            (("CC", "O"),   (False, True)),
-            (("CCC",),      (True, False)),
-            (("CCC", "O"),  (False, True)),
+            (("CC",), (True, False)),
+            (("CC", "O"), (False, True)),
+            (("CCC",), (True, False)),
+            (("CCC", "O"), (False, True)),
             (("CC", "CCC"), (True, False)),
-            (("CCCCC",),    (False, True)),
+            (("CCCCC",), (False, True)),
         ]
 
         filtered = self._filter(
@@ -1418,7 +1431,8 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
 
         assert _substances_for_property(filtered, "Density") == {("CC",), ("CCC",)}
         assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
-            ("CC", "O"), ("CCC", "O")
+            ("CC", "O"),
+            ("CCC", "O"),
         }
         assert ("CC", "CCC") not in data_frame_to_substances(filtered)
         assert ("CCCCC",) not in data_frame_to_substances(filtered)
@@ -1553,9 +1567,7 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             select_by="similarity",
         )
 
-        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
-            ("CCCCCCC",)
-        }
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CCCCCCC",)}
         assert _substances_for_property(filtered, "DielectricConstant") == {
             ("CCCCCCC",),  # the shared dHmix+DC pick covers the octane region
             ("Cc1ccccc1",),  # so the next DC pick spreads to the benzene region
@@ -1592,9 +1604,7 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             select_by="similarity",
         )
 
-        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
-            ("CCCCCCC",)
-        }
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CCCCCCC",)}
         # Heptane fills DC's single slot too; the closer toluene is not added.
         assert _substances_for_property(filtered, "DielectricConstant") == {
             ("CCCCCCC",)
@@ -1604,9 +1614,9 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
     def test_filter_by_core_and_additional_multi_type_coverage(self):
         """Gap-fill prefers substances covering multiple additional types."""
         substance_entries = [
-            (("CC", "O"),    (False, True, False)),
-            (("CCC",),       (True, False, True)),
-            (("CCCC",),      (True, False, False)),
+            (("CC", "O"), (False, True, False)),
+            (("CCC",), (True, False, True)),
+            (("CCCC",), (True, False, False)),
             (("CCCCC", "O"), (False, False, True)),
         ]
 
@@ -1634,15 +1644,15 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         # DielectricConstant target=4 with overlap {CC+O, CCC+O} → gap-fill
         # the only candidate, CCCCCC+O.
         substance_entries = [
-            (("CC",),        (True,  False, False)),
-            (("CC", "O"),     (False, True,  True)),
-            (("CCC",),       (True,  False, False)),
-            (("CCC", "O"),    (False, True,  True)),
-            (("CCCC",),      (True,  False, False)),
-            (("CCCC", "O"),   (False, True,  False)),
-            (("CCCCC",),     (True,  False, False)),
-            (("CCCCC", "O"),  (False, True,  False)),
-            (("CCCCCC",),    (True,  False, False)),
+            (("CC",), (True, False, False)),
+            (("CC", "O"), (False, True, True)),
+            (("CCC",), (True, False, False)),
+            (("CCC", "O"), (False, True, True)),
+            (("CCCC",), (True, False, False)),
+            (("CCCC", "O"), (False, True, False)),
+            (("CCCCC",), (True, False, False)),
+            (("CCCCC", "O"), (False, True, False)),
+            (("CCCCCC",), (True, False, False)),
             (("CCCCCC", "O"), (False, False, True)),
         ]
 

--- a/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
@@ -1723,6 +1723,43 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CC", "O")}
         assert _substances_for_property(filtered, "Density") == {("CCC",)}
 
+    def test_filter_by_core_dhmix_additional_density_n_components(self):
+        """Core on EnthalpyOfMixing (binaries), additional Density with
+        n_components=[1, 2] retains both pure and binary density data.
+        """
+        substance_entries = [
+            # Two binary mixtures with dHmix and density -> core set + overlap
+            (("CC", "O"), (True, True)),
+            (("CCC", "O"), (True, True)),
+            # Gap-fill candidates
+            (("CC",), (True, False)),  # pure (n_components=1)
+            (("CCCC", "O"), (True, False)), # mixture (n_components=2)
+            # excluded
+            (("CC", "O", "CCC"), (True, False)), # (n_components=3)
+            (("CF", "N"), (True, False)), # mixture (n_components=2 but too dissimilar)
+        ]
+
+        filtered = self._filter(
+            substance_entries,
+            {"EnthalpyOfMixing": None},
+            {"Density": {"scale_factor": 2.0, "n_components": [1, 2]}},
+        )
+
+        assert _substances_for_property(filtered, "EnthalpyOfMixing") == {
+            ("CC", "O"),
+            ("CCC", "O"),
+        }
+        density_subs = _substances_for_property(filtered, "Density")
+        # Core overlap: binaries that also have density
+        assert ("CC", "O") in density_subs
+        assert ("CCC", "O") in density_subs
+        # Gap-filled substances
+        assert ("CC",) in density_subs
+        assert ("CCCC", "O") in density_subs
+        # excluded
+        assert ("CC", "CCC", "O") not in density_subs
+        assert ("CF", "N") not in density_subs
+
 
 def test_validate_filter_by_tautomers():
     FilterByTautomersSchema()

--- a/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
@@ -1496,10 +1496,7 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         candidates sit near octane (heptane @1.0, hexane @0.875) and one near
         benzene (toluene @0.273). With two gaps, the dynamic strategy picks one
         aliphatic and then — having marked octane covered — switches to toluene for
-        the benzene region, giving {heptane, toluene}. A static reference would take
-        the two highest-scoring aliphatics {heptane, hexane} and leave benzene
-        uncovered, so this pins the spreading behaviour.
-        """
+        the benzene region, giving {heptane, toluene}."""
         substance_entries = [
             (("CCCCCCCC",), (True, False)),  # core, under-represented
             (("c1ccccc1",), (True, False)),  # core, under-represented
@@ -1604,13 +1601,8 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
         }
         assert ("Cc1ccccc1",) not in data_frame_to_substances(filtered)
 
-    @pytest.mark.parametrize("select_by", ["similarity", "diversity"])
-    def test_filter_by_core_and_additional_multi_type_coverage(self, select_by):
+    def test_filter_by_core_and_additional_multi_type_coverage(self):
         """Gap-fill prefers substances covering multiple additional types."""
-        # Core: {CC+O} (EnthalpyOfMixing). Targets: 1 Density + 1
-        # DielectricConstant substance. CCC covers both additional types and
-        # fills both gaps at once, so it is preferred over CCCC (Density only)
-        # and CCCCC+O (DielectricConstant only) under either strategy.
         substance_entries = [
             (("CC", "O"),    (False, True, False)),
             (("CCC",),       (True, False, True)),
@@ -1626,7 +1618,6 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
                 "DielectricConstant": {},
             },
             property_types=["Density", "EnthalpyOfMixing", "DielectricConstant"],
-            select_by=select_by,
         )
 
         assert _substances_for_property(filtered, "EnthalpyOfMixing") == {("CC", "O")}

--- a/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
+++ b/openff/evaluator/_tests/test_datasets/test_curation/test_filtering.py
@@ -1733,10 +1733,10 @@ class TestFilterByCoreAndAdditionalPropertyTypes:
             (("CCC", "O"), (True, True)),
             # Gap-fill candidates
             (("CC",), (True, False)),  # pure (n_components=1)
-            (("CCCC", "O"), (True, False)), # mixture (n_components=2)
+            (("CCCC", "O"), (True, False)),  # mixture (n_components=2)
             # excluded
-            (("CC", "O", "CCC"), (True, False)), # (n_components=3)
-            (("CF", "N"), (True, False)), # mixture (n_components=2 but too dissimilar)
+            (("CC", "O", "CCC"), (True, False)),  # (n_components=3)
+            (("CF", "N"), (True, False)),  # mixture (n_components=2 but too dissimilar)
         ]
 
         filtered = self._filter(

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -1448,14 +1448,10 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
             type_overlap[add_type] = s_core & s_a
             type_candidates[add_type] = s_a - s_core
 
-        gap = {
-            a: max(
-                0,
-                int(schema.additional_property_types[a].scale_factor * len(s_core))
-                - len(overlap),
-            )
-            for a, overlap in type_overlap.items()
-        }
+        gap = {}
+        for a, overlap in type_overlap.items():
+            target = int(schema.additional_property_types[a].scale_factor * len(s_core))
+            gap[a] = max(0, target - len(overlap))
         selected = cls._gap_fill(schema, s_core, type_candidates, gap)
 
         # Mask rows per additional type so that a substance kept for one type

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -1299,6 +1299,14 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
     are kept: first the overlap with the core set, then gap-fill candidates chosen
     by the ``select_by`` strategy, with preference for substances that cover
     multiple additional types at once.
+
+    This acts very similarly to the FilterByPropertyTypes component when ``scale_factor``
+    is 0 for all additional types, but with the added guarantee that all core substances
+    are retained, even if they don't have data for all additional types.
+    With a positive ``scale_factor``, this component can be used to curate a data set
+    with good coverage of the core set across multiple properties,
+    while supplementing with additional data for substances in the same or diverse
+    chemical space.
     """
 
     @staticmethod

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -8,6 +8,7 @@ import numpy
 import pandas
 from openff.units import unit
 from pydantic import (
+    BaseModel,
     Field,
     PositiveFloat,
     PositiveInt,
@@ -37,6 +38,9 @@ logger = logging.getLogger(__name__)
 
 ComponentEnvironments = List[List[ChemicalEnvironment]]
 MoleFractionRange = Tuple[confloat(ge=0.0, le=1.0), confloat(ge=0.0, le=1.0)]
+# A mapping of property type -> optional list of allowed component counts
+# (``None`` means no ``n_components`` restriction).
+PropertyTypeFilter = Dict[constr(min_length=1), Optional[List[PositiveInt]]]
 
 
 class FilterDuplicatesSchema(CurationComponentSchema):
@@ -1222,31 +1226,42 @@ def _morgan_fp(smiles: str):
     return AllChem.GetMorganFingerprintAsBitVect(mol, radius=2, nBits=2048)
 
 
-class FilterByCoreAndAdditionalPropertyTypesSchema(CurationComponentSchema):
-    type: Literal[
-        "FilterByCoreAndAdditionalPropertyTypes"
-    ] = "FilterByCoreAndAdditionalPropertyTypes"
+class AdditionalPropertyTypeConfig(BaseModel):
+    """Per-type configuration for an additional property type."""
 
-    core_property_types: Dict[constr(min_length=1), Optional[List[PositiveInt]]] = Field(
+    scale_factor: float = Field(
+        1.0,
+        ge=0.0,
+        description="Ratio of gap-fill substances to core count for this type: "
+        "int(scale_factor * core_count) substances are targeted. The overlap — "
+        "additional-type data already present for core substances — is always "
+        "retained. Set to 0 for overlap-only (no gap-fill).",
+    )
+    n_components: Optional[List[PositiveInt]] = Field(
+        None,
+        description="If set, only substances with this many components qualify "
+        "for this additional type.",
+    )
+
+
+class FilterByCoreAndAdditionalPropertyTypesSchema(CurationComponentSchema):
+    type: Literal["FilterByCoreAndAdditionalPropertyTypes"] = (
+        "FilterByCoreAndAdditionalPropertyTypes"
+    )
+
+    core_property_types: PropertyTypeFilter = Field(
         ...,
         min_length=1,
         description="Property types that define the core substance set. A substance "
         "must have data for ALL listed types to be included in the core set. "
         "Dict values are optional n_components filters; use None for no filter.",
     )
-    additional_property_types: Dict[constr(min_length=1), Optional[List[PositiveInt]]] = Field(
+    additional_property_types: Dict[constr(min_length=1), AdditionalPropertyTypeConfig] = Field(
         ...,
         min_length=1,
-        description="Property types for which additional data are retained. For each "
-        "type, up to int(scale_factor * core_count) substance rows are kept. "
-        "Dict values are optional n_components filters; use None for no filter.",
-    )
-    scale_factor: float = Field(
-        1.0,
-        ge=0.0,
-        description="Ratio of additional to core substances. 0 means no additional "
-        "data are retained, including additional-type rows for substances that are "
-        "already in the core set.",
+        description="Property types for which additional data are retained. Each "
+        "key is a property type name; its value is an AdditionalPropertyTypeConfig "
+        "controlling the scale_factor and optional n_components filter.",
     )
     select_by: Literal["similarity", "diversity"] = Field(
         "similarity",
@@ -1276,6 +1291,24 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
     multiple additional types at once.
     """
 
+    @staticmethod
+    def _value_column(data_frame: pandas.DataFrame, property_type: str):
+        """The ``<type> Value ...`` column for *property_type*, or ``None``."""
+        return next(
+            (
+                header
+                for header in data_frame
+                if " Value " in header and header.split(" ")[0] == property_type
+            ),
+            None,
+        )
+
+    @classmethod
+    def _value_columns(cls, data_frame: pandas.DataFrame, property_types) -> List[str]:
+        """The value columns present for *property_types* (missing types dropped)."""
+        columns = (cls._value_column(data_frame, t) for t in property_types)
+        return [column for column in columns if column is not None]
+
     @classmethod
     def _type_substances(
         cls,
@@ -1283,10 +1316,7 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
         property_type: str,
         n_components_filter: Optional[List[int]],
     ):
-        val_col = next(
-            (h for h in data_frame.columns if h.startswith(f"{property_type} Value")),
-            None,
-        )
+        val_col = cls._value_column(data_frame, property_type)
         if val_col is None:
             return set()
         rows = data_frame[data_frame[val_col].notna()]
@@ -1295,13 +1325,89 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
         return data_frame_to_substances(rows)
 
     @classmethod
+    def _gap_fill(cls, schema, s_core, type_candidates, gap) -> set:
+        """Greedily pick candidate substances to fill ``gap`` per additional type.
+
+        Candidates covering several additional types at once are preferred; ties
+        are broken by the ``select_by`` strategy (most 'similarity' to, or most
+        'diversity' from, the core set). ``gap`` is mutated in place. Returns the
+        set of selected substances.
+        """
+        if not any(g > 0 for g in gap.values()):
+            return set()
+
+        from rdkit import DataStructs
+
+        s_core_smiles = frozenset(smi for sub in s_core for smi in sub)
+        ref_fps = [fp for fp in map(_morgan_fp, s_core_smiles) if fp is not None]
+        # For diversity the reference set grows as substances are selected.
+        selected_smiles = set(s_core_smiles)
+
+        def fp_score(substance):
+            fps_sub = [fp for fp in map(_morgan_fp, substance) if fp is not None]
+            if not fps_sub:
+                return 0.0
+            if schema.select_by == "similarity":
+                fps_ref = ref_fps
+            else:  # diversity — MaxMin: score = 1 - nearest-neighbour Tanimoto
+                fps_ref = [
+                    fp for fp in map(_morgan_fp, selected_smiles) if fp is not None
+                ]
+            if not fps_ref:
+                return 0.0 if schema.select_by == "similarity" else 1.0
+            nn_sim = max(
+                DataStructs.TanimotoSimilarity(fp, ref)
+                for fp in fps_sub
+                for ref in fps_ref
+            )
+            return nn_sim if schema.select_by == "similarity" else 1.0 - nn_sim
+
+        coverage_map = {
+            sub: [a for a, cands in type_candidates.items() if sub in cands]
+            for sub in set().union(*type_candidates.values())
+        }
+
+        selected: set = set()
+
+        def take(substance):
+            for covered in coverage_map[substance]:
+                gap[covered] = max(0, gap[covered] - 1)
+            selected.add(substance)
+            selected_smiles.update(substance)
+
+        for add_type in schema.additional_property_types:
+            remaining = [
+                sub for sub in type_candidates[add_type] if sub not in selected
+            ]
+            if schema.select_by == "similarity":
+                # Similarity scores are static, so rank candidates once.
+                score = {sub: fp_score(sub) for sub in remaining}
+                remaining.sort(key=lambda c: (-len(coverage_map[c]), -score[c]))
+                for sub in remaining:
+                    if gap[add_type] <= 0:
+                        break
+                    take(sub)
+            else:
+                # Diversity scores depend on prior picks, so re-rank each step.
+                while gap[add_type] > 0 and remaining:
+                    take(
+                        max(
+                            remaining,
+                            key=lambda c: (-len(coverage_map[c]), fp_score(c)),
+                        )
+                    )
+                    remaining = [sub for sub in remaining if sub not in selected]
+
+        return selected
+
+    @classmethod
     def _apply(
         cls,
         data_frame: pandas.DataFrame,
         schema: FilterByCoreAndAdditionalPropertyTypesSchema,
-        n_processes,  # unused; filtering is CPU-light
+        n_processes,  # unused
     ) -> pandas.DataFrame:
-        # ── Step 1: S_core = intersection of per-type substance sets ──────────────
+        # Core substance set: intersection of the per-type substance sets.
         s_core = None
         for prop_type, nc_filter in schema.core_property_types.items():
             subs = cls._type_substances(data_frame, prop_type, nc_filter)
@@ -1309,138 +1415,44 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
         if not s_core:
             return data_frame.iloc[0:0]
 
-        core_count = len(s_core)
-
-        # ── Step 2: pre-compute substance tuples (used in both row masks) ─────────
+        # Substance tuple per row, used by both the core and additional masks.
+        # The ordering (alphabetical) must match data_frame_to_substances so the
+        # `.isin` checks below line up with the sets built from it.
         def _sub_tuple(row):
             n = int(row["N Components"])
             return tuple(sorted(row[f"Component {i + 1}"] for i in range(n)))
 
         substance_col = data_frame.apply(_sub_tuple, axis=1)
 
-        # ── Step 3: core rows ─────────────────────────────────────────────────────
-        # Keep rows whose substance is in S_core and that carry at least one
-        # core-type value.  Additional-type rows for core substances are only
-        # retained when scale_factor > 0 (assembled in Steps 5–6 via type_overlap).
-        core_val_cols = [
-            next((h for h in data_frame.columns if h.startswith(f"{t} Value")), None)
-            for t in schema.core_property_types
-        ]
-        core_val_cols = [c for c in core_val_cols if c is not None]
-
+        # Core rows: substance in S_core carrying at least one core-type value.
+        core_val_cols = cls._value_columns(data_frame, schema.core_property_types)
         core_rows = data_frame[
             substance_col.isin(s_core) & data_frame[core_val_cols].notna().any(axis=1)
         ]
 
-        # ── Step 4: target and per-type substance sets ────────────────────────────
-        target = int(schema.scale_factor * core_count)
-        if target == 0:
-            return core_rows
-
-        type_overlap = {}  # add_type -> S_core ∩ S_a
-        type_candidates = {}  # add_type -> S_a \ S_core
-        for add_type, nc_filter in schema.additional_property_types.items():
-            s_a = cls._type_substances(data_frame, add_type, nc_filter)
+        # Per additional type, split into the core overlap (always kept) and the
+        # gap-fill candidates (substances outside the core set).
+        # The overlap is retained regardless of scale_factor; only gap-fill is
+        # suppressed when a type's target == 0.
+        type_overlap = {}
+        type_candidates = {}
+        for add_type, config in schema.additional_property_types.items():
+            s_a = cls._type_substances(data_frame, add_type, config.n_components)
             type_overlap[add_type] = s_core & s_a
             type_candidates[add_type] = s_a - s_core
 
         gap = {
-            a: max(0, target - len(type_overlap[a]))
-            for a in schema.additional_property_types
+            a: max(
+                0,
+                int(schema.additional_property_types[a].scale_factor * len(s_core))
+                - len(overlap),
+            )
+            for a, overlap in type_overlap.items()
         }
+        selected = cls._gap_fill(schema, s_core, type_candidates, gap)
 
-        # ── Step 5: greedy gap-fill ───────────────────────────────────────────────
-        selected_set: set = set()
-        if any(g > 0 for g in gap.values()):
-            from rdkit import DataStructs
-
-            s_core_smiles = frozenset(smi for sub in s_core for smi in sub)
-            ref_fps = [
-                fp for fp in (_morgan_fp(s) for s in s_core_smiles) if fp is not None
-            ]
-            if schema.select_by == "diversity":
-                selected_smiles: set = set(s_core_smiles)
-
-            def fp_score(substance):
-                fps_sub = [
-                    fp for fp in (_morgan_fp(s) for s in substance) if fp is not None
-                ]
-                if not fps_sub:
-                    return 0.0
-                if schema.select_by == "similarity":
-                    fps_ref = ref_fps
-                    if not fps_ref:
-                        return 0.0
-                else:  # diversity — MaxMin: score = 1 - nearest-neighbour Tanimoto
-                    fps_ref = [
-                        fp
-                        for fp in (_morgan_fp(s) for s in selected_smiles)
-                        if fp is not None
-                    ]
-                    if not fps_ref:
-                        return 1.0
-                nn_sim = max(
-                    DataStructs.TanimotoSimilarity(fp, r)
-                    for fp in fps_sub
-                    for r in fps_ref
-                )
-                return nn_sim if schema.select_by == "similarity" else 1.0 - nn_sim
-
-            all_candidates: set = set().union(*type_candidates.values())
-            coverage_map = {
-                sub: [a for a, cands in type_candidates.items() if sub in cands]
-                for sub in all_candidates
-            }
-
-            for add_type in schema.additional_property_types:
-                if gap[add_type] <= 0:
-                    continue
-                if schema.select_by == "similarity":
-                    # Scores are static; sort once and iterate.
-                    cands = sorted(
-                        [
-                            sub
-                            for sub in type_candidates[add_type]
-                            if sub not in selected_set
-                        ],
-                        key=lambda c: (-len(coverage_map[c]), -fp_score(c)),
-                    )
-                    for sub in cands:
-                        if gap[add_type] <= 0:
-                            break
-                        if sub in selected_set:
-                            continue
-                        for b in coverage_map[sub]:
-                            gap[b] = max(0, gap[b] - 1)
-                        selected_set.add(sub)
-                else:  # diversity — re-rank after each pick for correct MaxMin behaviour
-                    remaining = [
-                        sub
-                        for sub in type_candidates[add_type]
-                        if sub not in selected_set
-                    ]
-                    while gap[add_type] > 0 and remaining:
-                        best = max(
-                            remaining,
-                            key=lambda c: (-len(coverage_map[c]), fp_score(c)),
-                        )
-                        for b in coverage_map[best]:
-                            gap[b] = max(0, gap[b] - 1)
-                        selected_set.add(best)
-                        # best is a tuple of SMILES strings; update adds each
-                        # string individually to selected_smiles.
-                        selected_smiles.update(best)
-                        remaining = [s for s in remaining if s not in selected_set]
-
-        # ── Step 6: assemble result ───────────────────────────────────────────────
-        additional_substances = set().union(*type_overlap.values()) | selected_set
-
-        add_val_cols = [
-            next((h for h in data_frame.columns if h.startswith(f"{t} Value")), None)
-            for t in schema.additional_property_types
-        ]
-        add_val_cols = [c for c in add_val_cols if c is not None]
-
+        additional_substances = set().union(*type_overlap.values()) | selected
+        add_val_cols = cls._value_columns(data_frame, schema.additional_property_types)
         additional_rows = data_frame[
             substance_col.isin(additional_substances)
             & data_frame[add_val_cols].notna().any(axis=1)

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -1275,8 +1275,10 @@ class FilterByCoreAndAdditionalPropertyTypesSchema(CurationComponentSchema):
     )
     select_by: Literal["similarity", "diversity"] = Field(
         "similarity",
-        description="Gap-fill strategy: 'similarity' favours substances most similar "
-        "to the core set; 'diversity' favours dissimilar ones (MaxMin).",
+        description="Gap-fill strategy: 'similarity' favours substances similar to the "
+        "under-represented core (the core substances that lack the additional type), "
+        "spreading picks to balance coverage; 'diversity' favours substances dissimilar "
+        "to everything kept so far (MaxMin).",
     )
 
     @model_validator(mode="after")
@@ -1298,7 +1300,11 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
     For each additional type, up to ``int(scale_factor * core_count)`` substances
     are kept: first the overlap with the core set, then gap-fill candidates chosen
     by the ``select_by`` strategy, with preference for substances that cover
-    multiple additional types at once.
+    multiple additional types at once. In ``"similarity"`` mode the gap-fill targets
+    the *under-represented* core — the core substances that lack that additional type
+    — and spreads picks across those substances, so each tends to gain a nearby
+    representative rather than the budget concentrating around whichever ones the
+    candidate pool happens to sit densest around.
 
     This acts very similarly to the FilterByPropertyTypes component when ``scale_factor``
     is 0 for all additional types, but with the added guarantee that all core substances
@@ -1322,82 +1328,169 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
         )
 
     @classmethod
-    def _gap_fill(cls, schema, s_core, type_candidates, gap) -> set:
+    def _gap_fill(cls, schema, s_core, type_overlap, type_candidates, gap) -> dict:
         """Greedily pick candidate substances to fill ``gap`` per additional type.
 
-        Candidates covering several additional types at once are preferred; ties
-        are broken by the ``select_by`` strategy (most 'similarity' to, or most
-        'diversity' from, the core set), then by the substance tuple so the
-        selection is deterministic. ``gap`` is mutated in place. Returns the set
-        of selected substances.
+        Candidates covering several additional types at once are preferred. The
+        per-type tie-break depends on ``select_by``:
+
+        * ``"diversity"`` — MaxMin against everything kept so far (the core set
+          plus prior picks), favouring substances dissimilar to it.
+        * ``"similarity"`` — favour substances similar to the *under-represented*
+          core: the core substances that lack data for this additional type. As
+          each pick is made, the under-represented core substance it best
+          represents is dropped from the reference, so subsequent picks spread to
+          the still-uncovered under-represented core substances instead of piling
+          onto one already covered. Once every member has been covered the reference
+          refills, allowing balanced further rounds.
+
+        A pick is charged only to the types it covers that still have budget
+        (``gap > 0``), so a multi-type candidate taken for one type never drags in
+        rows for a type that is already satisfied or was never to be gap-filled
+        (``scale_factor`` 0). Ties are finally broken by the substance tuple so
+        selection is deterministic. ``gap`` is mutated in place. Returns a mapping
+        of each additional type to the set of substances chosen to fill its gap
+        (the always-kept core overlap is not included).
         """
         if not any(g > 0 for g in gap.values()):
-            return set()
+            return {a: set() for a in schema.additional_property_types}
 
         from rdkit import DataStructs
 
-        # Reference fingerprints: the core set; in diversity mode each pick is
-        # added so the MaxMin score reflects everything kept so far.
-        ref_smiles = {smi for sub in s_core for smi in sub}
-        ref_fps = [fp for fp in map(_morgan_fp, ref_smiles) if fp is not None]
+        fp_cache: Dict[tuple, list] = {}
 
-        def fp_score(substance):
-            fps_sub = [fp for fp in map(_morgan_fp, substance) if fp is not None]
-            if not fps_sub:
+        def sub_fps(substance):
+            """Cached, ``None``-free Morgan fingerprints for *substance*."""
+            if substance not in fp_cache:
+                fp_cache[substance] = [
+                    fp for fp in map(_morgan_fp, substance) if fp is not None
+                ]
+            return fp_cache[substance]
+
+        def sub_sim(fps_a, fps_b):
+            """Nearest-neighbour Tanimoto between two substances' fingerprints."""
+            if not fps_a or not fps_b:
                 return 0.0
-            if not ref_fps:
-                return 0.0 if schema.select_by == "similarity" else 1.0
-            nn_sim = max(
-                DataStructs.TanimotoSimilarity(fp, ref)
-                for fp in fps_sub
-                for ref in ref_fps
+            return max(
+                DataStructs.TanimotoSimilarity(x, y) for x in fps_a for y in fps_b
             )
-            return nn_sim if schema.select_by == "similarity" else 1.0 - nn_sim
 
+        # Which additional types each candidate covers (computed once). Covering
+        # more still-unfilled types at once is the primary ranking key, so one pick
+        # fills several gaps.
         coverage_map = {
             sub: [a for a, cands in type_candidates.items() if sub in cands]
             for sub in set().union(*type_candidates.values())
         }
-        # Similarity scores are static (the reference set is fixed), so compute
-        # them once; diversity scores change after every pick.
-        static_score = (
-            {sub: fp_score(sub) for sub in coverage_map}
-            if schema.select_by == "similarity"
-            else None
-        )
 
-        def rank(substance):
-            score = (
-                static_score[substance]
-                if static_score is not None
-                else fp_score(substance)
-            )
-            return (len(coverage_map[substance]), score, substance)
-
+        # Global dedup set (a substance is picked at most once) plus the per-type
+        # record of which substances were charged to each type's gap — the latter
+        # drives the final row masking in ``_apply``.
         selected: set = set()
+        selected_by_type = {a: set() for a in schema.additional_property_types}
+
+        def active_coverage(substance):
+            """How many still-unfilled additional types this candidate covers."""
+            return sum(1 for c in coverage_map[substance] if gap[c] > 0)
 
         def take(substance):
-            for covered in coverage_map[substance]:
-                gap[covered] = max(0, gap[covered] - 1)
+            """Charge *substance* against every type it covers that still has
+            budget, recording it per type. Returns those types so the caller can
+            advance their spread."""
+            filled = [c for c in coverage_map[substance] if gap[c] > 0]
+            for c in filled:
+                gap[c] -= 1
+                selected_by_type[c].add(substance)
             selected.add(substance)
-            if schema.select_by == "diversity":
-                for smi in substance:
-                    if smi not in ref_smiles:
-                        ref_smiles.add(smi)
-                        fp = _morgan_fp(smi)
-                        if fp is not None:
-                            ref_fps.append(fp)
+            return filled
+
+        if schema.select_by == "diversity":
+            # MaxMin: stay far from everything kept so far. The reference starts as
+            # the whole core set and grows with each pick.
+            ref_smiles = {smi for sub in s_core for smi in sub}
+            ref_fps = [fp for fp in map(_morgan_fp, ref_smiles) if fp is not None]
+
+            def rank(substance):
+                fps_sub = sub_fps(substance)
+                if not fps_sub:
+                    score = 0.0  # unparseable candidate: treat as least diverse
+                elif not ref_fps:
+                    score = 1.0
+                else:
+                    score = 1.0 - sub_sim(fps_sub, ref_fps)
+                return (active_coverage(substance), score, substance)
+
+            for add_type in schema.additional_property_types:
+                remaining = [
+                    sub for sub in type_candidates[add_type] if sub not in selected
+                ]
+                while gap[add_type] > 0 and remaining:
+                    best = max(remaining, key=rank)
+                    take(best)
+                    remaining.remove(best)
+                    for smi in best:
+                        if smi not in ref_smiles:
+                            ref_smiles.add(smi)
+                            fp = _morgan_fp(smi)
+                            if fp is not None:
+                                ref_fps.append(fp)
+            return selected_by_type
+
+        # select_by == "similarity": target the under-represented core per type.
+        # Each additional type keeps its own reference — the core substances that
+        # still lack it (falling back to the whole core if every core substance
+        # already has it). The references are shared across the whole fill rather
+        # than rebuilt per loop, so a multi-type candidate picked while filling one
+        # type also advances the spread of the others it covers.
+        type_under = {
+            a: (sorted(s_core - type_overlap[a]) or sorted(s_core))
+            for a in schema.additional_property_types
+        }
+        type_ref = {a: list(under) for a, under in type_under.items()}
+
+        def credit(substance, filled):
+            """For each type in *filled* (the types *substance* was charged to),
+            mark the one under-represented core substance it best represents as
+            covered: drop it from that type's reference (refilling once the
+            reference is exhausted). Skip a type when the pick resembles nothing in
+            its reference (e.g. an unparseable candidate, or a cross-fill dissimilar
+            to that type's core) — there is no real coverage to credit.
+            """
+            fps_sub = sub_fps(substance)
+            for covered_type in filled:
+                ref = type_ref[covered_type]
+                if not ref:
+                    continue
+                best_sim, core_sub = max(
+                    (sub_sim(fps_sub, sub_fps(cs)), cs) for cs in ref
+                )
+                if best_sim > 0.0:
+                    ref.remove(core_sub)
+                    if not ref:  # all covered → refill for a balanced next round
+                        type_ref[covered_type] = list(type_under[covered_type])
 
         for add_type in schema.additional_property_types:
             remaining = [
                 sub for sub in type_candidates[add_type] if sub not in selected
             ]
             while gap[add_type] > 0 and remaining:
-                best = max(remaining, key=rank)
-                take(best)
-                remaining.remove(best)
+                flat_ref_fps = [fp for cs in type_ref[add_type] for fp in sub_fps(cs)]
 
-        return selected
+                # Prefer covering more still-unfilled types, then nearest-neighbour
+                # similarity to this type's (shrinking) reference, then the substance
+                # tuple for determinism.
+                best = max(
+                    remaining,
+                    key=lambda sub, _ref=flat_ref_fps: (
+                        active_coverage(sub),
+                        sub_sim(sub_fps(sub), _ref),
+                        sub,
+                    ),
+                )
+                remaining.remove(best)
+                credit(best, take(best))
+
+        return selected_by_type
 
     @classmethod
     def _apply(
@@ -1465,21 +1558,22 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
         for a, overlap in type_overlap.items():
             target = int(schema.additional_property_types[a].scale_factor * len(s_core))
             gap[a] = max(0, target - len(overlap))
-        selected = cls._gap_fill(schema, s_core, type_candidates, gap)
+        selected_by_type = cls._gap_fill(
+            schema, s_core, type_overlap, type_candidates, gap
+        )
 
-        # Mask rows per additional type so that a substance kept for one type
-        # does not drag along its rows for another type whose n_components
-        # filter excludes it.
+        # Mask rows per additional type. A type keeps its core overlap plus exactly
+        # the candidates charged to its gap, so a substance kept for one type does
+        # not drag along its rows for another type that excludes it (whether by an
+        # n_components filter or by having no remaining budget).
         additional_mask = pandas.Series(False, index=data_frame.index)
         for add_type in schema.additional_property_types:
             val_col = cls._value_column(data_frame, add_type)
             if val_col is None:
                 continue
-            type_substances = type_overlap[add_type] | (
-                selected & type_candidates[add_type]
-            )
+            keep = type_overlap[add_type] | selected_by_type[add_type]
             additional_mask |= (
-                substance_col.isin(type_substances) & data_frame[val_col].notna()
+                substance_col.isin(keep) & data_frame[val_col].notna()
             )
 
         additional_rows = data_frame[

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -1296,11 +1296,7 @@ class _GapFiller:
     """Greedy gap-fill selection for :class:`FilterByCoreAndAdditionalPropertyTypes`.
 
     Picks candidate substances to fill the per-type ``gap`` left once each
-    additional type's core overlap has been retained. The selection loop carries
-    a fair amount of mutable bookkeeping — a fingerprint cache, the per-type
-    budgets, the set of picks so far, and the shrinking similarity references — so
-    it lives on an instance: each step is a small, named method rather than a
-    closure over shared local state.
+    additional type's core overlap has been retained.
 
     Candidates covering several still-unfilled additional types at once are always
     preferred (one pick fills several gaps). The per-type tie-break then depends
@@ -1326,9 +1322,6 @@ class _GapFiller:
     """
 
     def __init__(self, schema, s_core, type_overlap, type_candidates, gap):
-        from rdkit import DataStructs
-
-        self._tanimoto = DataStructs.TanimotoSimilarity
         self.schema = schema
         self.s_core = s_core
         self.type_overlap = type_overlap
@@ -1374,9 +1367,13 @@ class _GapFiller:
 
     def _sub_sim(self, fps_a, fps_b):
         """Nearest-neighbour Tanimoto between two substances' fingerprints."""
+        from rdkit import DataStructs
+
         if not fps_a or not fps_b:
             return 0.0
-        return max(self._tanimoto(x, y) for x in fps_a for y in fps_b)
+        return max(
+            DataStructs.TanimotoSimilarity(x, y) for x in fps_a for y in fps_b
+        )
 
     # -- shared bookkeeping --------------------------------------------------
 
@@ -1457,21 +1454,22 @@ class _GapFiller:
             while self.gap[add_type] > 0 and remaining:
                 # Reference fingerprints for this type's current (shrinking)
                 # under-represented core, computed once per pick.
-                ref_fps = [
+                self._ref_fps = [
                     fp for cs in self._type_ref[add_type] for fp in self._sub_fps(cs)
                 ]
-                # Prefer covering more still-unfilled types, then similarity to
-                # this reference, then the substance tuple for determinism.
-                best = max(
-                    remaining,
-                    key=lambda sub: (
-                        self._active_coverage(sub),
-                        self._sub_sim(self._sub_fps(sub), ref_fps),
-                        sub,
-                    ),
-                )
+                best = max(remaining, key=self._similarity_rank)
                 remaining.remove(best)
                 self._credit(best, self._take(best))
+
+    def _similarity_rank(self, substance):
+        """Rank key: (#types covered, similarity to the under-represented core,
+        tuple). Prefers covering more still-unfilled types, then resemblance to the
+        current reference, then the substance tuple for determinism."""
+        return (
+            self._active_coverage(substance),
+            self._sub_sim(self._sub_fps(substance), self._ref_fps),
+            substance,
+        )
 
     def _credit(self, substance, filled):
         """For each type in *filled* (the types *substance* was charged to), mark

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -1245,7 +1245,8 @@ class FilterByCoreAndAdditionalPropertyTypesSchema(CurationComponentSchema):
         1.0,
         ge=0.0,
         description="Ratio of additional to core substances. 0 means no additional "
-        "data are retained.",
+        "data are retained, including additional-type rows for substances that are "
+        "already in the core set.",
     )
     select_by: Literal["similarity", "diversity"] = Field(
         "similarity",
@@ -1426,6 +1427,8 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
                         for b in coverage_map[best]:
                             gap[b] = max(0, gap[b] - 1)
                         selected_set.add(best)
+                        # best is a tuple of SMILES strings; update adds each
+                        # string individually to selected_smiles.
                         selected_smiles.update(best)
                         remaining = [s for s in remaining if s not in selected_set]
 
@@ -1441,6 +1444,7 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
         additional_rows = data_frame[
             substance_col.isin(additional_substances)
             & data_frame[add_val_cols].notna().any(axis=1)
+            & ~data_frame.index.isin(core_rows.index)
         ]
 
         return pandas.concat([core_rows, additional_rows], ignore_index=True)

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -9,6 +9,7 @@ import pandas
 from openff.units import unit
 from pydantic import (
     BaseModel,
+    ConfigDict,
     Field,
     PositiveFloat,
     PositiveInt,
@@ -39,7 +40,7 @@ logger = logging.getLogger(__name__)
 ComponentEnvironments = List[List[ChemicalEnvironment]]
 MoleFractionRange = Tuple[confloat(ge=0.0, le=1.0), confloat(ge=0.0, le=1.0)]
 # A mapping of property type -> optional list of allowed component counts
-# (``None`` means no ``n_components`` restriction).
+# (``None`` — or an empty list — means no ``n_components`` restriction).
 PropertyTypeFilter = Dict[constr(min_length=1), Optional[List[PositiveInt]]]
 
 
@@ -1229,6 +1230,8 @@ def _morgan_fp(smiles: str):
 class AdditionalPropertyTypeConfig(BaseModel):
     """Per-type configuration for an additional property type."""
 
+    model_config = ConfigDict(extra="forbid")
+
     scale_factor: float = Field(
         1.0,
         ge=0.0,
@@ -1240,7 +1243,8 @@ class AdditionalPropertyTypeConfig(BaseModel):
     n_components: Optional[List[PositiveInt]] = Field(
         None,
         description="If set, only substances with this many components qualify "
-        "for this additional type.",
+        "for this additional type. An empty list is treated the same as None: "
+        "no n_components restriction.",
     )
 
 
@@ -1254,7 +1258,8 @@ class FilterByCoreAndAdditionalPropertyTypesSchema(CurationComponentSchema):
         min_length=1,
         description="Property types that define the core substance set. A substance "
         "must have data for ALL listed types to be included in the core set. "
-        "Dict values are optional n_components filters; use None for no filter.",
+        "Dict values are optional n_components filters; None (or an empty list) "
+        "means no filter.",
     )
     additional_property_types: Dict[constr(min_length=1), AdditionalPropertyTypeConfig] = Field(
         ...,
@@ -1304,61 +1309,35 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
         )
 
     @classmethod
-    def _value_columns(cls, data_frame: pandas.DataFrame, property_types) -> List[str]:
-        """The value columns present for *property_types* (missing types dropped)."""
-        columns = (cls._value_column(data_frame, t) for t in property_types)
-        return [column for column in columns if column is not None]
-
-    @classmethod
-    def _type_substances(
-        cls,
-        data_frame: pandas.DataFrame,
-        property_type: str,
-        n_components_filter: Optional[List[int]],
-    ):
-        val_col = cls._value_column(data_frame, property_type)
-        if val_col is None:
-            return set()
-        rows = data_frame[data_frame[val_col].notna()]
-        if n_components_filter:
-            rows = rows[rows["N Components"].isin(n_components_filter)]
-        return data_frame_to_substances(rows)
-
-    @classmethod
     def _gap_fill(cls, schema, s_core, type_candidates, gap) -> set:
         """Greedily pick candidate substances to fill ``gap`` per additional type.
 
         Candidates covering several additional types at once are preferred; ties
         are broken by the ``select_by`` strategy (most 'similarity' to, or most
-        'diversity' from, the core set). ``gap`` is mutated in place. Returns the
-        set of selected substances.
+        'diversity' from, the core set), then by the substance tuple so the
+        selection is deterministic. ``gap`` is mutated in place. Returns the set
+        of selected substances.
         """
         if not any(g > 0 for g in gap.values()):
             return set()
 
         from rdkit import DataStructs
 
-        s_core_smiles = frozenset(smi for sub in s_core for smi in sub)
-        ref_fps = [fp for fp in map(_morgan_fp, s_core_smiles) if fp is not None]
-        # For diversity the reference set grows as substances are selected.
-        selected_smiles = set(s_core_smiles)
+        # Reference fingerprints: the core set; in diversity mode each pick is
+        # added so the MaxMin score reflects everything kept so far.
+        ref_smiles = {smi for sub in s_core for smi in sub}
+        ref_fps = [fp for fp in map(_morgan_fp, ref_smiles) if fp is not None]
 
         def fp_score(substance):
             fps_sub = [fp for fp in map(_morgan_fp, substance) if fp is not None]
             if not fps_sub:
                 return 0.0
-            if schema.select_by == "similarity":
-                fps_ref = ref_fps
-            else:  # diversity — MaxMin: score = 1 - nearest-neighbour Tanimoto
-                fps_ref = [
-                    fp for fp in map(_morgan_fp, selected_smiles) if fp is not None
-                ]
-            if not fps_ref:
+            if not ref_fps:
                 return 0.0 if schema.select_by == "similarity" else 1.0
             nn_sim = max(
                 DataStructs.TanimotoSimilarity(fp, ref)
                 for fp in fps_sub
-                for ref in fps_ref
+                for ref in ref_fps
             )
             return nn_sim if schema.select_by == "similarity" else 1.0 - nn_sim
 
@@ -1366,6 +1345,21 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
             sub: [a for a, cands in type_candidates.items() if sub in cands]
             for sub in set().union(*type_candidates.values())
         }
+        # Similarity scores are static (the reference set is fixed), so compute
+        # them once; diversity scores change after every pick.
+        static_score = (
+            {sub: fp_score(sub) for sub in coverage_map}
+            if schema.select_by == "similarity"
+            else None
+        )
+
+        def rank(substance):
+            score = (
+                static_score[substance]
+                if static_score is not None
+                else fp_score(substance)
+            )
+            return (len(coverage_map[substance]), score, substance)
 
         selected: set = set()
 
@@ -1373,30 +1367,22 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
             for covered in coverage_map[substance]:
                 gap[covered] = max(0, gap[covered] - 1)
             selected.add(substance)
-            selected_smiles.update(substance)
+            if schema.select_by == "diversity":
+                for smi in substance:
+                    if smi not in ref_smiles:
+                        ref_smiles.add(smi)
+                        fp = _morgan_fp(smi)
+                        if fp is not None:
+                            ref_fps.append(fp)
 
         for add_type in schema.additional_property_types:
             remaining = [
                 sub for sub in type_candidates[add_type] if sub not in selected
             ]
-            if schema.select_by == "similarity":
-                # Similarity scores are static, so rank candidates once.
-                score = {sub: fp_score(sub) for sub in remaining}
-                remaining.sort(key=lambda c: (-len(coverage_map[c]), -score[c]))
-                for sub in remaining:
-                    if gap[add_type] <= 0:
-                        break
-                    take(sub)
-            else:
-                # Diversity scores depend on prior picks, so re-rank each step.
-                while gap[add_type] > 0 and remaining:
-                    take(
-                        max(
-                            remaining,
-                            key=lambda c: (len(coverage_map[c]), fp_score(c)),
-                        )
-                    )
-                    remaining = [sub for sub in remaining if sub not in selected]
+            while gap[add_type] > 0 and remaining:
+                best = max(remaining, key=rank)
+                take(best)
+                remaining.remove(best)
 
         return selected
 
@@ -1407,25 +1393,46 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
         schema: FilterByCoreAndAdditionalPropertyTypesSchema,
         n_processes,  # unused
     ) -> pandas.DataFrame:
-        # Core substance set: intersection of the per-type substance sets.
-        s_core = None
-        for prop_type, nc_filter in schema.core_property_types.items():
-            subs = cls._type_substances(data_frame, prop_type, nc_filter)
-            s_core = subs if s_core is None else s_core & subs
-        if not s_core:
-            return data_frame.iloc[0:0]
+        if len(data_frame) == 0:
+            return data_frame
 
-        # Substance tuple per row, used by both the core and additional masks.
-        # The ordering (alphabetical) must match data_frame_to_substances so the
-        # `.isin` checks below line up with the sets built from it.
+        # Substance tuple per row (components alphabetical, the same convention
+        # as data_frame_to_substances) — the single source of substance identity
+        # for every set and mask below.
         def _sub_tuple(row):
             n = int(row["N Components"])
             return tuple(sorted(row[f"Component {i + 1}"] for i in range(n)))
 
         substance_col = data_frame.apply(_sub_tuple, axis=1)
 
+        def type_substances(property_type, n_components_filter):
+            """Substances with data for *property_type*, optionally restricted
+            to the allowed component counts."""
+            val_col = cls._value_column(data_frame, property_type)
+            if val_col is None:
+                return set()
+            mask = data_frame[val_col].notna()
+            if n_components_filter:
+                mask &= data_frame["N Components"].isin(n_components_filter)
+            return set(substance_col[mask])
+
+        # Core substance set: intersection of the per-type substance sets.
+        s_core = set.intersection(
+            *(
+                type_substances(prop_type, nc_filter)
+                for prop_type, nc_filter in schema.core_property_types.items()
+            )
+        )
+        if not s_core:
+            return data_frame.iloc[0:0]
+
         # Core rows: substance in S_core carrying at least one core-type value.
-        core_val_cols = cls._value_columns(data_frame, schema.core_property_types)
+        # Every core type has a value column here — a missing column would have
+        # emptied the intersection above.
+        core_val_cols = [
+            cls._value_column(data_frame, prop_type)
+            for prop_type in schema.core_property_types
+        ]
         core_rows = data_frame[
             substance_col.isin(s_core) & data_frame[core_val_cols].notna().any(axis=1)
         ]
@@ -1437,7 +1444,7 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
         type_overlap = {}
         type_candidates = {}
         for add_type, config in schema.additional_property_types.items():
-            s_a = cls._type_substances(data_frame, add_type, config.n_components)
+            s_a = type_substances(add_type, config.n_components)
             type_overlap[add_type] = s_core & s_a
             type_candidates[add_type] = s_a - s_core
 
@@ -1451,12 +1458,23 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
         }
         selected = cls._gap_fill(schema, s_core, type_candidates, gap)
 
-        additional_substances = set().union(*type_overlap.values()) | selected
-        add_val_cols = cls._value_columns(data_frame, schema.additional_property_types)
+        # Mask rows per additional type so that a substance kept for one type
+        # does not drag along its rows for another type whose n_components
+        # filter excludes it.
+        additional_mask = pandas.Series(False, index=data_frame.index)
+        for add_type in schema.additional_property_types:
+            val_col = cls._value_column(data_frame, add_type)
+            if val_col is None:
+                continue
+            type_substances = type_overlap[add_type] | (
+                selected & type_candidates[add_type]
+            )
+            additional_mask |= (
+                substance_col.isin(type_substances) & data_frame[val_col].notna()
+            )
+
         additional_rows = data_frame[
-            substance_col.isin(additional_substances)
-            & data_frame[add_val_cols].notna().any(axis=1)
-            & ~data_frame.index.isin(core_rows.index)
+            additional_mask & ~data_frame.index.isin(core_rows.index)
         ]
 
         return pandas.concat([core_rows, additional_rows], ignore_index=True)

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -1207,6 +1207,245 @@ class FilterByEnvironments(CurationComponent):
         return data_frame[data_frame.apply(filter_function, axis=1)]
 
 
+@functools.lru_cache(maxsize=4096)
+def _morgan_fp(smiles: str):
+    """Return the Morgan (radius-2, 2048-bit) fingerprint for *smiles*.
+
+    Returns ``None`` if the SMILES cannot be parsed by RDKit.
+    """
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        return None
+    return AllChem.GetMorganFingerprintAsBitVect(mol, radius=2, nBits=2048)
+
+
+class FilterByCoreAndAdditionalPropertyTypesSchema(CurationComponentSchema):
+    type: Literal[
+        "FilterByCoreAndAdditionalPropertyTypes"
+    ] = "FilterByCoreAndAdditionalPropertyTypes"
+
+    core_property_types: Dict[constr(min_length=1), Optional[List[PositiveInt]]] = Field(
+        ...,
+        min_length=1,
+        description="Property types that define the core substance set. A substance "
+        "must have data for ALL listed types to be included in the core set. "
+        "Dict values are optional n_components filters; use None for no filter.",
+    )
+    additional_property_types: Dict[constr(min_length=1), Optional[List[PositiveInt]]] = Field(
+        ...,
+        min_length=1,
+        description="Property types for which additional data are retained. For each "
+        "type, up to int(scale_factor * core_count) substance rows are kept. "
+        "Dict values are optional n_components filters; use None for no filter.",
+    )
+    scale_factor: float = Field(
+        1.0,
+        ge=0.0,
+        description="Ratio of additional to core substances. 0 means no additional "
+        "data are retained.",
+    )
+    select_by: Literal["similarity", "diversity"] = Field(
+        "similarity",
+        description="Gap-fill strategy: 'similarity' favours substances most similar "
+        "to the core set; 'diversity' favours dissimilar ones (MaxMin).",
+    )
+
+    @model_validator(mode="after")
+    def _validate_disjoint(self):
+        overlap = set(self.core_property_types) & set(self.additional_property_types)
+        if overlap:
+            raise ValueError(
+                "core_property_types and additional_property_types share keys: "
+                f"{overlap}"
+            )
+        return self
+
+
+class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
+    """Retain data for core property types and supplement with additional types.
+
+    The *core substance set* is the intersection of substance sets across all
+    ``core_property_types`` (each optionally constrained by ``n_components``).
+    For each additional type, up to ``int(scale_factor * core_count)`` substances
+    are kept: first the overlap with the core set, then gap-fill candidates chosen
+    by the ``select_by`` strategy, with preference for substances that cover
+    multiple additional types at once.
+    """
+
+    @classmethod
+    def _type_substances(
+        cls,
+        data_frame: pandas.DataFrame,
+        property_type: str,
+        n_components_filter: Optional[List[int]],
+    ):
+        val_col = next(
+            (h for h in data_frame.columns if h.startswith(f"{property_type} Value")),
+            None,
+        )
+        if val_col is None:
+            return set()
+        rows = data_frame[data_frame[val_col].notna()]
+        if n_components_filter:
+            rows = rows[rows["N Components"].isin(n_components_filter)]
+        return data_frame_to_substances(rows)
+
+    @classmethod
+    def _apply(
+        cls,
+        data_frame: pandas.DataFrame,
+        schema: FilterByCoreAndAdditionalPropertyTypesSchema,
+        n_processes,  # unused; filtering is CPU-light
+    ) -> pandas.DataFrame:
+        # ── Step 1: S_core = intersection of per-type substance sets ──────────────
+        s_core = None
+        for prop_type, nc_filter in schema.core_property_types.items():
+            subs = cls._type_substances(data_frame, prop_type, nc_filter)
+            s_core = subs if s_core is None else s_core & subs
+        if not s_core:
+            return data_frame.iloc[0:0]
+
+        core_count = len(s_core)
+
+        # ── Step 2: pre-compute substance tuples (used in both row masks) ─────────
+        def _sub_tuple(row):
+            n = int(row["N Components"])
+            return tuple(sorted(row[f"Component {i + 1}"] for i in range(n)))
+
+        substance_col = data_frame.apply(_sub_tuple, axis=1)
+
+        # ── Step 3: core rows ─────────────────────────────────────────────────────
+        # Keep rows whose substance is in S_core and that carry at least one
+        # core-type value.  Additional-type rows for core substances are only
+        # retained when scale_factor > 0 (assembled in Steps 5–6 via type_overlap).
+        core_val_cols = [
+            next((h for h in data_frame.columns if h.startswith(f"{t} Value")), None)
+            for t in schema.core_property_types
+        ]
+        core_val_cols = [c for c in core_val_cols if c is not None]
+
+        core_rows = data_frame[
+            substance_col.isin(s_core) & data_frame[core_val_cols].notna().any(axis=1)
+        ]
+
+        # ── Step 4: target and per-type substance sets ────────────────────────────
+        target = int(schema.scale_factor * core_count)
+        if target == 0:
+            return core_rows
+
+        type_overlap = {}  # add_type -> S_core ∩ S_a
+        type_candidates = {}  # add_type -> S_a \ S_core
+        for add_type, nc_filter in schema.additional_property_types.items():
+            s_a = cls._type_substances(data_frame, add_type, nc_filter)
+            type_overlap[add_type] = s_core & s_a
+            type_candidates[add_type] = s_a - s_core
+
+        gap = {
+            a: max(0, target - len(type_overlap[a]))
+            for a in schema.additional_property_types
+        }
+
+        # ── Step 5: greedy gap-fill ───────────────────────────────────────────────
+        selected_set: set = set()
+        if any(g > 0 for g in gap.values()):
+            from rdkit import DataStructs
+
+            s_core_smiles = frozenset(smi for sub in s_core for smi in sub)
+            ref_fps = [
+                fp for fp in (_morgan_fp(s) for s in s_core_smiles) if fp is not None
+            ]
+            if schema.select_by == "diversity":
+                selected_smiles: set = set(s_core_smiles)
+
+            def fp_score(substance):
+                fps_sub = [
+                    fp for fp in (_morgan_fp(s) for s in substance) if fp is not None
+                ]
+                if not fps_sub:
+                    return 0.0
+                if schema.select_by == "similarity":
+                    fps_ref = ref_fps
+                    if not fps_ref:
+                        return 0.0
+                else:  # diversity — MaxMin: score = 1 - nearest-neighbour Tanimoto
+                    fps_ref = [
+                        fp
+                        for fp in (_morgan_fp(s) for s in selected_smiles)
+                        if fp is not None
+                    ]
+                    if not fps_ref:
+                        return 1.0
+                nn_sim = max(
+                    DataStructs.TanimotoSimilarity(fp, r)
+                    for fp in fps_sub
+                    for r in fps_ref
+                )
+                return nn_sim if schema.select_by == "similarity" else 1.0 - nn_sim
+
+            all_candidates: set = set().union(*type_candidates.values())
+            coverage_map = {
+                sub: [a for a, cands in type_candidates.items() if sub in cands]
+                for sub in all_candidates
+            }
+
+            for add_type in schema.additional_property_types:
+                if gap[add_type] <= 0:
+                    continue
+                if schema.select_by == "similarity":
+                    # Scores are static; sort once and iterate.
+                    cands = sorted(
+                        [
+                            sub
+                            for sub in type_candidates[add_type]
+                            if sub not in selected_set
+                        ],
+                        key=lambda c: (-len(coverage_map[c]), -fp_score(c)),
+                    )
+                    for sub in cands:
+                        if gap[add_type] <= 0:
+                            break
+                        if sub in selected_set:
+                            continue
+                        for b in coverage_map[sub]:
+                            gap[b] = max(0, gap[b] - 1)
+                        selected_set.add(sub)
+                else:  # diversity — re-rank after each pick for correct MaxMin behaviour
+                    remaining = [
+                        sub
+                        for sub in type_candidates[add_type]
+                        if sub not in selected_set
+                    ]
+                    while gap[add_type] > 0 and remaining:
+                        best = max(
+                            remaining,
+                            key=lambda c: (-len(coverage_map[c]), fp_score(c)),
+                        )
+                        for b in coverage_map[best]:
+                            gap[b] = max(0, gap[b] - 1)
+                        selected_set.add(best)
+                        selected_smiles.update(best)
+                        remaining = [s for s in remaining if s not in selected_set]
+
+        # ── Step 6: assemble result ───────────────────────────────────────────────
+        additional_substances = set().union(*type_overlap.values()) | selected_set
+
+        add_val_cols = [
+            next((h for h in data_frame.columns if h.startswith(f"{t} Value")), None)
+            for t in schema.additional_property_types
+        ]
+        add_val_cols = [c for c in add_val_cols if c is not None]
+
+        additional_rows = data_frame[
+            substance_col.isin(additional_substances)
+            & data_frame[add_val_cols].notna().any(axis=1)
+        ]
+
+        return pandas.concat([core_rows, additional_rows], ignore_index=True)
+
+
 FilterComponentSchema = Union[
     FilterDuplicatesSchema,
     FilterByTemperatureSchema,
@@ -1223,4 +1462,5 @@ FilterComponentSchema = Union[
     FilterByNComponentsSchema,
     FilterBySubstancesSchema,
     FilterByEnvironmentsSchema,
+    FilterByCoreAndAdditionalPropertyTypesSchema,
 ]

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -1292,6 +1292,209 @@ class FilterByCoreAndAdditionalPropertyTypesSchema(CurationComponentSchema):
         return self
 
 
+class _GapFiller:
+    """Greedy gap-fill selection for :class:`FilterByCoreAndAdditionalPropertyTypes`.
+
+    Picks candidate substances to fill the per-type ``gap`` left once each
+    additional type's core overlap has been retained. The selection loop carries
+    a fair amount of mutable bookkeeping — a fingerprint cache, the per-type
+    budgets, the set of picks so far, and the shrinking similarity references — so
+    it lives on an instance: each step is a small, named method rather than a
+    closure over shared local state.
+
+    Candidates covering several still-unfilled additional types at once are always
+    preferred (one pick fills several gaps). The per-type tie-break then depends
+    on ``schema.select_by``:
+
+    * ``"diversity"`` — MaxMin against everything kept so far (the core set plus
+      prior picks), favouring substances dissimilar to it.
+    * ``"similarity"`` — favour substances similar to the *under-represented*
+      core: the core substances that lack data for this additional type. As each
+      pick is made, the under-represented core substance it best represents is
+      dropped from the reference, so subsequent picks spread to the still-
+      uncovered core substances instead of piling onto one already covered. Once
+      every member has been covered the reference refills, allowing balanced
+      further rounds.
+
+    A pick is charged only to the types it covers that still have budget
+    (``gap > 0``), so a multi-type candidate taken for one type never drags in
+    rows for a type that is already satisfied or was never to be gap-filled
+    (``scale_factor`` 0). Ties are finally broken by the substance tuple, so
+    selection is deterministic. ``gap`` is mutated in place. :meth:`fill` returns
+    a mapping of each additional type to the set of substances chosen to fill its
+    gap (the always-kept core overlap is not included).
+    """
+
+    def __init__(self, schema, s_core, type_overlap, type_candidates, gap):
+        from rdkit import DataStructs
+
+        self._tanimoto = DataStructs.TanimotoSimilarity
+        self.schema = schema
+        self.s_core = s_core
+        self.type_overlap = type_overlap
+        self.type_candidates = type_candidates
+        self.gap = gap
+
+        # Memoised, None-free Morgan fingerprints, keyed by substance tuple.
+        self._fp_cache: Dict[tuple, list] = {}
+
+        # Which additional types each candidate covers (computed once). Covering
+        # more still-unfilled types at once is the primary ranking key, so one
+        # pick fills several gaps.
+        self.coverage_map = {
+            sub: [a for a, cands in type_candidates.items() if sub in cands]
+            for sub in set().union(*type_candidates.values())
+        }
+
+        # Global dedup set (each substance picked at most once) plus the per-type
+        # record of which substances were charged to each type's gap — the latter
+        # drives the final row masking in ``_apply``.
+        self.selected: set = set()
+        self.selected_by_type = {a: set() for a in schema.additional_property_types}
+
+    # -- entry point ---------------------------------------------------------
+
+    def fill(self) -> dict:
+        """Run the configured ``select_by`` strategy; return ``selected_by_type``."""
+        if self.schema.select_by == "diversity":
+            self._fill_diversity()
+        else:
+            self._fill_similarity()
+        return self.selected_by_type
+
+    # -- fingerprint helpers -------------------------------------------------
+
+    def _sub_fps(self, substance):
+        """Cached, ``None``-free Morgan fingerprints for *substance*."""
+        if substance not in self._fp_cache:
+            self._fp_cache[substance] = [
+                fp for fp in map(_morgan_fp, substance) if fp is not None
+            ]
+        return self._fp_cache[substance]
+
+    def _sub_sim(self, fps_a, fps_b):
+        """Nearest-neighbour Tanimoto between two substances' fingerprints."""
+        if not fps_a or not fps_b:
+            return 0.0
+        return max(self._tanimoto(x, y) for x in fps_a for y in fps_b)
+
+    # -- shared bookkeeping --------------------------------------------------
+
+    def _active_coverage(self, substance):
+        """How many still-unfilled additional types this candidate covers."""
+        return sum(1 for c in self.coverage_map[substance] if self.gap[c] > 0)
+
+    def _take(self, substance):
+        """Charge *substance* against every type it covers that still has budget,
+        recording it per type. Returns those types so the caller can advance their
+        spread."""
+        filled = [c for c in self.coverage_map[substance] if self.gap[c] > 0]
+        for c in filled:
+            self.gap[c] -= 1
+            self.selected_by_type[c].add(substance)
+        self.selected.add(substance)
+        return filled
+
+    def _remaining(self, add_type):
+        """Not-yet-picked candidates carrying *add_type* data."""
+        return [s for s in self.type_candidates[add_type] if s not in self.selected]
+
+    # -- diversity strategy --------------------------------------------------
+
+    def _fill_diversity(self):
+        # MaxMin: stay far from everything kept so far. The reference starts as
+        # the whole core set and grows with each pick.
+        self._ref_smiles = {smi for sub in self.s_core for smi in sub}
+        self._ref_fps = [
+            fp for fp in map(_morgan_fp, self._ref_smiles) if fp is not None
+        ]
+
+        for add_type in self.schema.additional_property_types:
+            remaining = self._remaining(add_type)
+            while self.gap[add_type] > 0 and remaining:
+                best = max(remaining, key=self._diversity_rank)
+                self._take(best)
+                remaining.remove(best)
+                self._grow_diversity_reference(best)
+
+    def _diversity_rank(self, substance):
+        """Rank key: (#types covered, distance from the kept set, tuple)."""
+        fps_sub = self._sub_fps(substance)
+        if not fps_sub:
+            score = 0.0  # unparseable candidate: treat as least diverse
+        elif not self._ref_fps:
+            score = 1.0
+        else:
+            score = 1.0 - self._sub_sim(fps_sub, self._ref_fps)
+        return (self._active_coverage(substance), score, substance)
+
+    def _grow_diversity_reference(self, substance):
+        """Fold a freshly picked substance's fingerprints into the MaxMin reference."""
+        for smi in substance:
+            if smi not in self._ref_smiles:
+                self._ref_smiles.add(smi)
+                fp = _morgan_fp(smi)
+                if fp is not None:
+                    self._ref_fps.append(fp)
+
+    # -- similarity strategy -------------------------------------------------
+
+    def _fill_similarity(self):
+        # Each additional type targets its under-represented core — the core
+        # substances that still lack it (falling back to the whole core if every
+        # core substance already has it). The references are shared across the
+        # whole fill rather than rebuilt per loop, so a multi-type candidate
+        # picked while filling one type also advances the spread of the others it
+        # covers.
+        self._type_under = {
+            a: (sorted(self.s_core - self.type_overlap[a]) or sorted(self.s_core))
+            for a in self.schema.additional_property_types
+        }
+        self._type_ref = {a: list(under) for a, under in self._type_under.items()}
+
+        for add_type in self.schema.additional_property_types:
+            remaining = self._remaining(add_type)
+            while self.gap[add_type] > 0 and remaining:
+                # Reference fingerprints for this type's current (shrinking)
+                # under-represented core, computed once per pick.
+                ref_fps = [
+                    fp for cs in self._type_ref[add_type] for fp in self._sub_fps(cs)
+                ]
+                # Prefer covering more still-unfilled types, then similarity to
+                # this reference, then the substance tuple for determinism.
+                best = max(
+                    remaining,
+                    key=lambda sub: (
+                        self._active_coverage(sub),
+                        self._sub_sim(self._sub_fps(sub), ref_fps),
+                        sub,
+                    ),
+                )
+                remaining.remove(best)
+                self._credit(best, self._take(best))
+
+    def _credit(self, substance, filled):
+        """For each type in *filled* (the types *substance* was charged to), mark
+        the one under-represented core substance it best represents as covered:
+        drop it from that type's reference (refilling once the reference is
+        exhausted). Skip a type when the pick resembles nothing in its reference
+        (e.g. an unparseable candidate, or a cross-fill dissimilar to that type's
+        core) — there is no real coverage to credit.
+        """
+        fps_sub = self._sub_fps(substance)
+        for covered_type in filled:
+            ref = self._type_ref[covered_type]
+            if not ref:
+                continue
+            best_sim, core_sub = max(
+                (self._sub_sim(fps_sub, self._sub_fps(cs)), cs) for cs in ref
+            )
+            if best_sim > 0.0:
+                ref.remove(core_sub)
+                if not ref:  # all covered → refill for a balanced next round
+                    self._type_ref[covered_type] = list(self._type_under[covered_type])
+
+
 class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
     """Retain data for core property types and supplement with additional types.
 
@@ -1327,170 +1530,40 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
             None,
         )
 
+    @staticmethod
+    def _substance_tuple(row) -> tuple:
+        """Substance identity for a data-frame row: its components, sorted (the
+        same convention as ``data_frame_to_substances``)."""
+        n = int(row["N Components"])
+        return tuple(sorted(row[f"Component {i + 1}"] for i in range(n)))
+
+    @classmethod
+    def _type_substances(
+        cls, data_frame, substance_col, property_type, n_components_filter
+    ):
+        """Substances with data for *property_type*, optionally restricted to the
+        allowed component counts."""
+        val_col = cls._value_column(data_frame, property_type)
+        if val_col is None:
+            return set()
+        mask = data_frame[val_col].notna()
+        if n_components_filter:
+            mask &= data_frame["N Components"].isin(n_components_filter)
+        return set(substance_col[mask])
+
     @classmethod
     def _gap_fill(cls, schema, s_core, type_overlap, type_candidates, gap) -> dict:
         """Greedily pick candidate substances to fill ``gap`` per additional type.
 
-        Candidates covering several additional types at once are preferred. The
-        per-type tie-break depends on ``select_by``:
-
-        * ``"diversity"`` — MaxMin against everything kept so far (the core set
-          plus prior picks), favouring substances dissimilar to it.
-        * ``"similarity"`` — favour substances similar to the *under-represented*
-          core: the core substances that lack data for this additional type. As
-          each pick is made, the under-represented core substance it best
-          represents is dropped from the reference, so subsequent picks spread to
-          the still-uncovered under-represented core substances instead of piling
-          onto one already covered. Once every member has been covered the reference
-          refills, allowing balanced further rounds.
-
-        A pick is charged only to the types it covers that still have budget
-        (``gap > 0``), so a multi-type candidate taken for one type never drags in
-        rows for a type that is already satisfied or was never to be gap-filled
-        (``scale_factor`` 0). Ties are finally broken by the substance tuple so
-        selection is deterministic. ``gap`` is mutated in place. Returns a mapping
-        of each additional type to the set of substances chosen to fill its gap
-        (the always-kept core overlap is not included).
+        Thin wrapper around :class:`_GapFiller`; see that class for the selection
+        rules. Returns each additional type's chosen gap-fill substances (the
+        always-kept core overlap is not included).
         """
+        # Nothing to fill (every type is overlap-only or already satisfied):
+        # short-circuit before importing rdkit or building the selection machinery.
         if not any(g > 0 for g in gap.values()):
             return {a: set() for a in schema.additional_property_types}
-
-        from rdkit import DataStructs
-
-        fp_cache: Dict[tuple, list] = {}
-
-        def sub_fps(substance):
-            """Cached, ``None``-free Morgan fingerprints for *substance*."""
-            if substance not in fp_cache:
-                fp_cache[substance] = [
-                    fp for fp in map(_morgan_fp, substance) if fp is not None
-                ]
-            return fp_cache[substance]
-
-        def sub_sim(fps_a, fps_b):
-            """Nearest-neighbour Tanimoto between two substances' fingerprints."""
-            if not fps_a or not fps_b:
-                return 0.0
-            return max(
-                DataStructs.TanimotoSimilarity(x, y) for x in fps_a for y in fps_b
-            )
-
-        # Which additional types each candidate covers (computed once). Covering
-        # more still-unfilled types at once is the primary ranking key, so one pick
-        # fills several gaps.
-        coverage_map = {
-            sub: [a for a, cands in type_candidates.items() if sub in cands]
-            for sub in set().union(*type_candidates.values())
-        }
-
-        # Global dedup set (a substance is picked at most once) plus the per-type
-        # record of which substances were charged to each type's gap — the latter
-        # drives the final row masking in ``_apply``.
-        selected: set = set()
-        selected_by_type = {a: set() for a in schema.additional_property_types}
-
-        def active_coverage(substance):
-            """How many still-unfilled additional types this candidate covers."""
-            return sum(1 for c in coverage_map[substance] if gap[c] > 0)
-
-        def take(substance):
-            """Charge *substance* against every type it covers that still has
-            budget, recording it per type. Returns those types so the caller can
-            advance their spread."""
-            filled = [c for c in coverage_map[substance] if gap[c] > 0]
-            for c in filled:
-                gap[c] -= 1
-                selected_by_type[c].add(substance)
-            selected.add(substance)
-            return filled
-
-        if schema.select_by == "diversity":
-            # MaxMin: stay far from everything kept so far. The reference starts as
-            # the whole core set and grows with each pick.
-            ref_smiles = {smi for sub in s_core for smi in sub}
-            ref_fps = [fp for fp in map(_morgan_fp, ref_smiles) if fp is not None]
-
-            def rank(substance):
-                fps_sub = sub_fps(substance)
-                if not fps_sub:
-                    score = 0.0  # unparseable candidate: treat as least diverse
-                elif not ref_fps:
-                    score = 1.0
-                else:
-                    score = 1.0 - sub_sim(fps_sub, ref_fps)
-                return (active_coverage(substance), score, substance)
-
-            for add_type in schema.additional_property_types:
-                remaining = [
-                    sub for sub in type_candidates[add_type] if sub not in selected
-                ]
-                while gap[add_type] > 0 and remaining:
-                    best = max(remaining, key=rank)
-                    take(best)
-                    remaining.remove(best)
-                    for smi in best:
-                        if smi not in ref_smiles:
-                            ref_smiles.add(smi)
-                            fp = _morgan_fp(smi)
-                            if fp is not None:
-                                ref_fps.append(fp)
-            return selected_by_type
-
-        # select_by == "similarity": target the under-represented core per type.
-        # Each additional type keeps its own reference — the core substances that
-        # still lack it (falling back to the whole core if every core substance
-        # already has it). The references are shared across the whole fill rather
-        # than rebuilt per loop, so a multi-type candidate picked while filling one
-        # type also advances the spread of the others it covers.
-        type_under = {
-            a: (sorted(s_core - type_overlap[a]) or sorted(s_core))
-            for a in schema.additional_property_types
-        }
-        type_ref = {a: list(under) for a, under in type_under.items()}
-
-        def credit(substance, filled):
-            """For each type in *filled* (the types *substance* was charged to),
-            mark the one under-represented core substance it best represents as
-            covered: drop it from that type's reference (refilling once the
-            reference is exhausted). Skip a type when the pick resembles nothing in
-            its reference (e.g. an unparseable candidate, or a cross-fill dissimilar
-            to that type's core) — there is no real coverage to credit.
-            """
-            fps_sub = sub_fps(substance)
-            for covered_type in filled:
-                ref = type_ref[covered_type]
-                if not ref:
-                    continue
-                best_sim, core_sub = max(
-                    (sub_sim(fps_sub, sub_fps(cs)), cs) for cs in ref
-                )
-                if best_sim > 0.0:
-                    ref.remove(core_sub)
-                    if not ref:  # all covered → refill for a balanced next round
-                        type_ref[covered_type] = list(type_under[covered_type])
-
-        for add_type in schema.additional_property_types:
-            remaining = [
-                sub for sub in type_candidates[add_type] if sub not in selected
-            ]
-            while gap[add_type] > 0 and remaining:
-                flat_ref_fps = [fp for cs in type_ref[add_type] for fp in sub_fps(cs)]
-
-                # Prefer covering more still-unfilled types, then nearest-neighbour
-                # similarity to this type's (shrinking) reference, then the substance
-                # tuple for determinism.
-                best = max(
-                    remaining,
-                    key=lambda sub, _ref=flat_ref_fps: (
-                        active_coverage(sub),
-                        sub_sim(sub_fps(sub), _ref),
-                        sub,
-                    ),
-                )
-                remaining.remove(best)
-                credit(best, take(best))
-
-        return selected_by_type
+        return _GapFiller(schema, s_core, type_overlap, type_candidates, gap).fill()
 
     @classmethod
     def _apply(
@@ -1502,39 +1575,28 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
         if len(data_frame) == 0:
             return data_frame
 
-        # Substance tuple per row (components alphabetical, the same convention
-        # as data_frame_to_substances) — the single source of substance identity
-        # for every set and mask below.
-        def _sub_tuple(row):
-            n = int(row["N Components"])
-            return tuple(sorted(row[f"Component {i + 1}"] for i in range(n)))
+        # --- Substance identity ------------------------------------------------
+        # One substance tuple per row, the single source of substance identity for
+        # every set and mask below.
+        substance_col = data_frame.apply(cls._substance_tuple, axis=1)
 
-        substance_col = data_frame.apply(_sub_tuple, axis=1)
-
-        def type_substances(property_type, n_components_filter):
-            """Substances with data for *property_type*, optionally restricted
-            to the allowed component counts."""
-            val_col = cls._value_column(data_frame, property_type)
-            if val_col is None:
-                return set()
-            mask = data_frame[val_col].notna()
-            if n_components_filter:
-                mask &= data_frame["N Components"].isin(n_components_filter)
-            return set(substance_col[mask])
-
-        # Core substance set: intersection of the per-type substance sets.
+        # --- Core substance set ------------------------------------------------
+        # Intersection of the per-type substance sets: a substance must carry data
+        # for every core type (each optionally constrained by n_components) to
+        # qualify. No core substances → nothing to anchor on, return empty.
         s_core = set.intersection(
             *(
-                type_substances(prop_type, nc_filter)
+                cls._type_substances(data_frame, substance_col, prop_type, nc_filter)
                 for prop_type, nc_filter in schema.core_property_types.items()
             )
         )
         if not s_core:
             return data_frame.iloc[0:0]
 
-        # Core rows: substance in S_core carrying at least one core-type value.
-        # Every core type has a value column here — a missing column would have
-        # emptied the intersection above.
+        # --- Core rows ---------------------------------------------------------
+        # Rows whose substance is in S_core and which carry at least one core-type
+        # value. Every core type has a value column here — a missing column would
+        # have emptied the intersection above.
         core_val_cols = [
             cls._value_column(data_frame, prop_type)
             for prop_type in schema.core_property_types
@@ -1543,17 +1605,23 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
             substance_col.isin(s_core) & data_frame[core_val_cols].notna().any(axis=1)
         ]
 
-        # Per additional type, split into the core overlap (always kept) and the
-        # gap-fill candidates (substances outside the core set).
-        # The overlap is retained regardless of scale_factor; only gap-fill is
-        # suppressed when a type's target == 0.
+        # --- Overlap vs. candidates per additional type ------------------------
+        # Split each additional type's substances into the core overlap (always
+        # kept, regardless of scale_factor) and the gap-fill candidates (those
+        # outside the core set).
         type_overlap = {}
         type_candidates = {}
         for add_type, config in schema.additional_property_types.items():
-            s_a = type_substances(add_type, config.n_components)
+            s_a = cls._type_substances(
+                data_frame, substance_col, add_type, config.n_components
+            )
             type_overlap[add_type] = s_core & s_a
             type_candidates[add_type] = s_a - s_core
 
+        # --- Per-type gap and gap-fill selection -------------------------------
+        # Target int(scale_factor * core_count) substances per type; the gap is
+        # whatever the overlap does not already cover (so a type with target 0, or
+        # whose overlap meets the target, is gap-filled with nothing).
         gap = {}
         for a, overlap in type_overlap.items():
             target = int(schema.additional_property_types[a].scale_factor * len(s_core))
@@ -1562,10 +1630,11 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
             schema, s_core, type_overlap, type_candidates, gap
         )
 
-        # Mask rows per additional type. A type keeps its core overlap plus exactly
-        # the candidates charged to its gap, so a substance kept for one type does
-        # not drag along its rows for another type that excludes it (whether by an
-        # n_components filter or by having no remaining budget).
+        # --- Additional-type row mask ------------------------------------------
+        # Each type keeps its core overlap plus exactly the candidates charged to
+        # its gap, so a substance kept for one type does not drag along its rows
+        # for another type that excludes it (whether by an n_components filter or
+        # by having no remaining budget).
         additional_mask = pandas.Series(False, index=data_frame.index)
         for add_type in schema.additional_property_types:
             val_col = cls._value_column(data_frame, add_type)
@@ -1576,10 +1645,12 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
                 substance_col.isin(keep) & data_frame[val_col].notna()
             )
 
+        # --- Assemble ----------------------------------------------------------
+        # Additional rows exclude the core rows (kept separately) to avoid dupes,
+        # then concatenate the two with a fresh index.
         additional_rows = data_frame[
             additional_mask & ~data_frame.index.isin(core_rows.index)
         ]
-
         return pandas.concat([core_rows, additional_rows], ignore_index=True)
 
 

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -1393,7 +1393,7 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
                     take(
                         max(
                             remaining,
-                            key=lambda c: (-len(coverage_map[c]), fp_score(c)),
+                            key=lambda c: (len(coverage_map[c]), fp_score(c)),
                         )
                     )
                     remaining = [sub for sub in remaining if sub not in selected]

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -1269,9 +1269,7 @@ class FilterByCoreAndAdditionalPropertyTypesSchema(CurationComponentSchema):
         "Dict values are optional n_components filters; None (or an empty list) "
         "means no filter.",
     )
-    additional_property_types: Dict[
-        str, AdditionalPropertyTypeConfig
-    ] = Field(
+    additional_property_types: Dict[str, AdditionalPropertyTypeConfig] = Field(
         ...,
         min_length=1,
         description="Property types for which additional data are retained. Each "
@@ -1381,7 +1379,9 @@ class _GapFiller:
             ]
         return self._fp_cache[substance]
 
-    def _sub_sim(self, fps_a: "list[ExplicitBitVect]", fps_b: "list[ExplicitBitVect]") -> float:
+    def _sub_sim(
+        self, fps_a: "list[ExplicitBitVect]", fps_b: "list[ExplicitBitVect]"
+    ) -> float:
         """Optimal-assignment Tanimoto similarity between two substances."""
         from rdkit import DataStructs
 

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -45,8 +45,8 @@ logger = logging.getLogger(__name__)
 ComponentEnvironments = List[List[ChemicalEnvironment]]
 MoleFractionRange = Tuple[confloat(ge=0.0, le=1.0), confloat(ge=0.0, le=1.0)]
 # A mapping of property type -> optional list of allowed component counts
-# (``None`` — or an empty list — means no ``n_components`` restriction).
-PropertyTypeFilter = Dict[constr(min_length=1), Optional[List[PositiveInt]]]
+# (an empty list means no ``n_components`` restriction).
+PropertyTypeFilter = Dict[constr(min_length=1), List[PositiveInt]]
 
 
 class FilterDuplicatesSchema(CurationComponentSchema):

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -2,7 +2,10 @@ import functools
 import itertools
 import logging
 from collections import defaultdict
-from typing import Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+
+if TYPE_CHECKING:
+    from rdkit.DataStructs import ExplicitBitVect
 
 import numpy
 import pandas
@@ -1218,7 +1221,7 @@ class FilterByEnvironments(CurationComponent):
 
 
 @functools.lru_cache(maxsize=4096)
-def _morgan_fp(smiles: str):
+def _morgan_fp(smiles: str) -> "ExplicitBitVect":
     """Return the Morgan (radius-2, 2048-bit) fingerprint for *smiles*.
 
     Returns ``None`` if the SMILES cannot be parsed by RDKit.
@@ -1267,7 +1270,7 @@ class FilterByCoreAndAdditionalPropertyTypesSchema(CurationComponentSchema):
         "means no filter.",
     )
     additional_property_types: Dict[
-        constr(min_length=1), AdditionalPropertyTypeConfig
+        str, AdditionalPropertyTypeConfig
     ] = Field(
         ...,
         min_length=1,
@@ -1310,31 +1313,57 @@ class _GapFiller:
 
     ``gap`` is mutated in place. :meth:`fill` returns each additional type's chosen
     substances (the always-kept core overlap is not included).
+
+    Parameters
+    ----------
+    schema
+        The parent filter schema; supplies ``select_by``, ``additional_property_types``,
+        and per-type configuration.
+    s_core
+        Substances present in every core property type (the core set).
+        Each substance is a tuple of SMILES.
+    type_overlap
+        ``{additional_type: {substances in both core and that type}}``.
+        Each additional type is a string (class name),
+        each substance is a tuple of SMILES.
+    type_candidates
+        ``{additional_type: {non-core substances with data for that type}}``.
+        Each additional type is a string (class name),
+        each substance is a tuple of SMILES.
+    gap
+        ``{additional_type: remaining count to fill}``. Mutated in place as
+        substances are selected.
     """
 
-    def __init__(self, schema, s_core, type_overlap, type_candidates, gap):
+    def __init__(
+        self,
+        schema: "FilterByCoreAndAdditionalPropertyTypesSchema",
+        s_core: set[tuple[str, ...]],
+        type_overlap: dict[str, set[tuple[str, ...]]],
+        type_candidates: dict[str, set[tuple[str, ...]]],
+        gap: dict[str, int],
+    ) -> None:
         self.schema = schema
         self.s_core = s_core
         self.type_overlap = type_overlap
         self.type_candidates = type_candidates
         self.gap = gap
 
-        # Memoised, None-free Morgan fingerprints, keyed by substance tuple.
-        self._fp_cache: Dict[tuple, list] = {}
+        self._fp_cache: dict[tuple[str, ...], list[ExplicitBitVect]] = {}
 
-        # Additional types each candidate covers; covering more is the top rank key.
-        self.coverage_map = {
+        self.coverage_map: dict[tuple[str, ...], list[str]] = {
             sub: [a for a, cands in type_candidates.items() if sub in cands]
             for sub in set().union(*type_candidates.values())
         }
 
-        # Global dedup set; per-type record drives the final row masking in ``_apply``.
-        self.selected: set = set()
-        self.selected_by_type = {a: set() for a in schema.additional_property_types}
+        self.selected: set[tuple[str, ...]] = set()
+        self.selected_by_type: dict[str, set[tuple[str, ...]]] = {
+            a: set() for a in schema.additional_property_types
+        }
 
     # -- entry point ---------------------------------------------------------
 
-    def fill(self) -> dict:
+    def fill(self) -> dict[str, set[tuple[str, ...]]]:
         """Run the configured ``select_by`` strategy; return ``selected_by_type``."""
         if self.schema.select_by == "diversity":
             self._fill_diversity()
@@ -1344,7 +1373,7 @@ class _GapFiller:
 
     # -- fingerprint helpers -------------------------------------------------
 
-    def _sub_fps(self, substance):
+    def _sub_fps(self, substance: tuple[str, ...]) -> list[ExplicitBitVect]:
         """Cached, ``None``-free Morgan fingerprints for *substance*."""
         if substance not in self._fp_cache:
             self._fp_cache[substance] = [
@@ -1352,7 +1381,7 @@ class _GapFiller:
             ]
         return self._fp_cache[substance]
 
-    def _sub_sim(self, fps_a, fps_b):
+    def _sub_sim(self, fps_a: list[ExplicitBitVect], fps_b: list[ExplicitBitVect]) -> float:
         """Optimal-assignment Tanimoto similarity between two substances."""
         from rdkit import DataStructs
 
@@ -1366,11 +1395,11 @@ class _GapFiller:
 
     # -- shared bookkeeping --------------------------------------------------
 
-    def _active_coverage(self, substance):
+    def _active_coverage(self, substance: tuple[str, ...]) -> int:
         """How many still-unfilled additional types this candidate covers."""
         return sum(1 for c in self.coverage_map[substance] if self.gap[c] > 0)
 
-    def _take(self, substance):
+    def _take(self, substance: tuple[str, ...]) -> list[str]:
         """Charge *substance* to every type it covers that still has budget; return
         those types."""
         filled = [c for c in self.coverage_map[substance] if self.gap[c] > 0]
@@ -1380,16 +1409,15 @@ class _GapFiller:
         self.selected.add(substance)
         return filled
 
-    def _remaining(self, add_type):
+    def _remaining(self, add_type: str) -> list[tuple[str, ...]]:
         """Not-yet-picked candidates carrying *add_type* data."""
         return [s for s in self.type_candidates[add_type] if s not in self.selected]
 
     # -- diversity strategy --------------------------------------------------
 
-    def _fill_diversity(self):
-        # Reference = every component kept so far (core set, then each pick).
-        self._ref_smiles = {smi for sub in self.s_core for smi in sub}
-        self._ref_fps = [
+    def _fill_diversity(self) -> None:
+        self._ref_smiles: set[str] = {smi for sub in self.s_core for smi in sub}
+        self._ref_fps: list[ExplicitBitVect] = [
             fp for fp in map(_morgan_fp, self._ref_smiles) if fp is not None
         ]
 
@@ -1401,7 +1429,9 @@ class _GapFiller:
                 remaining.remove(best)
                 self._grow_diversity_reference(best)
 
-    def _diversity_rank(self, substance):
+    def _diversity_rank(
+        self, substance: tuple[str, ...]
+    ) -> tuple[int, float, tuple[str, ...]]:
         """Rank key: (#types covered, distance from the kept set, tuple). An
         unparseable candidate scores 0.0 (least diverse), not the inverted 1.0."""
         fps_sub = self._sub_fps(substance)
@@ -1413,7 +1443,7 @@ class _GapFiller:
             score = 1.0 - self._sub_sim(fps_sub, self._ref_fps)
         return (self._active_coverage(substance), score, substance)
 
-    def _grow_diversity_reference(self, substance):
+    def _grow_diversity_reference(self, substance: tuple[str, ...]) -> None:
         """Fold a freshly picked substance's fingerprints into the MaxMin reference."""
         for smi in substance:
             if smi not in self._ref_smiles:
@@ -1424,15 +1454,14 @@ class _GapFiller:
 
     # -- similarity strategy -------------------------------------------------
 
-    def _fill_similarity(self):
-        # Per type, target its under-represented core (members lacking the type, or
-        # the whole core if none do). References persist across the whole fill, so a
-        # multi-type pick advances the spread of every type it covers.
-        self._type_under = {
+    def _fill_similarity(self) -> None:
+        self._type_under: dict[str, list[tuple[str, ...]]] = {
             a: (sorted(self.s_core - self.type_overlap[a]) or sorted(self.s_core))
             for a in self.schema.additional_property_types
         }
-        self._type_ref = {a: list(under) for a, under in self._type_under.items()}
+        self._type_ref: dict[str, list[tuple[str, ...]]] = {
+            a: list(under) for a, under in self._type_under.items()
+        }
 
         for add_type in self.schema.additional_property_types:
             remaining = self._remaining(add_type)
@@ -1445,7 +1474,9 @@ class _GapFiller:
                 remaining.remove(best)
                 self._credit(best, self._take(best))
 
-    def _similarity_rank(self, substance):
+    def _similarity_rank(
+        self, substance: tuple[str, ...]
+    ) -> tuple[int, float, tuple[str, ...]]:
         """Rank key: (#types covered, similarity to the under-represented core,
         tuple). Prefers covering more still-unfilled types, then resemblance to the
         current reference, then the substance tuple for determinism."""
@@ -1455,7 +1486,7 @@ class _GapFiller:
             substance,
         )
 
-    def _credit(self, substance, filled):
+    def _credit(self, substance: tuple[str, ...], filled: list[str]) -> None:
         """For each type *substance* was charged to, drop the core member it best
         represents from that type's reference (refilling when empty), so later picks
         spread to still-uncovered members. A pick resembling nothing credits nothing.

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -45,8 +45,8 @@ logger = logging.getLogger(__name__)
 ComponentEnvironments = List[List[ChemicalEnvironment]]
 MoleFractionRange = Tuple[confloat(ge=0.0, le=1.0), confloat(ge=0.0, le=1.0)]
 # A mapping of property type -> optional list of allowed component counts
-# (an empty list means no ``n_components`` restriction).
-PropertyTypeFilter = Dict[constr(min_length=1), List[PositiveInt]]
+# (``None`` — or an empty list — means no ``n_components`` restriction).
+PropertyTypeFilter = Dict[constr(min_length=1), Optional[List[PositiveInt]]]
 
 
 class FilterDuplicatesSchema(CurationComponentSchema):

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -1266,7 +1266,9 @@ class FilterByCoreAndAdditionalPropertyTypesSchema(CurationComponentSchema):
         "Dict values are optional n_components filters; None (or an empty list) "
         "means no filter.",
     )
-    additional_property_types: Dict[constr(min_length=1), AdditionalPropertyTypeConfig] = Field(
+    additional_property_types: Dict[
+        constr(min_length=1), AdditionalPropertyTypeConfig
+    ] = Field(
         ...,
         min_length=1,
         description="Property types for which additional data are retained. Each "
@@ -1618,9 +1620,7 @@ class FilterByCoreAndAdditionalPropertyTypes(CurationComponent):
             if val_col is None:
                 continue
             keep = type_overlap[add_type] | selected_by_type[add_type]
-            additional_mask |= (
-                substance_col.isin(keep) & data_frame[val_col].notna()
-            )
+            additional_mask |= substance_col.isin(keep) & data_frame[val_col].notna()
 
         # --- Assemble ----------------------------------------------------------
         # Additional rows exclude the core rows (kept separately) to avoid dupes,

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -1349,7 +1349,7 @@ class _GapFiller:
         self.type_candidates = type_candidates
         self.gap = gap
 
-        self._fp_cache: dict[tuple[str, ...], list[ExplicitBitVect]] = {}
+        self._fp_cache: dict[tuple[str, ...], "list[ExplicitBitVect]"] = {}
 
         self.coverage_map: dict[tuple[str, ...], list[str]] = {
             sub: [a for a, cands in type_candidates.items() if sub in cands]
@@ -1373,7 +1373,7 @@ class _GapFiller:
 
     # -- fingerprint helpers -------------------------------------------------
 
-    def _sub_fps(self, substance: tuple[str, ...]) -> list[ExplicitBitVect]:
+    def _sub_fps(self, substance: tuple[str, ...]) -> "list[ExplicitBitVect]":
         """Cached, ``None``-free Morgan fingerprints for *substance*."""
         if substance not in self._fp_cache:
             self._fp_cache[substance] = [
@@ -1381,7 +1381,7 @@ class _GapFiller:
             ]
         return self._fp_cache[substance]
 
-    def _sub_sim(self, fps_a: list[ExplicitBitVect], fps_b: list[ExplicitBitVect]) -> float:
+    def _sub_sim(self, fps_a: "list[ExplicitBitVect]", fps_b: "list[ExplicitBitVect]") -> float:
         """Optimal-assignment Tanimoto similarity between two substances."""
         from rdkit import DataStructs
 
@@ -1417,7 +1417,7 @@ class _GapFiller:
 
     def _fill_diversity(self) -> None:
         self._ref_smiles: set[str] = {smi for sub in self.s_core for smi in sub}
-        self._ref_fps: list[ExplicitBitVect] = [
+        self._ref_fps: "list[ExplicitBitVect]" = [
             fp for fp in map(_morgan_fp, self._ref_smiles) if fp is not None
         ]
 

--- a/openff/evaluator/datasets/curation/components/filtering.py
+++ b/openff/evaluator/datasets/curation/components/filtering.py
@@ -1223,6 +1223,7 @@ def _morgan_fp(smiles: str):
 
     Returns ``None`` if the SMILES cannot be parsed by RDKit.
     """
+    # Deliberately use the open-source RDKit backend here (not OpenEye).
     from rdkit import Chem
     from rdkit.Chem import AllChem
 
@@ -1237,9 +1238,8 @@ class AdditionalPropertyTypeConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    scale_factor: float = Field(
+    scale_factor: confloat(ge=0.0, allow_inf_nan=False) = Field(
         1.0,
-        ge=0.0,
         description="Ratio of gap-fill substances to core count for this type: "
         "int(scale_factor * core_count) substances are targeted. The overlap — "
         "additional-type data already present for core substances — is always "
@@ -1293,32 +1293,21 @@ class FilterByCoreAndAdditionalPropertyTypesSchema(CurationComponentSchema):
 
 
 class _GapFiller:
-    """Greedy gap-fill selection for :class:`FilterByCoreAndAdditionalPropertyTypes`.
+    """Greedily pick candidate substances to fill each additional type's ``gap``.
 
-    Picks candidate substances to fill the per-type ``gap`` left once each
-    additional type's core overlap has been retained.
+    Candidates covering more still-unfilled types are preferred (one pick fills
+    several gaps); ties break on a similarity score, then the substance tuple
+    (deterministic). The score depends on ``schema.select_by``:
 
-    Candidates covering several still-unfilled additional types at once are always
-    preferred (one pick fills several gaps). The per-type tie-break then depends
-    on ``schema.select_by``:
+    * ``"diversity"`` — distance (1 − Tanimoto) from everything kept so far, which
+      grows with each pick (MaxMin).
+    * ``"similarity"`` — Tanimoto to the *under-represented* core (core substances
+      lacking this type). Each pick drops the core member it best represents from
+      the reference, so picks spread across the core instead of piling onto one;
+      the reference refills once exhausted.
 
-    * ``"diversity"`` — MaxMin against everything kept so far (the core set plus
-      prior picks), favouring substances dissimilar to it.
-    * ``"similarity"`` — favour substances similar to the *under-represented*
-      core: the core substances that lack data for this additional type. As each
-      pick is made, the under-represented core substance it best represents is
-      dropped from the reference, so subsequent picks spread to the still-
-      uncovered core substances instead of piling onto one already covered. Once
-      every member has been covered the reference refills, allowing balanced
-      further rounds.
-
-    A pick is charged only to the types it covers that still have budget
-    (``gap > 0``), so a multi-type candidate taken for one type never drags in
-    rows for a type that is already satisfied or was never to be gap-filled
-    (``scale_factor`` 0). Ties are finally broken by the substance tuple, so
-    selection is deterministic. ``gap`` is mutated in place. :meth:`fill` returns
-    a mapping of each additional type to the set of substances chosen to fill its
-    gap (the always-kept core overlap is not included).
+    ``gap`` is mutated in place. :meth:`fill` returns each additional type's chosen
+    substances (the always-kept core overlap is not included).
     """
 
     def __init__(self, schema, s_core, type_overlap, type_candidates, gap):
@@ -1331,17 +1320,13 @@ class _GapFiller:
         # Memoised, None-free Morgan fingerprints, keyed by substance tuple.
         self._fp_cache: Dict[tuple, list] = {}
 
-        # Which additional types each candidate covers (computed once). Covering
-        # more still-unfilled types at once is the primary ranking key, so one
-        # pick fills several gaps.
+        # Additional types each candidate covers; covering more is the top rank key.
         self.coverage_map = {
             sub: [a for a, cands in type_candidates.items() if sub in cands]
             for sub in set().union(*type_candidates.values())
         }
 
-        # Global dedup set (each substance picked at most once) plus the per-type
-        # record of which substances were charged to each type's gap — the latter
-        # drives the final row masking in ``_apply``.
+        # Global dedup set; per-type record drives the final row masking in ``_apply``.
         self.selected: set = set()
         self.selected_by_type = {a: set() for a in schema.additional_property_types}
 
@@ -1366,14 +1351,16 @@ class _GapFiller:
         return self._fp_cache[substance]
 
     def _sub_sim(self, fps_a, fps_b):
-        """Nearest-neighbour Tanimoto between two substances' fingerprints."""
+        """Optimal-assignment Tanimoto similarity between two substances."""
         from rdkit import DataStructs
 
         if not fps_a or not fps_b:
             return 0.0
-        return max(
-            DataStructs.TanimotoSimilarity(x, y) for x in fps_a for y in fps_b
+        cost = numpy.array(
+            [[1.0 - DataStructs.TanimotoSimilarity(a, b) for b in fps_b] for a in fps_a]
         )
+        ri, ci = linear_sum_assignment(cost)
+        return float((1.0 - cost[ri, ci]).sum())
 
     # -- shared bookkeeping --------------------------------------------------
 
@@ -1382,9 +1369,8 @@ class _GapFiller:
         return sum(1 for c in self.coverage_map[substance] if self.gap[c] > 0)
 
     def _take(self, substance):
-        """Charge *substance* against every type it covers that still has budget,
-        recording it per type. Returns those types so the caller can advance their
-        spread."""
+        """Charge *substance* to every type it covers that still has budget; return
+        those types."""
         filled = [c for c in self.coverage_map[substance] if self.gap[c] > 0]
         for c in filled:
             self.gap[c] -= 1
@@ -1399,8 +1385,7 @@ class _GapFiller:
     # -- diversity strategy --------------------------------------------------
 
     def _fill_diversity(self):
-        # MaxMin: stay far from everything kept so far. The reference starts as
-        # the whole core set and grows with each pick.
+        # Reference = every component kept so far (core set, then each pick).
         self._ref_smiles = {smi for sub in self.s_core for smi in sub}
         self._ref_fps = [
             fp for fp in map(_morgan_fp, self._ref_smiles) if fp is not None
@@ -1415,10 +1400,11 @@ class _GapFiller:
                 self._grow_diversity_reference(best)
 
     def _diversity_rank(self, substance):
-        """Rank key: (#types covered, distance from the kept set, tuple)."""
+        """Rank key: (#types covered, distance from the kept set, tuple). An
+        unparseable candidate scores 0.0 (least diverse), not the inverted 1.0."""
         fps_sub = self._sub_fps(substance)
         if not fps_sub:
-            score = 0.0  # unparseable candidate: treat as least diverse
+            score = 0.0
         elif not self._ref_fps:
             score = 1.0
         else:
@@ -1437,12 +1423,9 @@ class _GapFiller:
     # -- similarity strategy -------------------------------------------------
 
     def _fill_similarity(self):
-        # Each additional type targets its under-represented core — the core
-        # substances that still lack it (falling back to the whole core if every
-        # core substance already has it). The references are shared across the
-        # whole fill rather than rebuilt per loop, so a multi-type candidate
-        # picked while filling one type also advances the spread of the others it
-        # covers.
+        # Per type, target its under-represented core (members lacking the type, or
+        # the whole core if none do). References persist across the whole fill, so a
+        # multi-type pick advances the spread of every type it covers.
         self._type_under = {
             a: (sorted(self.s_core - self.type_overlap[a]) or sorted(self.s_core))
             for a in self.schema.additional_property_types
@@ -1452,8 +1435,7 @@ class _GapFiller:
         for add_type in self.schema.additional_property_types:
             remaining = self._remaining(add_type)
             while self.gap[add_type] > 0 and remaining:
-                # Reference fingerprints for this type's current (shrinking)
-                # under-represented core, computed once per pick.
+                # Fingerprints of this type's current (shrinking) under-rep core.
                 self._ref_fps = [
                     fp for cs in self._type_ref[add_type] for fp in self._sub_fps(cs)
                 ]
@@ -1472,12 +1454,9 @@ class _GapFiller:
         )
 
     def _credit(self, substance, filled):
-        """For each type in *filled* (the types *substance* was charged to), mark
-        the one under-represented core substance it best represents as covered:
-        drop it from that type's reference (refilling once the reference is
-        exhausted). Skip a type when the pick resembles nothing in its reference
-        (e.g. an unparseable candidate, or a cross-fill dissimilar to that type's
-        core) — there is no real coverage to credit.
+        """For each type *substance* was charged to, drop the core member it best
+        represents from that type's reference (refilling when empty), so later picks
+        spread to still-uncovered members. A pick resembling nothing credits nothing.
         """
         fps_sub = self._sub_fps(substance)
         for covered_type in filled:


### PR DESCRIPTION
## Description
Fixes #738 

Adds `FilterByCoreAndAdditionalPropertyTypes`, which is a modification of FilterByPropertyTypes but "softer". FilterByPropertyTypes requires that a substance has to be present in all property types to be kept, which was stripping out a lot of dhmix data that had *similar* substances present with the densities, but not always the *same* (e.g. CCC vs CCCC) . This filter instead lets you keep all the properties in "core" (e.g. keep all the dhmix data) and then select from the "additional" dataset (in this example, densities) for similar substances. 